### PR TITLE
Improve workflow triggers and add Slack notifications

### DIFF
--- a/.github/workflows/analytic-dashboard-glue-quicksight.yml
+++ b/.github/workflows/analytic-dashboard-glue-quicksight.yml
@@ -8,6 +8,9 @@ on:
       - amirbo_feature_branch
     paths:
       - 'examples/analytic-workflow/dashboard-glue-quick/**'
+      - 'src/**'
+      - '.github/workflows/smus-bundle-deploy.yml'
+      - '.github/workflows/analytic-dashboard-glue-quicksight.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/analytic-data-notebooks.yml
+++ b/.github/workflows/analytic-data-notebooks.yml
@@ -8,6 +8,9 @@ on:
       - amirbo_feature_branch
     paths:
       - 'examples/analytic-workflow/data-notebooks/**'
+      - 'src/**'
+      - '.github/workflows/smus-direct-deploy.yml'
+      - '.github/workflows/analytic-data-notebooks.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/analytic-genai.yml
+++ b/.github/workflows/analytic-genai.yml
@@ -8,6 +8,9 @@ on:
       - amirbo_feature_branch
     paths:
       - 'examples/analytic-workflow/genai/**'
+      - 'src/**'
+      - '.github/workflows/smus-direct-deploy.yml'
+      - '.github/workflows/analytic-genai.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/analytic-ml-deployment.yml
+++ b/.github/workflows/analytic-ml-deployment.yml
@@ -8,6 +8,9 @@ on:
       - amirbo_feature_branch
     paths:
       - 'examples/analytic-workflow/ml/deployment/**'
+      - 'src/**'
+      - '.github/workflows/smus-bundle-deploy.yml'
+      - '.github/workflows/analytic-ml-deployment.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/analytic-ml-training.yml
+++ b/.github/workflows/analytic-ml-training.yml
@@ -8,6 +8,9 @@ on:
       - amirbo_feature_branch
     paths:
       - 'examples/analytic-workflow/ml/training/**'
+      - 'src/**'
+      - '.github/workflows/smus-direct-deploy.yml'
+      - '.github/workflows/analytic-ml-training.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/slack-action-failure-notification.yml
+++ b/.github/workflows/slack-action-failure-notification.yml
@@ -11,6 +11,9 @@ on:
       - "Translate Documentation"
     types: [completed]
 
+permissions:
+  contents: read
+
 jobs:
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/slack-action-failure-notification.yml
+++ b/.github/workflows/slack-action-failure-notification.yml
@@ -1,0 +1,24 @@
+name: Slack Action Failure Notification
+
+on:
+  workflow_run:
+    workflows:
+      - "Deploy Dashboard Glue QuickSight"
+      - "Deploy Data Notebooks"
+      - "Deploy GenAI"
+      - "Deploy ML Deployment"
+      - "Deploy ML Training"
+      - "Translate Documentation"
+    types: [completed]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - name: Send Slack failure notification
+        run: |
+          curl -X POST ${{ secrets.SLACK_FAILURE_WEBHOOK_URL }} \
+            -H "Content-Type: application/json" \
+            -d "{\"workflow\": \"${{ github.event.workflow_run.name }}\", 
+            \"run_url\": \"${{ github.event.workflow_run.html_url }}\"}"

--- a/.github/workflows/slack-pr-notification.yml
+++ b/.github/workflows/slack-pr-notification.yml
@@ -1,0 +1,16 @@
+name: Slack PR Notification
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack notification
+        run: |
+          curl -X POST ${{ secrets.SLACK_PR_WEBHOOK_URL }} \
+            -H "Content-Type: application/json" \
+            -d "{\"PR_URL\": \"${{ github.event.pull_request.html_url }}\", 
+            \"PR_author\": \"${{ github.event.pull_request.user.login }}\"}"

--- a/.github/workflows/slack-pr-notification.yml
+++ b/.github/workflows/slack-pr-notification.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, reopened]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   notify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Add src/**, reusable workflow, and self-referencing paths to all analytic workflow triggers (dashboard-glue-quicksight, data-notebooks, genai, ml-deployment, ml-training)
- Use smus-bundle-deploy.yml for ml-deployment and glue-quicksight, smus-direct-deploy.yml for the rest
- Add slack-pr-notification.yml to notify Slack on PR open/reopen
- Add slack-action-failure-notification.yml to notify Slack on workflow failures across all analytic and translate-docs workflows

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
