### PR TITLE
Fix genai notebook: move utils download and add proper imports for early cleanup

### DIFF
--- a/examples/analytic-workflow/genai/workflows/bedrock_agent_notebook.ipynb
+++ b/examples/analytic-workflow/genai/workflows/bedrock_agent_notebook.ipynb
@@ -42,54 +42,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Cleanup from previous runs (ignore errors)\n",
-    "try:\n",
-    "    Agent.delete_by_name(\"mortgage_test_agent\")\n",
-    "    kb_helper.delete_kb(kb_name, delete_s3_bucket=True, delete_iam_roles_and_policies=True)\n",
-    "    print(\"✅ Cleaned up previous resources\")\n",
-    "except Exception as e:\n",
-    "    print(f\"⚠️ Cleanup warning (may not exist): {e}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "print(f\"IMAGE_VERSION: {os.environ.get('IMAGE_VERSION', 'Not set')}\")\n",
-    "print(f\"SAGEMAKER_INTERNAL_IMAGE_URI: {os.environ.get('SAGEMAKER_INTERNAL_IMAGE_URI', 'Not set')}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from datetime import datetime\n",
-    "from zoneinfo import ZoneInfo\n",
-    "print(f\"Execution Start Time (EST): {datetime.now(ZoneInfo('America/New_York')).strftime('%Y-%m-%d %H:%M:%S %Z')}\")\n",
-    "print(\"version 1.0.0\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Package upgrade skipped - using environment default\n",
-    "print('Using default sagemaker_studio package from environment')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "import boto3\n",
     "import time\n",
     "from sagemaker_studio import Project\n",
@@ -150,6 +102,67 @@
     "if '.' not in sys.path:\n",
     "    sys.path.insert(0, '.')\n",
     "    print(\"✅ Added current directory to sys.path\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Early cleanup from previous runs (ignore errors)\n",
+    "print(\"\\n🧹 Early cleanup from previous runs...\")\n",
+    "\n",
+    "try:\n",
+    "    from utils.bedrock_agent import Agent\n",
+    "    from utils.knowledge_base_helper import KnowledgeBaseHelper\n",
+    "    \n",
+    "    kb_helper = KnowledgeBaseHelper()\n",
+    "    \n",
+    "    # Try to delete specific resources that might conflict\n",
+    "    if Agent.exists(\"mortgage_test_agent\"):\n",
+    "        Agent.delete_by_name(\"mortgage_test_agent\")\n",
+    "        print(\"   Deleted mortgage_test_agent\")\n",
+    "    \n",
+    "    kb_helper.delete_kb(kb_name, delete_s3_bucket=True, delete_iam_roles_and_policies=True)\n",
+    "    print(f\"   Deleted knowledge base: {kb_name}\")\n",
+    "    \n",
+    "    print(\"✅ Early cleanup complete\")\n",
+    "except Exception as e:\n",
+    "    print(f\"⚠️ Early cleanup warning (resources may not exist): {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "print(f\"IMAGE_VERSION: {os.environ.get('IMAGE_VERSION', 'Not set')}\")\n",
+    "print(f\"SAGEMAKER_INTERNAL_IMAGE_URI: {os.environ.get('SAGEMAKER_INTERNAL_IMAGE_URI', 'Not set')}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "from zoneinfo import ZoneInfo\n",
+    "print(f\"Execution Start Time (EST): {datetime.now(ZoneInfo('America/New_York')).strftime('%Y-%m-%d %H:%M:%S %Z')}\")\n",
+    "print(\"version 1.0.0\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Package upgrade skipped - using environment default\n",
+    "print('Using default sagemaker_studio package from environment')"
    ]
   },
   {


### PR DESCRIPTION
## Problem
The genai notebook was failing at 55% execution (around cell 10-11) because Cell 3 tried to use `Agent` and `kb_helper` classes before they were imported or available.

## Root Cause
- Cell 3 attempted to call `Agent.delete_by_name()` and `kb_helper.delete_kb()` without importing these classes
- The utils module containing these classes wasn't downloaded until Cell 8
- This caused a NameError that was silently caught by try-except, but led to failures later in execution

## Solution
Reorganized the notebook cell order:
1. **Moved Cell 6 → Cell 2**: Project connections setup (gets region, bucket, role) now runs earlier
2. **Moved Cell 7 → Cell 3**: Utils module download from S3 now runs earlier
3. **Fixed Cell 2 → Cell 4**: Early cleanup now properly imports `Agent` and `KnowledgeBaseHelper` before using them
4. **Moved Cells 3-5 → Cells 5-7**: Environment info cells shifted down

## Changes
- `examples/analytic-workflow/genai/workflows/bedrock_agent_notebook.ipynb`: Reorganized cells and added proper imports

## Testing
- Notebook should now execute successfully through all cells
- Early cleanup will properly delete resources from previous runs
- Utils module is available before any code tries to use it

## Related Issues
Fixes the genai workflow failure seen in GitHub Actions run #21918179953