### PR TITLE
Fix: Bundle CLI now respects --targets parameter

### DIFF
--- a/examples/analytic-workflow/ml/deployment/manifest.yaml
+++ b/examples/analytic-workflow/ml/deployment/manifest.yaml
@@ -63,6 +63,42 @@ stages:
       - type: workflow.run
         workflowName: ml_deployment_workflow
         trailLogs: true
+  prod:
+    stage: PROD
+    domain:
+      tags:
+        purpose: smus-cicd-testing
+      region: ${PROD_DOMAIN_REGION:us-east-1}
+    project:
+      name: prod-marketing
+      create: true
+      owners:
+      - Eng1
+      - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests
+      - arn:aws:iam::${AWS_ACCOUNT_ID}:role/Admin
+      contributors: []
+      role:
+        arn: arn:aws:iam::${AWS_ACCOUNT_ID}:role/prod-marketing-role
+    environment_variables:
+      S3_PREFIX: prod
+    deployment_configuration:
+      storage:
+      - name: deployment-code
+        connectionName: default.s3_shared
+        targetDirectory: ml/bundle/deployment-code
+      - name: deployment-workflows
+        connectionName: default.s3_shared
+        targetDirectory: ml/bundle/deployment-workflows
+      - name: model-artifacts
+        connectionName: default.s3_shared
+        targetDirectory: ml/bundle/model-artifacts
+    bootstrap:
+      actions:
+      - type: workflow.create
+        workflowName: ml_deployment_workflow
+      - type: workflow.run
+        workflowName: ml_deployment_workflow
+        trailLogs: true
 tests:
   folder: examples/analytic-workflow/ml/deployment/app_tests/
 # Trigger workflow

--- a/src/smus_cicd/cli.py
+++ b/src/smus_cicd/cli.py
@@ -174,8 +174,8 @@ def bundle(
         bundle_source = final_targets or "default"
         console.print(f"📦 Bundling from local filesystem for target: {bundle_source}")
     else:
-        bundle_source = "dev"
-        console.print("🔍 Bundle source: dev target")
+        bundle_source = final_targets or "dev"
+        console.print(f"🔍 Bundle source: {bundle_source} target")
         console.print(f"📦 Bundle destination: {final_targets or 'default'}")
 
     bundle_command(bundle_source, manifest_file, output_dir, output)


### PR DESCRIPTION
## Problem
The ML deployment workflow was failing with 'No files found' error because the bundle CLI command was hardcoded to always bundle from the 'dev' stage, completely ignoring the `--targets` parameter.

## Root Cause
In `src/smus_cicd/cli.py`, line 178 had:
```python
bundle_source = "dev"  # ❌ Hardcoded!
```

This meant that when the workflow ran `smus-cli bundle --targets test`, it would:
1. Ignore the `--targets test` parameter
2. Always use `dev` as the bundle source
3. Try to bundle from dev-marketing project instead of test-marketing project
4. Fail with 'No files found' because ML training artifacts are in test stage

## Solution
Changed the logic to respect the `--targets` parameter:
```python
bundle_source = final_targets or "dev"  # ✅ Use targets parameter, default to dev
```

Now:
- `smus-cli bundle --targets test` → bundles FROM test stage
- `smus-cli bundle --targets dev` → bundles FROM dev stage
- `smus-cli bundle` (no targets) → defaults to dev stage (backward compatible)

## Changes
1. **src/smus_cicd/cli.py**: Fixed bundle command to use `final_targets` parameter instead of hardcoded 'dev'
2. **examples/analytic-workflow/ml/deployment/manifest.yaml**: Added prod stage configuration for complete workflow support

## Testing
This fix enables the ML deployment workflow to correctly bundle model artifacts from the test stage where they are produced by the ML training workflow.

Fixes the issue reported in: https://github.com/aws/CICD-for-SageMakerUnifiedStudio/actions/runs/22076386485