### PR TITLE
fix: upgrade sklearn container to 1.4-2 and improve weekly summary

### DIFF
--- a/.github/workflows/slack-weekly-summary.yml
+++ b/.github/workflows/slack-weekly-summary.yml
@@ -42,9 +42,14 @@ jobs:
 
           WORKFLOW_SUMMARY=""
           for WF in "${WORKFLOWS[@]}"; do
-            RUN=$(gh run list --repo "$REPO" --workflow "$WF" --limit 1 --json status,conclusion,url \
-              --jq '.[0] | "\(.conclusion // .status) - \(.url)"')
-            WORKFLOW_SUMMARY="${WORKFLOW_SUMMARY}• ${WF}: ${RUN}\n"
+            CONCLUSION=$(gh run list --repo "$REPO" --workflow "$WF" --limit 1 --json conclusion --jq ".[0].conclusion")
+            URL=$(gh run list --repo "$REPO" --workflow "$WF" --limit 1 --json url --jq ".[0].url")
+            if [ "$CONCLUSION" = "success" ]; then
+              ICON="✅"
+            else
+              ICON="❌"
+            fi
+            WORKFLOW_SUMMARY="${WORKFLOW_SUMMARY}${ICON} ${WF} - ${URL}\n"
           done
 
           # Build payload

--- a/README.md
+++ b/README.md
@@ -716,7 +716,7 @@ ml_training_workflow:
         input_params:
           mlflow_tracking_server_arn: "{proj.connection.mlflow-server.trackingServerArn}"
           mlflow_artifact_location: "{proj.connection.default.s3_shared.s3Uri}ml/mlflow-artifacts"
-          sklearn_version: "1.2-1"
+          sklearn_version: "1.4-2"
           python_version: "py3"
           training_instance_type: "ml.m5.large"
           model_name: "realistic-classifier-v1"
@@ -838,7 +838,7 @@ ml_deployment_workflow:
         input_path: "ml/bundle/deployment-workflows/ml_deployment_notebook.ipynb"
         input_params:
           model_s3_uri: "{proj.connection.default.s3_shared.s3Uri}ml/output/model-artifacts/latest/output/model.tar.gz"
-          sklearn_version: "1.2-1"
+          sklearn_version: "1.4-2"
           python_version: "py3"
           inference_instance_type: "ml.m5.large"
       output_config:

--- a/examples/analytic-workflow/ml/deployment/workflows/ml_deployment_notebook.ipynb
+++ b/examples/analytic-workflow/ml/deployment/workflows/ml_deployment_notebook.ipynb
@@ -26,7 +26,7 @@
      "parameters"
     ]
    },
-   "source": "# Parameters cell - will be replaced by Papermill\nmodel_s3_uri = None\nsklearn_version = \"1.2-1\"\npython_version = \"py3\"\ninference_instance_type = \"ml.m5.large\"\n",
+   "source": "# Parameters cell - will be replaced by Papermill\nmodel_s3_uri = None\nsklearn_version = \"1.4-2\"\npython_version = \"py3\"\ninference_instance_type = \"ml.m5.large\"\n",
    "outputs": [],
    "execution_count": null
   },

--- a/examples/analytic-workflow/ml/deployment/workflows/ml_deployment_workflow.yaml
+++ b/examples/analytic-workflow/ml/deployment/workflows/ml_deployment_workflow.yaml
@@ -8,7 +8,7 @@ ml_deployment_workflow:
         input_path: "ml/bundle/deployment-workflows/ml_deployment_notebook.ipynb"
         input_params:
           model_s3_uri: "{proj.connection.default.s3_shared.s3Uri}ml/bundle/model-artifacts/output/model.tar.gz"
-          sklearn_version: "1.2-1"
+          sklearn_version: "1.4-2"
           python_version: "py3"
           inference_instance_type: "ml.m5.large"
       output_config:

--- a/examples/analytic-workflow/ml/training/workflows/ml_training_notebook.ipynb
+++ b/examples/analytic-workflow/ml/training/workflows/ml_training_notebook.ipynb
@@ -40,7 +40,7 @@
     "# Parameters cell - will be replaced by Papermill\n",
     "mlflow_tracking_server_arn = None\n",
     "mlflow_artifact_location = None  # Optional: Custom artifact location\n",
-    "sklearn_version = \"1.2-1\"\n",
+    "sklearn_version = \"1.4-2\"\n",
     "python_version = \"py3\"\n",
     "training_instance_type = \"ml.m5.large\"\n",
     "inference_instance_type = \"ml.m5.large\"\n",

--- a/examples/analytic-workflow/ml/training/workflows/ml_training_workflow.yaml
+++ b/examples/analytic-workflow/ml/training/workflows/ml_training_workflow.yaml
@@ -9,7 +9,7 @@ ml_training_workflow:
         input_params:
           mlflow_tracking_server_arn: "{proj.connection.mlflow-server.trackingServerArn}"
           mlflow_artifact_location: "{proj.connection.default.s3_shared.s3Uri}ml/mlflow-artifacts"
-          sklearn_version: "1.2-1"
+          sklearn_version: "1.4-2"
           python_version: "py3"
           training_instance_type: "ml.m5.large"
           model_name: "realistic-classifier-v1"


### PR DESCRIPTION
- Bump sklearn_version from 1.2-1 to 1.4-2 in ML training and deployment workflows and notebooks. The 1.2-1 container uses Python 3.9 which cannot install mlflow>=3.0 (requires Python >=3.10). The 1.4-2 container ships with Python 3.10, unblocking mlflow==3.5.0.
- Update README examples to reflect new sklearn version.
- Improve slack-weekly-summary workflow: show ✅/❌ icons per workflow status instead of raw conclusion text.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
