### PR TITLE
docs: Add preview notice to main READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 [![zh](https://img.shields.io/badge/lang-zh-gray.svg)](docs/langs/zh/README.md)
 [![he](https://img.shields.io/badge/lang-he-gray.svg)](docs/langs/he/README.md)
 
+> **[Preview]** Amazon SageMaker Unified Studio CI/CD CLI is currently in preview and is subject to change. Commands, configuration formats, and APIs may evolve based on customer feedback. We recommend evaluating this tool in non-production environments during preview. For feedback and bug reports, please open an issue https://github.com/aws/CICD-for-SageMakerUnifiedStudio/issues
+
 **Automate deployment of data applications across SageMaker Unified Studio environments**
 
 Deploy Airflow DAGs, Jupyter notebooks, and ML workflows from development to production with confidence. Built for data scientists, data engineers, ML engineers, and GenAI app developers working with DevOps teams.

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -2,6 +2,7 @@
 
 ← [Back to Main README](../../README.md)
 
+> **[Preview]** Amazon SageMaker Unified Studio CI/CD CLI is currently in preview and is subject to change. Commands, configuration formats, and APIs may evolve based on customer feedback. We recommend evaluating this tool in non-production environments during preview. For feedback and bug reports, please open an issue https://github.com/aws/CICD-for-SageMakerUnifiedStudio/issues
 
 Choose the guide that matches your role:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,7 @@
 # SMUS CI/CD Pipeline Examples
 
+> **[Preview]** Amazon SageMaker Unified Studio CI/CD CLI is currently in preview and is subject to change. Commands, configuration formats, and APIs may evolve based on customer feedback. We recommend evaluating this tool in non-production environments during preview. For feedback and bug reports, please open an issue https://github.com/aws/CICD-for-SageMakerUnifiedStudio/issues
+
 This directory contains example pipelines and configurations demonstrating SMUS CI/CD capabilities.
 
 ## 📋 Table of Contents

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,5 +1,7 @@
 # SMUS CI/CD Tests
 
+> **[Preview]** Amazon SageMaker Unified Studio CI/CD CLI is currently in preview and is subject to change. Commands, configuration formats, and APIs may evolve based on customer feedback. We recommend evaluating this tool in non-production environments during preview. For feedback and bug reports, please open an issue https://github.com/aws/CICD-for-SageMakerUnifiedStudio/issues
+
 See [developer-guide.md](../developer-guide.md) for comprehensive testing documentation.
 
 ## Quick Start


### PR DESCRIPTION
## Summary
Adds a preview notice to the main README files informing users that the Amazon SageMaker Unified Studio CI/CD CLI is currently in preview.

## Changes
- Added preview notice to root `README.md`
- Added preview notice to `examples/README.md`
- Added preview notice to `tests/README.md`
- Added preview notice to `docs/getting-started/README.md`

## Preview Notice Content
The notice includes:
- Clear **[Preview]** label
- Statement that the CLI is subject to change
- Recommendation to evaluate in non-production environments
- Link to GitHub issues for feedback and bug reports

## Translation
Translated versions in `docs/langs/*/README.md` will be automatically updated by the `translate-docs` workflow after this PR is merged.

## Testing
- [x] Verified preview notice appears at the top of all modified READMEs
- [x] Confirmed translation workflow exists and will handle translations automatically