### PR TITLE
fix: Enable flexible bundle source stage for ML deployment workflow

### DIFF
--- a/.github/workflows/analytic-ml-deployment.yml
+++ b/.github/workflows/analytic-ml-deployment.yml
@@ -23,6 +23,7 @@ jobs:
       AWS_ROLE_ARN_PROD: ${{ secrets.AWS_ROLE_ARN_PROD }}
     with:
       manifest_path: 'examples/analytic-workflow/ml/deployment/manifest.yaml'
+      bundle_from_target: 'test'
       test_target: 'test'
       prod_target: 'prod'
       deploy_to_prod: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/smus-bundle-deploy.yml
+++ b/.github/workflows/smus-bundle-deploy.yml
@@ -45,6 +45,12 @@ on:
         type: boolean
         default: true
       
+      bundle_from_target:
+        description: 'Target to bundle from (default: dev)'
+        required: false
+        type: string
+        default: 'dev'
+      
       quicksight_setup_script:
         description: 'Optional path to QuickSight setup script to run before bundling'
         required: false
@@ -76,7 +82,7 @@ jobs:
   bundle:
     name: Bundle Application
     runs-on: ubuntu-latest
-    environment: dev-aws-account
+    environment: ${{ fromJSON('{"dev":"dev-aws-account","test":"test-aws-account","prod":"prod-aws-account"}')[inputs.bundle_from_target] || 'dev-aws-account' }}
     
     steps:
       - uses: actions/checkout@v4
@@ -92,10 +98,30 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
       
+      - name: Determine AWS Role ARN for bundle source
+        id: bundle-role
+        run: |
+          case "${{ inputs.bundle_from_target }}" in
+            dev)
+              echo "role-arn=${{ secrets.AWS_ROLE_ARN_DEV }}" >> $GITHUB_OUTPUT
+              ;;
+            test)
+              echo "role-arn=${{ secrets.AWS_ROLE_ARN_TEST }}" >> $GITHUB_OUTPUT
+              ;;
+            prod)
+              echo "role-arn=${{ secrets.AWS_ROLE_ARN_PROD }}" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "❌ Invalid bundle_from_target: ${{ inputs.bundle_from_target }}"
+              echo "   Valid values: dev, test, prod"
+              exit 1
+              ;;
+          esac
+      
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEV }}
+          role-to-assume: ${{ steps.bundle-role.outputs.role-arn }}
           aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-bundle-session
       
@@ -114,29 +140,36 @@ jobs:
           echo "📊 Setting up QuickSight dashboard..."
           python ${{ inputs.quicksight_setup_script }}
       
-      - name: smus-cli describe (validate dev target)
+      - name: smus-cli describe (validate bundle source target)
         env:
           DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
           DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         run: |
-          echo "🔍 Validating dev target"
+          echo "🔍 Validating bundle source target: ${{ inputs.bundle_from_target }}"
           
-          smus-cli describe --manifest ${{ inputs.manifest_path }} --targets dev --connect
+          smus-cli describe --manifest ${{ inputs.manifest_path }} --targets ${{ inputs.bundle_from_target }} --connect
       
-      - name: smus-cli bundle from dev
+      - name: smus-cli bundle from ${{ inputs.bundle_from_target }}
         env:
           DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
           DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         run: |
           echo "🔍 DOMAIN_REGION: $DOMAIN_REGION"
           echo "🔍 DEV_DOMAIN_REGION: $DEV_DOMAIN_REGION"
+          echo "🔍 TEST_DOMAIN_REGION: $TEST_DOMAIN_REGION"
+          echo "🔍 PROD_DOMAIN_REGION: $PROD_DOMAIN_REGION"
+          echo "📦 Bundling from target: ${{ inputs.bundle_from_target }}"
           BUNDLE_DIR="${{ runner.temp }}/smus-bundles-${{ github.run_id }}"
           mkdir -p "$BUNDLE_DIR"
           echo "BUNDLE_DIR=$BUNDLE_DIR" >> $GITHUB_ENV
           
           smus-cli bundle \
             --manifest ${{ inputs.manifest_path }} \
-            --targets dev \
+            --targets ${{ inputs.bundle_from_target }} \
             --output-dir "$BUNDLE_DIR"
       
       - name: Upload bundle artifact


### PR DESCRIPTION
## Problem
The ML deployment workflow was failing during the bundle step because it tried to bundle model artifacts from the `dev` stage, but the ML training workflow produces artifacts in the `test` stage.

**Error:**
```
❌ No files found
  Downloaded 0 files for 'model-artifacts'
Error: 1
```

## Root Cause
- ML Training workflow runs in `test` stage and writes model artifacts to test project's S3 bucket
- ML Deployment workflow was hardcoded to bundle from `dev` stage
- Model artifacts path `ml/output/model-artifacts/latest/` was empty in dev

## Solution
Made the `smus-bundle-deploy.yml` workflow flexible to bundle from any stage (dev, test, or prod) using proper stage-to-role mapping.

## Changes

### 1. `.github/workflows/smus-bundle-deploy.yml`
- Added `bundle_from_target` input parameter (defaults to 'dev' for backward compatibility)
- Implemented stage-to-environment mapping using `fromJSON()` for dynamic environment selection
- Added validation step with case statement to map stages to AWS roles:
  - `dev` → `AWS_ROLE_ARN_DEV`
  - `test` → `AWS_ROLE_ARN_TEST`
  - `prod` → `AWS_ROLE_ARN_PROD`
  - Invalid values → Error with helpful message
- Updated AWS credentials configuration to use dynamically determined role
- Added all stage environment variables (DEV_DOMAIN_REGION, TEST_DOMAIN_REGION, PROD_DOMAIN_REGION)

### 2. `.github/workflows/analytic-ml-deployment.yml`
- Added `bundle_from_target: 'test'` to bundle from test stage where ML training produces artifacts

## Benefits
1. **Flexible**: Can now bundle from any stage (dev, test, prod)
2. **Maintainable**: Clear mapping between stages and AWS roles
3. **Safe**: Validates bundle_from_target and fails with helpful error for invalid values
4. **Backward Compatible**: Defaults to 'dev' for existing workflows
5. **Scalable**: Easy to add new stages if needed

## Testing
The ML deployment workflow should now successfully:
1. Bundle model artifacts from the test stage (where training produces them)
2. Deploy to the test stage
3. Optionally deploy to prod stage

## Related
- Fixes ML deployment workflow failure: https://github.com/aws/CICD-for-SageMakerUnifiedStudio/actions/runs/22075320279