### PR TITLE
Fix: Add pre-deploy step for ML deployment workflow

### DIFF
--- a/.github/workflows/analytic-ml-deployment.yml
+++ b/.github/workflows/analytic-ml-deployment.yml
@@ -24,6 +24,7 @@ jobs:
     with:
       manifest_path: 'examples/analytic-workflow/ml/deployment/manifest.yaml'
       bundle_from_target: 'test'
+      pre_deploy_local_files: true
       test_target: 'test'
       prod_target: 'prod'
       deploy_to_prod: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/smus-bundle-deploy.yml
+++ b/.github/workflows/smus-bundle-deploy.yml
@@ -62,6 +62,12 @@ on:
         required: false
         type: boolean
         default: false
+      
+      pre_deploy_local_files:
+        description: 'Pre-deploy local files to bundle source before bundling'
+        required: false
+        type: boolean
+        default: false
     
     secrets:
       AWS_ROLE_ARN_DEV:
@@ -150,6 +156,23 @@ jobs:
           echo "🔍 Validating bundle source target: ${{ inputs.bundle_from_target }}"
           
           smus-cli describe --manifest ${{ inputs.manifest_path }} --targets ${{ inputs.bundle_from_target }} --connect
+      
+      - name: Pre-deploy local files to bundle source (if needed)
+        if: ${{ inputs.pre_deploy_local_files }}
+        env:
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+        run: |
+          echo "📤 Pre-deploying local files to ${{ inputs.bundle_from_target }} stage for bundling..."
+          
+          # Deploy local files to the bundle source target
+          # This ensures all content (local + S3) is available in the bundle source
+          smus-cli deploy \
+            --manifest ${{ inputs.manifest_path }} \
+            --targets ${{ inputs.bundle_from_target }} \
+            --local
       
       - name: smus-cli bundle from ${{ inputs.bundle_from_target }}
         env:


### PR DESCRIPTION
## Problem
The ML deployment workflow was failing with 'Workflow not found' error because:
1. The workflow bundles from the test stage (where model artifacts are stored)
2. But deployment code and workflows only exist in the local filesystem
3. When bundling from test, only model artifacts were found, not the deployment code/workflows

## Solution
Added a new optional  parameter to the reusable  workflow:
- When enabled, deploys local files to the bundle source target BEFORE bundling
- This ensures all content (local files + S3 artifacts) is available in the bundle source
- Only runs when explicitly enabled, so it doesn't affect other workflows

## Changes
1. **smus-bundle-deploy.yml**: Added `pre_deploy_local_files` input parameter and conditional pre-deploy step
2. **analytic-ml-deployment.yml**: Enabled `pre_deploy_local_files: true` for ML deployment

## Workflow
For ML deployment:
1. Pre-deploy local deployment code/workflows to test stage
2. Bundle from test stage (now includes both local files and model artifacts)
3. Deploy bundle to test/prod

## Impact
- Fixes ML deployment workflow to successfully bundle all required files
- Other workflows unaffected (parameter defaults to false)
- Enables flexible bundling from any stage with mixed local/S3 content

Fixes the issue from: https://github.com/aws/CICD-for-SageMakerUnifiedStudio/actions/runs/22076832600