### PR TITLE
Remove pre-deploy functionality and fix ML deployment workflow

### DIFF
--- a/.github/workflows/analytic-ml-deployment.yml
+++ b/.github/workflows/analytic-ml-deployment.yml
@@ -24,7 +24,6 @@ jobs:
     with:
       manifest_path: 'examples/analytic-workflow/ml/deployment/manifest.yaml'
       bundle_from_target: 'test'
-      pre_deploy_local_files: true
       test_target: 'test'
       prod_target: 'prod'
       deploy_to_prod: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/smus-bundle-deploy.yml
+++ b/.github/workflows/smus-bundle-deploy.yml
@@ -62,12 +62,6 @@ on:
         required: false
         type: boolean
         default: false
-      
-      pre_deploy_local_files:
-        description: 'Pre-deploy local files to bundle source before bundling'
-        required: false
-        type: boolean
-        default: false
     
     secrets:
       AWS_ROLE_ARN_DEV:
@@ -157,22 +151,6 @@ jobs:
           
           smus-cli describe --manifest ${{ inputs.manifest_path }} --targets ${{ inputs.bundle_from_target }} --connect
       
-      - name: Pre-deploy local files to bundle source (optional)
-        if: ${{ inputs.pre_deploy_local_files }}
-        env:
-          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
-          DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
-          TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
-          PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
-        run: |
-          echo "📤 Pre-deploying local files to ${{ inputs.bundle_from_target }} stage for bundling..."
-          
-          # Deploy local files to the bundle source target
-          # This ensures all content (local + S3) is available in the bundle source
-          smus-cli deploy \
-            --manifest ${{ inputs.manifest_path }} \
-            --targets ${{ inputs.bundle_from_target }}
-      
       - name: smus-cli bundle from ${{ inputs.bundle_from_target }}
         env:
           DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
@@ -244,8 +222,8 @@ jobs:
     name: Deploy to Test
     runs-on: ubuntu-latest
     needs: validate
-    # Skip if we already pre-deployed to the test target
-    if: ${{ !(inputs.pre_deploy_local_files && inputs.bundle_from_target == inputs.test_target) }}
+    # Skip if we already bundled from the test target (no need to redeploy)
+    if: ${{ inputs.bundle_from_target != inputs.test_target }}
     environment: test-aws-account
     
     steps:

--- a/examples/analytic-workflow/ml/deployment/manifest.yaml
+++ b/examples/analytic-workflow/ml/deployment/manifest.yaml
@@ -4,15 +4,15 @@ content:
   - name: deployment-code
     connectionName: default.s3_shared
     include:
-    - ml/deployment/code
+    - code
   - name: deployment-workflows
     connectionName: default.s3_shared
     include:
-    - ml/deployment/workflows
+    - workflows
   - name: model-artifacts
     connectionName: default.s3_shared
     include:
-    - ml/output/model-artifacts/latest
+    - ../../output/model-artifacts/latest
   workflows:
   - workflowName: ml_deployment_workflow
     connectionName: default.workflow_serverless

--- a/examples/analytic-workflow/ml/deployment/workflows/ml_deployment_notebook.ipynb
+++ b/examples/analytic-workflow/ml/deployment/workflows/ml_deployment_notebook.ipynb
@@ -71,7 +71,7 @@
   {
    "cell_type": "code",
    "metadata": {},
-   "source": "from sagemaker_studio import Project\n\n# Get project connections dynamically\nproj = Project()\n\n# Get region\nregion = boto3.Session().region_name\nprint(f\"\u2705 Region: {region}\")\n\n# Get S3 bucket\ns3_shared_conn = proj.connection('default.s3_shared')\nbucket = s3_shared_conn.data.s3_uri.rstrip('/').split('/')[-2]\nprint(f\"\u2705 S3 Bucket: {bucket}\")\n\n# Get IAM role\niam_conn = proj.connection('default.iam')\nrole = iam_conn.iam_role\nprint(f\"\u2705 IAM Role: {role}\")\n\n# Create SageMaker session\nsession = sagemaker.Session()\n",
+   "source": "from sagemaker_studio import Project\n\n# Get project connections dynamically\nproj = Project()\n\n# Get region\nregion = boto3.Session().region_name\nprint(f\"\u2705 Region: {region}\")\n\n# Get S3 bucket\ns3_shared_conn = proj.connection('default.s3_shared')\nbucket = s3_shared_conn.data.s3_uri.rstrip('/').split('/')[-2]\nprint(f\"\u2705 S3 Bucket: {bucket}\")\n\n# Get IAM role\niam_conn = proj.connection('default.iam')\nrole = iam_conn.iam_role\nprint(f\"\u2705 IAM Role: {role}\")\n\n# Create SageMaker session with explicit bucket to avoid CreateBucket permission issues\nsession = sagemaker.Session(default_bucket=bucket)\nprint(f\"\u2705 SageMaker session created with bucket: {bucket}\")\n",
    "outputs": [],
    "execution_count": null
   },


### PR DESCRIPTION
## Summary
This PR removes the pre-deploy functionality that's no longer needed and includes fixes to enable the ML deployment workflow to work correctly.

## Changes
- Remove `pre_deploy_local_files` parameter from analytic-ml-deployment workflow
- Remove pre-deploy functionality from smus-bundle-deploy reusable workflow:
  - Remove `pre_deploy_local_files` input parameter
  - Remove pre-deploy step that deployed local files before bundling
  - Simplify deploy-test condition to skip when bundling from test target
- Fix ML deployment manifest include paths to be relative to manifest directory
- Fix ML deployment notebook to use `default_bucket` parameter to avoid S3 CreateBucket permission error

## Context
The pre-deploy functionality was originally added to deploy local files to the bundle source target before bundling. However, this approach is no longer needed since:
1. ML deployment now correctly bundles from the test target
2. The test target already contains the trained model artifacts from the ML training workflow
3. The manifest include paths have been fixed to be relative to the manifest directory
4. The notebook has been fixed to use an existing S3 bucket instead of trying to create one

## Testing
- ML deployment workflow should now work end-to-end
- The workflow correctly skips redundant test deployment when bundling from test
- Model artifacts from training are properly included in the deployment bundle