### PR TITLE
Add production stage to dashboard-glue-quick example

### DIFF
--- a/examples/analytic-workflow/dashboard-glue-quick/manifest.yaml
+++ b/examples/analytic-workflow/dashboard-glue-quick/manifest.yaml
@@ -122,6 +122,55 @@ stages:
         overrideParameters:
           ResourceIdOverrideConfiguration:
             PrefixForAllResources: deployed-{stage.name}-covid-
+  prod:
+    stage: PROD
+    domain:
+      tags:
+        purpose: smus-cicd-production
+      region: ${PROD_DOMAIN_REGION:us-east-1}
+    project:
+      name: prod-marketing
+      owners:
+      - Eng1
+      - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests
+      - arn:aws:iam::${AWS_ACCOUNT_ID}:role/Admin
+    environment_variables:
+      S3_PREFIX: prod
+      AWS_REGION: ${PROD_DOMAIN_REGION:us-east-1}
+      GRANT_TO: Admin,service-role/aws-quicksight-service-role-v0
+    bootstrap:
+      actions:
+      - type: workflow.create
+        workflowName: covid_dashboard_glue_quick_pipeline
+      - type: workflow.run
+        workflowName: covid_dashboard_glue_quick_pipeline
+        trailLogs: true
+      - type: quicksight.refresh_dataset
+        refreshScope: IMPORTED
+        ingestionType: FULL_REFRESH
+        wait: false
+    deployment_configuration:
+      storage:
+      - name: dashboard-glue-quick
+        connectionName: default.s3_shared
+        targetDirectory: dashboard-glue-quick/bundle
+      - name: workflows
+        connectionName: default.s3_shared
+        targetDirectory: dashboard-glue-quick/bundle/workflows
+      git:
+      - name: covid-19-dataset
+        connectionName: default.s3_shared
+        targetDirectory: repos
+      quicksight:
+        assets:
+        - name: TotalDeathByCountry
+          owners:
+          - arn:aws:quicksight:${PROD_DOMAIN_REGION:us-east-1}:${AWS_ACCOUNT_ID}:user/default/Admin/*
+          viewers:
+          - arn:aws:quicksight:${PROD_DOMAIN_REGION:us-east-1}:${AWS_ACCOUNT_ID}:user/default/Admin/*
+        overrideParameters:
+          ResourceIdOverrideConfiguration:
+            PrefixForAllResources: deployed-{stage.name}-covid-
 tests:
   folder: examples/analytic-workflow/dashboard-glue-quick/app_tests/
 


### PR DESCRIPTION
## Summary
This PR adds a production stage to the dashboard-glue-quick example manifest, enabling deployment to a production environment.

## Changes

### Production Stage Configuration
- Added `prod` stage to `examples/analytic-workflow/dashboard-glue-quick/manifest.yaml`
- Uses `purpose: smus-cicd-production` domain tag for discovery
- Configured with `prod-marketing` project
- Region: us-east-1 (PROD_DOMAIN_REGION environment variable)
- Includes GitHub Actions role as project owner for CI/CD access

### Stage Configuration Details
- **Environment Variables:**
  - S3_PREFIX: prod
  - AWS_REGION: us-east-1
  - GRANT_TO: Admin,service-role/aws-quicksight-service-role-v0

- **Bootstrap Actions:**
  - Create workflow: covid_dashboard_glue_quick_pipeline
  - Run workflow with log trailing
  - Refresh QuickSight dataset (FULL_REFRESH)

- **Deployment Configuration:**
  - Storage: dashboard-glue-quick code and workflows
  - Git: covid-19-dataset repository
  - QuickSight: TotalDeathByCountry dashboard with Admin permissions

### Prerequisites
- Production domain tagged with `purpose: smus-cicd-production` ✅ (completed)
- GitHub Actions role has necessary permissions ✅ (from PR #7)
- Production environment configured in GitHub repository settings

## Testing
The production stage will be deployed when the workflow runs with `deploy_to_prod: true` (typically on main branch merges).

## Related
- Builds on PR #7 (GitHub Actions permissions and QuickSight setup)
- Production domain tagged: dzd-67k2ebgdf93rl3