### PR TITLE
fix: describe command no longer requires AWS credentials without --connect

### DIFF
--- a/src/smus_cicd/application/application_manifest.py
+++ b/src/smus_cicd/application/application_manifest.py
@@ -239,7 +239,9 @@ class ApplicationManifest:
     _file_path: Optional[str] = field(default=None, init=False)
 
     @classmethod
-    def from_file(cls, manifest_file: str, resolve_aws_pseudo_vars: bool = True) -> "ApplicationManifest":
+    def from_file(
+        cls, manifest_file: str, resolve_aws_pseudo_vars: bool = True
+    ) -> "ApplicationManifest":
         """Load bundle manifest from YAML file with validation."""
         from .validation import validate_manifest_file
 

--- a/src/smus_cicd/application/application_manifest.py
+++ b/src/smus_cicd/application/application_manifest.py
@@ -239,13 +239,15 @@ class ApplicationManifest:
     _file_path: Optional[str] = field(default=None, init=False)
 
     @classmethod
-    def from_file(cls, manifest_file: str) -> "ApplicationManifest":
+    def from_file(cls, manifest_file: str, resolve_aws_pseudo_vars: bool = True) -> "ApplicationManifest":
         """Load bundle manifest from YAML file with validation."""
         from .validation import validate_manifest_file
 
         # Validate manifest file (YAML syntax + schema)
         # Missing env var check happens in load_yaml
-        is_valid, errors, manifest_data = validate_manifest_file(manifest_file)
+        is_valid, errors, manifest_data = validate_manifest_file(
+            manifest_file, resolve_aws_pseudo_vars=resolve_aws_pseudo_vars
+        )
         if not is_valid:
             error_msg = (
                 f"Manifest validation failed for {manifest_file}:\n"

--- a/src/smus_cicd/application/validation.py
+++ b/src/smus_cicd/application/validation.py
@@ -19,7 +19,9 @@ def load_schema() -> Dict[str, Any]:
     return load_yaml(str(schema_path))
 
 
-def validate_yaml_syntax(manifest_path: str) -> Tuple[bool, str, Dict[str, Any]]:
+def validate_yaml_syntax(
+    manifest_path: str, resolve_aws_pseudo_vars: bool = True
+) -> Tuple[bool, str, Dict[str, Any]]:
     """
     Validate YAML syntax of manifest file.
 
@@ -27,7 +29,7 @@ def validate_yaml_syntax(manifest_path: str) -> Tuple[bool, str, Dict[str, Any]]
         Tuple of (is_valid, error_message, parsed_data)
     """
     try:
-        data = load_yaml(manifest_path)
+        data = load_yaml(manifest_path, resolve_aws_pseudo_vars=resolve_aws_pseudo_vars)
         return True, "", data
     except FileNotFoundError:
         return False, f"File not found: {manifest_path}", {}
@@ -78,18 +80,22 @@ def validate_manifest_schema(
 
 def validate_manifest_file(
     manifest_path: str,
+    resolve_aws_pseudo_vars: bool = True,
 ) -> Tuple[bool, List[str], Dict[str, Any]]:
     """
     Validate a manifest file completely (YAML syntax + schema).
 
     Args:
         manifest_path: Path to the manifest file
+        resolve_aws_pseudo_vars: Passed through to load_yaml/substitute_env_vars
 
     Returns:
         Tuple of (is_valid, list_of_error_messages, parsed_data)
     """
     # First validate YAML syntax
-    yaml_valid, yaml_error, manifest_data = validate_yaml_syntax(manifest_path)
+    yaml_valid, yaml_error, manifest_data = validate_yaml_syntax(
+        manifest_path, resolve_aws_pseudo_vars=resolve_aws_pseudo_vars
+    )
     if not yaml_valid:
         return False, [yaml_error], {}
 

--- a/src/smus_cicd/commands/describe.py
+++ b/src/smus_cicd/commands/describe.py
@@ -38,15 +38,18 @@ def describe_command(
     """Describe and validate pipeline manifest file."""
     try:
         # Load pipeline manifest using centralized parser
-        manifest = ApplicationManifest.from_file(manifest_file)
+        # Only resolve AWS pseudo vars (STS calls) when --connect is explicitly requested
+        manifest = ApplicationManifest.from_file(
+            manifest_file, resolve_aws_pseudo_vars=connect
+        )
 
         # Determine which targets to show
         targets_to_show = {}
         if targets:
-            if targets in manifest.stages:
-                targets_to_show[targets] = manifest.stages[targets]
-            else:
-                error_msg = f"Target '{targets}' not found in manifest"
+            requested = [t.strip() for t in targets.split(",") if t.strip()]
+            missing = [t for t in requested if t not in manifest.stages]
+            if missing:
+                error_msg = f"Target(s) not found in manifest: {', '.join(missing)}"
                 available_targets = list(manifest.stages.keys())
                 if output.upper() == "JSON":
                     output_data = {
@@ -60,25 +63,19 @@ def describe_command(
                         f"Available targets: {', '.join(available_targets)}", err=True
                     )
                 raise typer.Exit(1)
+            targets_to_show = {t: manifest.stages[t] for t in requested}
         else:
             targets_to_show = manifest.stages
-
-        # Get the first target's domain for display (they should all be the same)
-        first_target = next(iter(manifest.stages.values()))
-        domain_config = first_target.domain
-        domain_name = domain_config.get_name()
 
         # Prepare output data structure for JSON format
         output_data = {
             "bundle": manifest.application_name,
-            "domain": {"name": domain_name, "region": domain_config.region},
             "targets": {},
         }
 
         # TEXT output header
         if output.upper() != "JSON":
             typer.echo(f"Pipeline: {manifest.application_name}")
-            typer.echo(f"Domain: {domain_name} ({domain_config.region})")
             typer.echo("\nTargets:")
 
         # Track errors to exit with proper code
@@ -86,6 +83,12 @@ def describe_command(
 
         # Process targets
         for stage_name, target_config in targets_to_show.items():
+            # Resolve domain name per stage
+            if connect:
+                stage_domain_name = target_config.domain.get_name()
+            else:
+                stage_domain_name = target_config.domain.name or "Unknown"
+
             # Use to_dict method if available, otherwise build manually
             if hasattr(target_config.project, "to_dict"):
                 project_dict = target_config.project.to_dict()
@@ -95,7 +98,7 @@ def describe_command(
             target_data = {
                 "project": project_dict,
                 "domain": {
-                    "name": target_config.domain.name,
+                    "name": stage_domain_name,
                     "region": target_config.domain.region,
                 },
             }
@@ -110,7 +113,7 @@ def describe_command(
                 }
 
             if output.upper() != "JSON":
-                typer.echo(f"  - {stage_name}: {target_config.project.name}")
+                typer.echo(f"  - {stage_name}: {target_config.project.name} (domain: {stage_domain_name}, region: {target_config.domain.region})")
 
             # Add connections if requested or if connect flag is used
             if connections or connect:
@@ -447,7 +450,7 @@ def describe_command(
         # Show connections from initialization if they exist
         connections_found = False
         if output.upper() != "JSON":
-            for stage_name, target_config in manifest.stages.items():
+            for stage_name, target_config in targets_to_show.items():
                 if (
                     hasattr(target_config, "bootstrap")
                     and target_config.bootstrap

--- a/src/smus_cicd/commands/describe.py
+++ b/src/smus_cicd/commands/describe.py
@@ -113,7 +113,9 @@ def describe_command(
                 }
 
             if output.upper() != "JSON":
-                typer.echo(f"  - {stage_name}: {target_config.project.name} (domain: {stage_domain_name}, region: {target_config.domain.region})")
+                typer.echo(
+                    f"  - {stage_name}: {target_config.project.name} (domain: {stage_domain_name}, region: {target_config.domain.region})"
+                )
 
             # Add connections if requested or if connect flag is used
             if connections or connect:

--- a/src/smus_cicd/helpers/utils.py
+++ b/src/smus_cicd/helpers/utils.py
@@ -70,19 +70,26 @@ def find_missing_env_vars(data: Union[Dict, List, str]) -> List[str]:
     return sorted(missing)
 
 
-def substitute_env_vars(data: Union[Dict, List, str]) -> Union[Dict, List, str]:
+def substitute_env_vars(
+    data: Union[Dict, List, str], resolve_aws_pseudo_vars: bool = True
+) -> Union[Dict, List, str]:
     """
     Recursively substitute environment variables in YAML data.
 
     Supports ${VAR_NAME} or ${VAR_NAME:default_value} syntax for environment variable substitution.
 
-    Pseudo environment variables (auto-resolved from AWS credentials):
-    - AWS_ACCOUNT_ID: Current AWS account ID from STS
-    - STS_ACCOUNT_ID: Current AWS account ID from STS (alias for AWS_ACCOUNT_ID)
-    - STS_REGION: Current AWS region from boto3 session
+    Pseudo environment variables:
+    - AWS_ACCOUNT_ID: Current AWS account ID (from STS when resolve_aws_pseudo_vars=True,
+                      otherwise falls back to os.getenv, then leaves placeholder as-is)
+    - STS_ACCOUNT_ID: Alias for AWS_ACCOUNT_ID
+    - STS_REGION: Current AWS region (from boto3 session when resolve_aws_pseudo_vars=True,
+                  otherwise falls back to os.getenv/AWS_DEFAULT_REGION, then placeholder)
 
     Args:
         data: YAML data (dict, list, or string)
+        resolve_aws_pseudo_vars: If True (default), resolve AWS_ACCOUNT_ID/STS_ACCOUNT_ID/STS_REGION
+            via live AWS calls. If False, attempt os.getenv first and leave placeholder as-is
+            if not available (no AWS calls made).
 
     Returns:
         Data with environment variables substituted
@@ -91,9 +98,12 @@ def substitute_env_vars(data: Union[Dict, List, str]) -> Union[Dict, List, str]:
         ValueError: If a required variable (without default) is not found
     """
     if isinstance(data, dict):
-        return {key: substitute_env_vars(value) for key, value in data.items()}
+        return {
+            key: substitute_env_vars(value, resolve_aws_pseudo_vars)
+            for key, value in data.items()
+        }
     elif isinstance(data, list):
-        return [substitute_env_vars(item) for item in data]
+        return [substitute_env_vars(item, resolve_aws_pseudo_vars) for item in data]
     elif isinstance(data, str):
         # Pattern to match ${VAR_NAME} or ${VAR_NAME:default_value}
         pattern = r"\$\{([^}:]+)(?::([^}]*))?\}"
@@ -104,22 +114,33 @@ def substitute_env_vars(data: Union[Dict, List, str]) -> Union[Dict, List, str]:
             default_value = match.group(2) if has_default else None
 
             # Handle pseudo environment variables
-            if var_name == "STS_ACCOUNT_ID" or var_name == "AWS_ACCOUNT_ID":
-                import boto3
+            if var_name in ("STS_ACCOUNT_ID", "AWS_ACCOUNT_ID"):
+                if resolve_aws_pseudo_vars:
+                    import boto3
 
-                return boto3.client("sts").get_caller_identity()["Account"]
+                    return boto3.client("sts").get_caller_identity()["Account"]
+                # Fall back to env var, then leave placeholder as-is
+                return os.getenv(var_name) or match.group(0)
+
             elif var_name == "STS_REGION":
-                import boto3
+                if resolve_aws_pseudo_vars:
+                    import boto3
 
-                region = boto3.Session().region_name
-                if region:
-                    return region
-                elif has_default:
-                    return default_value
-                else:
-                    raise ValueError(
-                        f"Variable ${{{var_name}}} could not be resolved: No AWS region configured"
-                    )
+                    region = boto3.Session().region_name
+                    if region:
+                        return region
+                    elif has_default:
+                        return default_value
+                    else:
+                        raise ValueError(
+                            f"Variable ${{{var_name}}} could not be resolved: No AWS region configured"
+                        )
+                # Fall back to env var or AWS_DEFAULT_REGION, then leave placeholder as-is
+                return (
+                    os.getenv(var_name)
+                    or os.getenv("AWS_DEFAULT_REGION")
+                    or match.group(0)
+                )
 
             # Regular environment variable lookup
             value = os.getenv(var_name)
@@ -137,13 +158,20 @@ def substitute_env_vars(data: Union[Dict, List, str]) -> Union[Dict, List, str]:
         return data
 
 
-def load_yaml(file_path: str, check_missing_vars: bool = True) -> Dict[str, Any]:
+def load_yaml(
+    file_path: str,
+    check_missing_vars: bool = True,
+    resolve_aws_pseudo_vars: bool = True,
+) -> Dict[str, Any]:
     """
     Load and parse YAML file.
 
     Args:
         file_path: Path to the YAML file
         check_missing_vars: If True, check for missing required env vars before substitution
+        resolve_aws_pseudo_vars: If True (default), resolve AWS_ACCOUNT_ID/STS_ACCOUNT_ID/STS_REGION
+            via live AWS calls. If False, attempt os.getenv first and leave placeholder as-is
+            if not available (no AWS calls made).
 
     Returns:
         Parsed YAML content as dictionary
@@ -173,7 +201,7 @@ def load_yaml(file_path: str, check_missing_vars: bool = True) -> Dict[str, Any]
                         + "\n\nPlease set these environment variables before running the command."
                     )
 
-            return substitute_env_vars(data)
+            return substitute_env_vars(data, resolve_aws_pseudo_vars=resolve_aws_pseudo_vars)
     except yaml.YAMLError as e:
         raise yaml.YAMLError(f"Invalid YAML syntax in {file_path}: {e}")
 

--- a/src/smus_cicd/helpers/utils.py
+++ b/src/smus_cicd/helpers/utils.py
@@ -201,7 +201,9 @@ def load_yaml(
                         + "\n\nPlease set these environment variables before running the command."
                     )
 
-            return substitute_env_vars(data, resolve_aws_pseudo_vars=resolve_aws_pseudo_vars)
+            return substitute_env_vars(
+                data, resolve_aws_pseudo_vars=resolve_aws_pseudo_vars
+            )
     except yaml.YAMLError as e:
         raise yaml.YAMLError(f"Invalid YAML syntax in {file_path}: {e}")
 

--- a/tests/integration/glue-mwaa-catalog-app/test_multi_target_app.py
+++ b/tests/integration/glue-mwaa-catalog-app/test_multi_target_app.py
@@ -273,7 +273,7 @@ task = PythonOperator(
 
         # Verify it shows pipeline info
         assert "Pipeline: GlueMwaaCatalogApp" in result["output"]
-        assert "Domain:" in result["output"]  # Check domain field exists (name varies by environment)
+        assert "domain:" in result["output"]  # Check domain field exists inline per-target (name varies by environment)
 
         # Verify it shows target info with connections
         assert "Targets:" in result["output"]
@@ -1017,9 +1017,9 @@ stages:
             # Get the actual region from environment variable
             expected_region = os.environ.get('DEV_DOMAIN_REGION')
             assert expected_region, "DEV_DOMAIN_REGION environment variable must be set"
-            # Use regex to match any domain name with expected region
+            # Domain is now inline per-target: "- stage: project (domain: <name>, region: <region>)"
             import re
-            domain_pattern = rf"Domain: .+ \({re.escape(expected_region)}\)"
+            domain_pattern = rf"domain: .+, region: {re.escape(expected_region)}"
             assert re.search(domain_pattern, describe_output), \
                 f"Describe output missing domain with region {expected_region}: {describe_output}"
             assert (

--- a/tests/integration/multi_target_app_airless/test_multi_target_app.py
+++ b/tests/integration/multi_target_app_airless/test_multi_target_app.py
@@ -113,7 +113,7 @@ class TestMultiTargetApp(IntegrationTestBase):
 
         # Verify it shows pipeline info
         assert "Pipeline: IntegrationTestMultiTarget" in result["output"]
-        assert "Domain:" in result["output"]  # Check domain field exists (name varies by environment)
+        assert "domain:" in result["output"]  # Check domain field exists inline per-target (name varies by environment)
 
         # Verify it shows target info with connections
         assert "Targets:" in result["output"]
@@ -839,14 +839,14 @@ stages:
             # Verify domain with region from environment variable using regex
             expected_region = os.environ.get('DEV_DOMAIN_REGION')
             if expected_region:
-                # Use regex to match "Domain: <any-name> (<region>)"
+                # Domain is now inline per-target: "- stage: project (domain: <name>, region: <region>)"
                 import re
-                domain_pattern = rf"Domain: .+ \({re.escape(expected_region)}\)"
+                domain_pattern = rf"domain: .+, region: {re.escape(expected_region)}"
                 assert re.search(domain_pattern, describe_output), \
                     f"Describe output missing domain with region {expected_region}: {describe_output}"
             else:
                 # Fallback if no environment variable set
-                assert "Domain:" in describe_output, \
+                assert "domain:" in describe_output, \
                     f"Describe output missing domain info: {describe_output}"
 
             assert (

--- a/tests/unit/test_describe.py
+++ b/tests/unit/test_describe.py
@@ -48,7 +48,7 @@ def test_describe_basic(mock_load_config, mock_get_region, sample_manifest):
         result = runner.invoke(app, ["describe", "--manifest", "test.yaml"])
         assert result.exit_code == 0
         assert "Pipeline: TestPipeline" in result.stdout
-        assert "Domain: test-domain" in result.stdout
+        assert "dev: test-project (domain: test-domain, region: us-east-1)" in result.stdout
 
 
 @patch("smus_cicd.commands.describe.load_config")
@@ -116,3 +116,44 @@ def test_describe_with_connect_flag(sample_manifest):
         # Should at least show pipeline info even if connect fails
         if result.stdout:
             assert "Pipeline:" in result.stdout or "error" in result.stdout.lower()
+
+
+def test_describe_no_aws_credentials_required_without_connect():
+    """Verify describe works without AWS credentials when --connect is not used.
+
+    The describe command should never call STS or boto3 unless --connect is
+    explicitly passed. This test uses a manifest with AWS pseudo vars
+    (${AWS_ACCOUNT_ID}, ${STS_REGION}) and asserts no STS calls are made.
+    """
+    manifest_content = """
+applicationName: NoCredsPipeline
+content:
+  storage: []
+stages:
+  dev:
+    domain:
+      name: my-domain
+      region: ${STS_REGION:us-west-2}
+    stage: DEV
+    project:
+      name: project-${AWS_ACCOUNT_ID:unknown}
+      create: false
+"""
+    runner = CliRunner()
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write(manifest_content)
+        manifest_path = f.name
+
+    try:
+        with patch("boto3.client") as mock_boto3_client:
+            result = runner.invoke(app, ["describe", "--manifest", manifest_path])
+
+        assert result.exit_code == 0, f"Expected exit 0, got {result.exit_code}: {result.output}"
+        assert "Pipeline: NoCredsPipeline" in result.stdout
+        # Pseudo vars fall back to defaults when resolve_aws_pseudo_vars=False
+        assert "us-west-2" in result.stdout
+        assert "unknown" in result.stdout
+        # STS must NOT have been called
+        mock_boto3_client.assert_not_called()
+    finally:
+        os.unlink(manifest_path)

--- a/tests/unit/test_describe_comprehensive.py
+++ b/tests/unit/test_describe_comprehensive.py
@@ -51,7 +51,7 @@ stages:
         result = self.run_describe(manifest)
         assert result.exit_code == 0
         assert "Pipeline: MinimalPipeline" in result.stdout
-        assert "Domain: minimal-domain" in result.stdout
+        assert "staging: minimal-project (domain: minimal-domain, region: us-east-1)" in result.stdout
 
     def test_complex_manifest_with_workflows(self):
         """Test complex manifest with multiple workflows and targets."""
@@ -90,7 +90,8 @@ stages:
 
         # Check pipeline info
         assert "Pipeline: ComplexPipeline" in result.stdout
-        assert "Domain: complex-domain" in result.stdout
+        # Domain is now shown inline per-target
+        assert "development: dev-project (domain: complex-domain, region: us-east-1)" in result.stdout
 
         # Check targets
         assert "Targets:" in result.stdout
@@ -478,5 +479,4 @@ stages:
         result = self.run_describe(manifest, ["--connections"])
         assert result.exit_code == 0
         assert "Pipeline: Pipeline-With_Special_Characters123" in result.stdout
-        assert "Domain: domain-with-dashes" in result.stdout
-        assert "target-with-dashes: project_with_underscores" in result.stdout
+        assert "target-with-dashes: project_with_underscores (domain: domain-with-dashes, region: us-east-1)" in result.stdout

--- a/tests/unit/test_describe_new_features.py
+++ b/tests/unit/test_describe_new_features.py
@@ -63,14 +63,14 @@ stages:
             # Should be valid JSON
             output_data = json.loads(result.stdout)
             assert "bundle" in output_data
-            assert "domain" in output_data
             assert "targets" in output_data
             assert output_data["bundle"] == "TestPipeline"
-            assert output_data["domain"]["name"] == "test-domain"
-            assert output_data["domain"]["region"] == "us-east-1"
             assert "dev" in output_data["targets"]
             assert "test" in output_data["targets"]
             assert "prod" in output_data["targets"]
+            # Domain is now per-target, not top-level
+            assert output_data["targets"]["dev"]["domain"]["name"] == "test-domain"
+            assert output_data["targets"]["dev"]["domain"]["region"] == "us-east-1"
         finally:
             import os
 
@@ -88,9 +88,9 @@ stages:
 
             assert result.exit_code == 0
             assert "Pipeline: TestPipeline" in result.stdout
-            assert "Domain: test-domain (us-east-1)" in result.stdout
+            # Domain is now shown inline per-target
+            assert "dev: dev-project (domain: test-domain, region: us-east-1)" in result.stdout
             assert "Targets:" in result.stdout
-            assert "dev: dev-project" in result.stdout
             assert "test: test-project" in result.stdout
             assert "prod: prod-project" in result.stdout
         finally:
@@ -164,7 +164,7 @@ stages:
             assert result.exit_code == 1
             # Error messages go to stderr in typer
             assert (
-                "Target 'invalid' not found" in result.stderr
+                "Target(s) not found in manifest: invalid" in result.stderr
                 or "invalid" in result.stderr
             )
             assert (


### PR DESCRIPTION
- Add resolve_aws_pseudo_vars flag to substitute_env_vars() and load_yaml() to skip STS calls for AWS_ACCOUNT_ID/STS_ACCOUNT_ID/STS_REGION when not needed
- Thread flag through validate_manifest_file(), validate_yaml_syntax(), and ApplicationManifest.from_file()
- describe command only resolves AWS pseudo vars and domain names via live AWS calls when --connect is explicitly specified
- Without --connect, falls back to os.getenv for pseudo vars, leaves placeholders as-is if not set, and shows 'Unknown' for tag-based domains
- Fix domain name display to be per-stage instead of using first stage for all
- Add comma-separated list support for --targets option
- Fix bootstrap actions display to respect --targets filter

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
