### PR TITLE
Fix ML training MLflow S3 permissions

### DIFF
--- a/tests/scripts/setup/idc-based-domains/5-testing-infrastructure/testing-infrastructure/shared-resources-template.yaml
+++ b/tests/scripts/setup/idc-based-domains/5-testing-infrastructure/testing-infrastructure/shared-resources-template.yaml
@@ -31,6 +31,32 @@ Resources:
       VersioningConfiguration:
         Status: Enabled
 
+  # Policy to grant existing SageMaker role access to MLflow artifacts bucket
+  # This allows training jobs using AmazonSageMakerUserIAMExecutionRole to upload to MLflow
+  MLflowArtifactsPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: MLflowArtifactsAccess
+      Roles:
+        - AmazonSageMakerUserIAMExecutionRole
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:GetObject
+              - s3:PutObject
+              - s3:DeleteObject
+              - s3:ListBucket
+            Resource:
+              - !Sub '${MLflowArtifactsBucket.Arn}'
+              - !Sub '${MLflowArtifactsBucket.Arn}/*'
+          - Effect: Allow
+            Action:
+              - sagemaker-mlflow:*
+            Resource: "*"
+
+  # Role for MLflow tracking server (kept for backward compatibility)
   SageMakerExecutionRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
## Problem
ML training workflow fails when uploading model artifacts to MLflow with AccessDenied error:
```
User: arn:aws:sts::372123585851:assumed-role/AmazonSageMakerUserIAMExecutionRole/SageMaker 
is not authorized to perform: s3:PutObject on resource: 
arn:aws:s3:::smus-mlflow-artifacts-372123585851-us-east-1/mlflow/...
```

## Root Cause
Training jobs use `AmazonSageMakerUserIAMExecutionRole` (from DataZone's default.iam connection), but this role lacks permissions to write to the MLflow artifacts S3 bucket.

## Solution
Added `MLflowArtifactsPolicy` to CloudFormation template that grants:
- S3 permissions (GetObject, PutObject, DeleteObject, ListBucket) on MLflow artifacts bucket
- MLflow API permissions (sagemaker-mlflow:*)

to the existing `AmazonSageMakerUserIAMExecutionRole`.

## Changes
- Updated `shared-resources-template.yaml` to add MLflowArtifactsPolicy
- Kept `SageMakerExecutionRole` for backward compatibility (used by MLflow tracking server)
- No breaking changes to existing scripts or workflows

## Testing
After deploying the updated CloudFormation stack, ML training jobs should successfully upload model artifacts to MLflow.

Related to PR #13