### PR TITLE
Fix ML deployment prod domain tag

### DIFF
--- a/examples/analytic-workflow/ml/deployment/manifest.yaml
+++ b/examples/analytic-workflow/ml/deployment/manifest.yaml
@@ -67,7 +67,7 @@ stages:
     stage: PROD
     domain:
       tags:
-        purpose: smus-cicd-testing
+        purpose: smus-cicd-production
       region: ${PROD_DOMAIN_REGION:us-east-1}
     project:
       name: prod-marketing


### PR DESCRIPTION
## Summary
This PR fixes the prod domain tag in the ML deployment manifest to match the actual tag on the prod domain.

## Issue
The ML deployment workflow was failing during prod deployment with the error:
```
Domain not found - check domain name/tags in manifest or CloudFormation stack
```

## Root Cause
The manifest was configured to look for a domain with tag `purpose: smus-cicd-testing`, but the actual prod domain has tag `purpose: smus-cicd-production`.

## Changes
- Updated prod stage domain tag from `smus-cicd-testing` to `smus-cicd-production`

## Verification
Verified the actual tag on the prod domain using:
```python
python check_prod_domain_tags.py us-east-1
```

Output showed:
```
Domain: Default_02092026_Domain
  ID: dzd-67k2ebgdf93rl3
  Status: AVAILABLE
  Tags:
    purpose: smus-cicd-production
```

## Testing
This should allow the ML deployment workflow to successfully deploy to prod.