### PR TITLE
fix: upgrade sagemaker SDK at runtime to support sklearn 1.4-2

### DIFF
--- a/examples/analytic-workflow/ml/deployment/workflows/ml_deployment_notebook.ipynb
+++ b/examples/analytic-workflow/ml/deployment/workflows/ml_deployment_notebook.ipynb
@@ -57,8 +57,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Package upgrade skipped - using environment default\n",
-    "print('Using default sagemaker_studio package from environment')\n"
+    "# The notebook execution container (2.8.7-cpu) is managed by the platform and cannot be\n",
+    "# upgraded by us. Its bundled sagemaker SDK is too old to know about sklearn 1.4-2,\n",
+    "# so we upgrade it explicitly at runtime.\n",
+    "import subprocess, sys\n",
+    "result = subprocess.run(\n",
+    "    [sys.executable, \"-m\", \"pip\", \"install\", \"sagemaker>=2.200\", \"-q\"],\n",
+    "    capture_output=True, text=True\n",
+    ")\n",
+    "print(result.stdout or \"sagemaker>=2.200 installed successfully\")\n",
+    "if result.returncode != 0:\n",
+    "    print(result.stderr)\n"
    ]
   },
   {

--- a/examples/analytic-workflow/ml/training/workflows/ml_training_notebook.ipynb
+++ b/examples/analytic-workflow/ml/training/workflows/ml_training_notebook.ipynb
@@ -76,8 +76,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Package upgrade skipped - using environment default\n",
-    "print('Using default sagemaker_studio package from environment')\n"
+    "# The notebook execution container (2.8.7-cpu) is managed by the platform and cannot be\n",
+    "# upgraded by us. Its bundled sagemaker SDK is too old to know about sklearn 1.4-2,\n",
+    "# so we upgrade it explicitly at runtime.\n",
+    "import subprocess, sys\n",
+    "result = subprocess.run(\n",
+    "    [sys.executable, \"-m\", \"pip\", \"install\", \"sagemaker>=2.200\", \"-q\"],\n",
+    "    capture_output=True, text=True\n",
+    ")\n",
+    "print(result.stdout or \"sagemaker>=2.200 installed successfully\")\n",
+    "if result.returncode != 0:\n",
+    "    print(result.stderr)\n"
    ]
   },
   {


### PR DESCRIPTION
The notebook execution container (2.8.7-cpu) is platform-managed and cannot be upgraded by us. Its bundled sagemaker SDK only knows about sklearn versions up to 1.2-1, causing image_uris.retrieve() to fail with sklearn_version=1.4-2. Explicitly upgrade sagemaker>=2.200 at notebook startup to resolve this.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
