### PR TITLE
Remove skip logic for test deployment in ML workflow

### DIFF
--- a/.github/workflows/smus-bundle-deploy.yml
+++ b/.github/workflows/smus-bundle-deploy.yml
@@ -222,8 +222,6 @@ jobs:
     name: Deploy to Test
     runs-on: ubuntu-latest
     needs: validate
-    # Skip if we already bundled from the test target (no need to redeploy)
-    if: ${{ inputs.bundle_from_target != inputs.test_target }}
     environment: test-aws-account
     
     steps:


### PR DESCRIPTION
## Problem
The ML deployment workflow was skipping test deployment when bundling from test, which caused test failures because the endpoint was too old (from manual deployment).

## Root Cause
The workflow had this logic:
```yaml
if: ${{ inputs.bundle_from_target != inputs.test_target }}
```

When `bundle_from_target: test`, this skipped the test deployment step, so:
- No new endpoint was created
- Tests expected a recently created endpoint
- Tests failed with "Endpoint is too old"

## Solution
Remove the skip condition so test deployment always runs. This ensures:
- Fresh endpoint is created for tests to validate
- Tests pass with newly created endpoint
- Workflow completes successfully

## Trade-off
This means we deploy to test even when bundling from test, which is somewhat redundant. However, it's necessary for the tests to pass and ensures the workflow runs end-to-end.

## Related
- Follows PR #21 (bundle path fixes)
- Fixes test failure from run #22110061845