### PR TITLE
Fix ML deployment workflow to skip redundant test deployment

### DIFF
--- a/.github/workflows/smus-bundle-deploy.yml
+++ b/.github/workflows/smus-bundle-deploy.yml
@@ -157,7 +157,7 @@ jobs:
           
           smus-cli describe --manifest ${{ inputs.manifest_path }} --targets ${{ inputs.bundle_from_target }} --connect
       
-      - name: Pre-deploy local files to bundle source (if needed)
+      - name: Pre-deploy local files to bundle source (optional)
         if: ${{ inputs.pre_deploy_local_files }}
         env:
           DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
@@ -171,8 +171,7 @@ jobs:
           # This ensures all content (local + S3) is available in the bundle source
           smus-cli deploy \
             --manifest ${{ inputs.manifest_path }} \
-            --targets ${{ inputs.bundle_from_target }} \
-            --local
+            --targets ${{ inputs.bundle_from_target }}
       
       - name: smus-cli bundle from ${{ inputs.bundle_from_target }}
         env:
@@ -245,6 +244,8 @@ jobs:
     name: Deploy to Test
     runs-on: ubuntu-latest
     needs: validate
+    # Skip if we already pre-deployed to the test target
+    if: ${{ !(inputs.pre_deploy_local_files && inputs.bundle_from_target == inputs.test_target) }}
     environment: test-aws-account
     
     steps:
@@ -383,8 +384,9 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
-    needs: deploy-test
-    if: ${{ !inputs.skip_tests }}
+    needs: [bundle, validate, deploy-test]
+    # Run if tests are not skipped AND either deploy-test ran or was skipped
+    if: ${{ !inputs.skip_tests && (success() || needs.deploy-test.result == 'skipped') }}
     environment: test-aws-account
     
     steps:
@@ -430,8 +432,9 @@ jobs:
   deploy-prod:
     name: Deploy to Production
     runs-on: ubuntu-latest
-    needs: [deploy-test, test]
-    if: ${{ inputs.deploy_to_prod && (success() || inputs.skip_tests) }}
+    needs: [bundle, deploy-test, test]
+    # Deploy to prod if enabled AND (tests passed OR tests were skipped OR deploy-test was skipped)
+    if: ${{ inputs.deploy_to_prod && (success() || inputs.skip_tests || needs.deploy-test.result == 'skipped') }}
     environment: prod-aws-account
     
     steps:


### PR DESCRIPTION
## Problem

ML deployment workflow was deploying to test stage twice:
1. During pre-deploy step (to make local files available for bundling with model artifacts)
2. During deploy-test job (redundant)

Additionally, the pre-deploy step was using a non-existent `--local` flag.

## Solution

1. **Removed `--local` flag**: Deploy uses local files by default when no bundle is specified
2. **Skip redundant deploy-test**: Added condition to skip deploy-test job when we've already pre-deployed to test
3. **Updated job dependencies**: Modified test and deploy-prod jobs to handle skipped deploy-test correctly

## Workflow Flow (ML Deployment)

1. **Bundle job**: Pre-deploys local deployment code/workflows to test, then bundles from test (includes local files + model artifacts from training)
2. **Validate job**: Validates manifest
3. **Deploy-test job**: SKIPPED (already deployed in step 1)
4. **Test job**: Runs tests against test environment
5. **Deploy-prod job**: Deploys bundle to production

## Testing

- Workflow logic verified for both scenarios:
  - Normal workflows (glue-quicksight): deploy-test runs normally
  - ML deployment: deploy-test skipped, tests still run

## Related Issues

Fixes the ML deployment test failure where bundling from test stage failed because deployment code/workflows weren't available in S3 yet.