### PR TITLE
Fix ML deployment model S3 path

### DIFF
--- a/examples/analytic-workflow/ml/deployment/workflows/ml_deployment_workflow.yaml
+++ b/examples/analytic-workflow/ml/deployment/workflows/ml_deployment_workflow.yaml
@@ -7,7 +7,7 @@ ml_deployment_workflow:
       input_config:
         input_path: "ml/bundle/deployment-workflows/ml_deployment_notebook.ipynb"
         input_params:
-          model_s3_uri: "{proj.connection.default.s3_shared.s3Uri}ml/output/model-artifacts/latest/output/model.tar.gz"
+          model_s3_uri: "{proj.connection.default.s3_shared.s3Uri}ml/bundle/model-artifacts/output/model.tar.gz"
           sklearn_version: "1.2-1"
           python_version: "py3"
           inference_instance_type: "ml.m5.large"


### PR DESCRIPTION
## Problem
The ML deployment workflow was failing in prod because it was looking for the model at the wrong S3 path.

**Expected path (where workflow was looking):**
`ml/output/model-artifacts/latest/output/model.tar.gz`

**Actual path (where bundle deploys it):**
`ml/bundle/model-artifacts/output/model.tar.gz`

This caused the notebook execution to fail at cell 8 (67% complete) when trying to access the model.

## Root Cause
The workflow YAML was using:
```yaml
model_s3_uri: "{proj.connection.default.s3_shared.s3Uri}ml/output/model-artifacts/latest/output/model.tar.gz"
```

But the bundle process deploys model artifacts to `ml/bundle/model-artifacts/` not `ml/output/model-artifacts/latest/`.

## Solution
Updated the workflow to use the correct path:
```yaml
model_s3_uri: "{proj.connection.default.s3_shared.s3Uri}ml/bundle/model-artifacts/output/model.tar.gz"
```

## Verification
Confirmed the model exists at the correct location in prod:
```
s3://amazon-sagemaker-062718313821-us-east-1-dctcvk1vfvsqav/shared/ml/bundle/model-artifacts/output/model.tar.gz
```

## Testing
- [ ] Workflow should now successfully find and use the model in both test and prod environments
- [ ] Notebook execution should complete all 12 cells without errors