### PR TITLE
Fix ML deployment bundle include paths to match test S3 structure

### DIFF
--- a/examples/analytic-workflow/ml/deployment/manifest.yaml
+++ b/examples/analytic-workflow/ml/deployment/manifest.yaml
@@ -4,15 +4,15 @@ content:
   - name: deployment-code
     connectionName: default.s3_shared
     include:
-    - code
+    - ml/bundle/deployment-code
   - name: deployment-workflows
     connectionName: default.s3_shared
     include:
-    - workflows
+    - ml/bundle/deployment-workflows
   - name: model-artifacts
     connectionName: default.s3_shared
     include:
-    - ../../output/model-artifacts/latest
+    - ml/bundle/model-artifacts
   workflows:
   - workflowName: ml_deployment_workflow
     connectionName: default.workflow_serverless


### PR DESCRIPTION
## Problem
When bundling from test stage for prod deployment, the workflow files were not being found because the include paths in the manifest didn't match where files were actually deployed in test's S3.

## Root Cause
- Files were deployed to test at: `s3://bucket/shared/ml/bundle/deployment-workflows/`
- Bundle command was looking at: `s3://bucket/shared/workflows/` (from `include: [workflows]`)
- The paths didn't match, so workflow YAML files weren't included in the bundle

## Solution
Updated `content.storage` include paths to match test's deployment structure:
- `deployment-code`: `code` → `ml/bundle/deployment-code`
- `deployment-workflows`: `workflows` → `ml/bundle/deployment-workflows`
- `model-artifacts`: `../../output/model-artifacts/latest` → `ml/bundle/model-artifacts`

## Verification
Confirmed files exist in test's S3 at these exact paths:
```
✅ ml/bundle/deployment-code/inference.py
✅ ml/bundle/deployment-workflows/ml_deployment_notebook.ipynb
✅ ml/bundle/deployment-workflows/ml_deployment_workflow.yaml
✅ ml/bundle/model-artifacts/output/model.tar.gz
```

## Impact
This fixes the prod deployment workflow failure where workflows couldn't be created because the YAML files weren't in the bundle.

## Related
- Fixes issue from PR #20
- Part of ML deployment workflow improvements