### PR TITLE
fix: add sys.modules cache flush and pin sagemaker<3.0

### DIFF
--- a/examples/analytic-workflow/ml/deployment/workflows/ml_deployment_notebook.ipynb
+++ b/examples/analytic-workflow/ml/deployment/workflows/ml_deployment_notebook.ipynb
@@ -59,15 +59,22 @@
    "source": [
     "# The notebook execution container (2.8.7-cpu) is managed by the platform and cannot be\n",
     "# upgraded by us. Its bundled sagemaker SDK is too old to know about sklearn 1.4-2,\n",
-    "# so we upgrade it explicitly at runtime.\n",
+    "# so we upgrade it explicitly at runtime and flush the module cache so the new version\n",
+    "# is actually used (pip install alone does not affect already-loaded modules).\n",
     "import subprocess, sys\n",
     "result = subprocess.run(\n",
-    "    [sys.executable, \"-m\", \"pip\", \"install\", \"sagemaker>=2.200\", \"-q\"],\n",
+    "    [sys.executable, \"-m\", \"pip\", \"install\", \"sagemaker>=2.200,<3.0\", \"-q\"],\n",
     "    capture_output=True, text=True\n",
     ")\n",
     "print(result.stdout or \"sagemaker>=2.200 installed successfully\")\n",
     "if result.returncode != 0:\n",
-    "    print(result.stderr)\n"
+    "    print(result.stderr)\n",
+    "\n",
+    "# Flush cached sagemaker modules so the upgraded version is loaded on next import\n",
+    "mods_to_remove = [m for m in sys.modules if m == \"sagemaker\" or m.startswith(\"sagemaker.\")]\n",
+    "for m in mods_to_remove:\n",
+    "    del sys.modules[m]\n",
+    "print(f\"Cleared {len(mods_to_remove)} cached sagemaker module(s)\")\n"
    ]
   },
   {

--- a/examples/analytic-workflow/ml/training/workflows/ml_training_notebook.ipynb
+++ b/examples/analytic-workflow/ml/training/workflows/ml_training_notebook.ipynb
@@ -78,15 +78,22 @@
    "source": [
     "# The notebook execution container (2.8.7-cpu) is managed by the platform and cannot be\n",
     "# upgraded by us. Its bundled sagemaker SDK is too old to know about sklearn 1.4-2,\n",
-    "# so we upgrade it explicitly at runtime.\n",
+    "# so we upgrade it explicitly at runtime and flush the module cache so the new version\n",
+    "# is actually used (pip install alone does not affect already-loaded modules).\n",
     "import subprocess, sys\n",
     "result = subprocess.run(\n",
-    "    [sys.executable, \"-m\", \"pip\", \"install\", \"sagemaker>=2.200\", \"-q\"],\n",
+    "    [sys.executable, \"-m\", \"pip\", \"install\", \"sagemaker>=2.200,<3.0\", \"-q\"],\n",
     "    capture_output=True, text=True\n",
     ")\n",
     "print(result.stdout or \"sagemaker>=2.200 installed successfully\")\n",
     "if result.returncode != 0:\n",
-    "    print(result.stderr)\n"
+    "    print(result.stderr)\n",
+    "\n",
+    "# Flush cached sagemaker modules so the upgraded version is loaded on next import\n",
+    "mods_to_remove = [m for m in sys.modules if m == \"sagemaker\" or m.startswith(\"sagemaker.\")]\n",
+    "for m in mods_to_remove:\n",
+    "    del sys.modules[m]\n",
+    "print(f\"Cleared {len(mods_to_remove)} cached sagemaker module(s)\")\n"
    ]
   },
   {


### PR DESCRIPTION
The previous fix (pip install sagemaker>=2.200) had no effect because the kernel pre-loads sagemaker at startup, so re-importing it just returns the cached old version from sys.modules.

Fix: flush all sagemaker.* entries from sys.modules after the upgrade so the next import re-reads the upgraded version from disk.

Also pin sagemaker<3.0 since sagemaker 3.x removed sagemaker.image_uris which is used internally by SKLearn.__init__ and would cause a different failure if 3.x were installed.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
