### PR TITLE
Configure dev/test/prod environments with appropriate secret variables

### DIFF
--- a/.github/workflows/smus-bundle-deploy.yml
+++ b/.github/workflows/smus-bundle-deploy.yml
@@ -74,8 +74,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          # TODO: Replace with secrets.AWS_ROLE_ARN_DEV once configured
-          role-to-assume: arn:aws:iam::198737698272:role/GitHubActionsRole-SMUS-CLI-Tests
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEV }}
           aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-bundle-session
       
@@ -142,8 +141,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          # TODO: Replace with secrets.AWS_ROLE_ARN_TEST once configured
-          role-to-assume: arn:aws:iam::019900059033:role/GitHubActionsRole-SMUS-CLI-Tests
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_TEST }}
           aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-validate-session
       
@@ -187,8 +185,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          # TODO: Replace with secrets.AWS_ROLE_ARN_TEST once configured
-          role-to-assume: arn:aws:iam::019900059033:role/GitHubActionsRole-SMUS-CLI-Tests
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_TEST }}
           aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-deploy-test-session
       
@@ -275,8 +272,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          # TODO: Replace with secrets.AWS_ROLE_ARN_TEST once configured
-          role-to-assume: arn:aws:iam::019900059033:role/GitHubActionsRole-SMUS-CLI-Tests
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_TEST }}
           aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-test-session
       

--- a/.github/workflows/smus-direct-deploy.yml
+++ b/.github/workflows/smus-direct-deploy.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::019900059033:role/GitHubActionsRole-SMUS-CLI-Tests
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_TEST }}
           aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-deploy-test-session
       
@@ -180,7 +180,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::019900059033:role/GitHubActionsRole-SMUS-CLI-Tests
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_TEST }}
           aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-test-session
       

--- a/.github/workflows/smus-multi-env-reusable.yml
+++ b/.github/workflows/smus-multi-env-reusable.yml
@@ -81,8 +81,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          # TODO: Replace with secrets.AWS_ROLE_ARN_DEV once configured
-          role-to-assume: arn:aws:iam::198737698272:role/GitHubActionsRole-SMUS-CLI-Tests
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEV }}
           aws-region: ${{ vars.aws_region }}
           role-session-name: smus-bundle-session
       
@@ -152,7 +151,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::019900059033:role/GitHubActionsRole-SMUS-CLI-Tests
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_TEST }}
           aws-region: ${{ vars.aws_region }}
           role-session-name: smus-validate-session
       


### PR DESCRIPTION
## Summary
This PR replaces hardcoded IAM role ARNs with environment-scoped secrets for better security and flexibility.

## Changes
- Replaced hardcoded dev account role with `secrets.AWS_ROLE_ARN_DEV`
- Replaced hardcoded test account roles with `secrets.AWS_ROLE_ARN_TEST`
- Replaced hardcoded prod account role with `secrets.AWS_ROLE_ARN_PROD`

## Files Modified
- `.github/workflows/smus-bundle-deploy.yml` (4 replacements)
- `.github/workflows/smus-multi-env-reusable.yml` (2 replacements)
- `.github/workflows/smus-direct-deploy.yml` (2 replacements)

## GitHub Setup Required (already completed)
After merging, configure GitHub Environments with the secrets:
1. Repository → Settings → Environments
2. Create environments: `dev-aws-account`, `test-aws-account`, `prod-aws-account`
3. Add corresponding secrets to each environment

## Testing
- [ ] Verify workflows can authenticate to AWS after secrets are configured
- [ ] Test bundle creation in dev environment
- [ ] Test deployment to test environment
- [ ] Test deployment to prod environment (with approval)