### PR TITLE
fix: Use correct AWS secret name in translate-docs workflow

### DIFF
--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -45,7 +45,7 @@ jobs:
         if: steps.check-changes.outputs.has-changes == 'true'
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEV }}
           aws-region: us-east-1
           role-session-name: translate-docs-session
 


### PR DESCRIPTION
## Problem
The translate-docs workflow was failing with:
```
Credentials could not be loaded, please check your action inputs: Could not load credentials from any providers
```

See failed run: https://github.com/aws/CICD-for-SageMakerUnifiedStudio/actions/runs/22149269530

## Root Cause
The workflow referenced `secrets.AWS_ROLE_ARN` but this secret doesn't exist in the `dev-aws-account` environment. The actual secret name is `AWS_ROLE_ARN_DEV`.

## Solution
Updated the workflow to use `secrets.AWS_ROLE_ARN_DEV` which matches the secret configured in the environment.

## Verification
- Confirmed `AWS_ROLE_ARN_DEV` exists in `dev-aws-account` environment via `gh secret list --env dev-aws-account`
- Checked other workflows using the same environment and they all use `AWS_ROLE_ARN_DEV`

## Testing
After merge, the translate-docs workflow should successfully:
1. Authenticate with AWS using the correct secret
2. Call Bedrock to translate README.md
3. Commit translated versions to `docs/langs/*/README.md`