### PR TITLE
docs: Remove create:true from customer-facing examples and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,7 +668,6 @@ stages:
       region: us-east-1
     project:
       name: test-ml-training
-      create: true
       owners:
         - Eng1
         - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests
@@ -794,7 +793,6 @@ stages:
       region: us-east-1
     project:
       name: test-ml-deployment
-      create: true
       owners:
         - Eng1
         - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -45,12 +45,7 @@ stages:
       region: us-east-1
     project:
       name: test-project
-      create: true
     bootstrap:
-      project:
-        create: true
-        profileName: 'All capabilities'
-        owners: [admin@example.com]
       environments:
         - EnvironmentConfigurationName: 'OnDemand Workflows'
       
@@ -402,14 +397,8 @@ stages:
       region: us-east-1
     project:
       name: test-data-platform
-      create: true
     
     bootstrap:
-      project:
-        create: true
-        profileName: 'All capabilities'
-        owners: [admin@example.com]
-      
       environments:
         - EnvironmentConfigurationName: 'OnDemand Workflows'
       

--- a/docs/examples-guide.md
+++ b/docs/examples-guide.md
@@ -124,7 +124,6 @@ stages:
       region: us-east-1
     project:
       name: test-ml-training
-      create: true
       owners:
         - Eng1
         - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests
@@ -163,7 +162,6 @@ tests:
 - **Custom Role**: Uses project-specific IAM role for SageMaker training permissions
 - **MLflow Integration**: Tracks experiments, parameters, and metrics automatically
 - **SageMaker Distribution**: Uses pre-built images with common ML libraries
-- **Project Creation**: `create: true` automatically creates project if it doesn't exist
 
 **Use this example when:**
 - Training ML models with SageMaker
@@ -217,7 +215,6 @@ stages:
       region: us-east-1
     project:
       name: test-ml-deployment
-      create: true
       owners:
         - Eng1
         - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests
@@ -421,7 +418,6 @@ stages:
       region: us-east-1
     project:
       name: test-marketing
-      create: true
       owners:
         - Eng1
         - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests

--- a/docs/getting-started/admin-quickstart.md
+++ b/docs/getting-started/admin-quickstart.md
@@ -69,122 +69,16 @@ stages:
       region: us-east-1        # AWS region
     project:
       name: test-project       # SMUS project name
-      create: true             # Let CLI create project
-    bootstrap:            # Project creation settings
-      project:
-        create: true
-        profileName: 'All capabilities'
-        owners: [admin@example.com]
-      environments:
-        - EnvironmentConfigurationName: 'OnDemand Workflows'
 ```
 
 **Key points:**
-- `create: false` - Project already exists, CLI will deploy to it
-- `create: true` - CLI will create project on first deployment
-- `initialization` - Only used when `create: true`
-
-### Project Isolation Models
-
-The `create` flag enables two organizational models:
-
-**Shared Projects (create: false)** - Multiple applications deploy to the same test/prod projects:
-```yaml
-# Application 1: monthly-metrics/manifest.yaml
-stages:
-  test:
-    project:
-      name: shared-data-platform-test
-      create: false  # Use existing shared project
-  prod:
-    project:
-      name: shared-data-platform-prod
-      create: false
-
-# Application 2: churn-model/manifest.yaml
-stages:
-  test:
-    project:
-      name: shared-data-platform-test
-      create: false  # Same shared project
-  prod:
-    project:
-      name: shared-data-platform-prod
-      create: false
-```
-
-**Isolated Projects (create: true)** - Each application gets its own dedicated projects:
-```yaml
-# Application 1: monthly-metrics/manifest.yaml
-stages:
-  test:
-    project:
-      name: monthly-metrics-test
-      create: true  # Create dedicated project
-    bootstrap:
-      project:
-        create: true
-        profileName: 'Analytics'
-        owners: [metrics-team@example.com]
-  prod:
-    project:
-      name: monthly-metrics-prod
-      create: true
-
-# Application 2: churn-model/manifest.yaml
-stages:
-  test:
-    project:
-      name: churn-model-test
-      create: true  # Create separate dedicated project
-    bootstrap:
-      project:
-        create: true
-        profileName: 'ML and AI'
-        owners: [ml-team@example.com]
-  prod:
-    project:
-      name: churn-model-prod
-      create: true
-```
-
-**When to use each model:**
-- **Shared projects** - Teams collaborating, shared resources, centralized governance
-- **Isolated projects** - Team autonomy, different profiles/permissions, cost isolation
+- The project must already exist in the SMUS domain before deploying
+- Use the same project name across multiple applications to share resources
+- Different applications can deploy to the same project
 
 ---
 
-## Step 3: Configure Project Initialization
-
-When `create: true`, the CLI automatically creates projects with these settings:
-
-### Basic Project Creation
-
-```yaml
-bootstrap:
-  project:
-    create: true
-    profileName: 'All capabilities'    # Project profile
-    owners:                             # Project owners
-      - admin@example.com
-      - arn:aws:iam::123456789:role/GitHubActionsRole
-```
-
-### With Environment Configuration
-
-```yaml
-bootstrap:
-  project:
-    create: true
-    profileName: 'All capabilities'
-    owners: [admin@example.com]
-  environments:
-    - EnvironmentConfigurationName: 'OnDemand Workflows'  # Enables MWAA
-```
-
----
-
-## Step 4: Set Up Multi-Stage Configuration
+## Step 3: Set Up Multi-Stage Configuration
 
 Create a reference `manifest.yaml` for your organization:
 
@@ -208,14 +102,6 @@ stages:
       region: us-east-1
     project:
       name: test-data-platform
-      create: true
-    bootstrap:
-      project:
-        create: true
-        profileName: 'All capabilities'
-        owners: [arn:aws:iam::123456789:role/GitHubActionsRole]
-      environments:
-        - EnvironmentConfigurationName: 'OnDemand Workflows'
     
   prod:
     domain:
@@ -223,23 +109,15 @@ stages:
       region: us-east-1
     project:
       name: prod-data-platform
-      create: true
-    bootstrap:
-      project:
-        create: true
-        profileName: 'All capabilities'
-        owners: [arn:aws:iam::123456789:role/GitHubActionsRole]
-      environments:
-        - EnvironmentConfigurationName: 'OnDemand Workflows'
 ```
 
 **Note:** Dev project is typically created manually in the console by data teams.
 
 ---
 
-## Step 5: Configure Project Connections
+## Step 4: Configure Project Connections
 
-Connections define integrations with AWS services and data sources. They can be created automatically during project initialization or manually via the console.
+Connections define integrations with AWS services and data sources. They can be created automatically during deployment or manually via the console.
 
 ### Default Connections
 
@@ -261,16 +139,10 @@ stages:
       region: us-east-1
     project:
       name: test-data-platform
-      create: true
     bootstrap:
-      project:
-        create: true
-        profileName: 'All capabilities'
-        owners: [admin@example.com]
       environments:
         - EnvironmentConfigurationName: 'OnDemand Workflows'
       
-      # Connections created automatically during initialization
       connections:
         - name: s3-raw-data
           type: S3
@@ -401,7 +273,7 @@ tasks:
 
 ---
 
-## Step 6: Understand CLI Usage Across Stages
+## Step 5: Understand CLI Usage Across Stages
 
 The CLI is used differently depending on your deployment approach:
 
@@ -457,114 +329,7 @@ smus-cli monitor --stages test --manifest manifest.yaml
 
 ---
 
-## Step 7: Choose Your Project Organization Model
-
-Organizations can choose between shared or isolated project models using the `create` flag.
-
-### Shared Projects Model (create: false)
-
-Multiple applications deploy to the same test/prod projects. Best for teams that collaborate and share resources.
-
-```
-my-organization/
-├── monthly-metrics/           # Data application 1
-│   ├── manifest.yaml          # Points to shared-data-platform-test/prod
-│   ├── workflows/
-│   │   ├── metrics_etl.yaml
-│   │   └── metrics_report.yaml
-│   └── notebooks/
-│       └── metrics_analysis.ipynb
-│
-├── churn-model/               # Data application 2
-│   ├── manifest.yaml          # Points to shared-data-platform-test/prod
-│   ├── workflows/
-│   │   ├── feature_engineering.yaml
-│   │   └── model_training.yaml
-│   └── notebooks/
-│       └── train_model.ipynb
-│
-└── README.md
-```
-
-**Deployment:**
-```bash
-# Both applications deploy to the same shared projects
-cd monthly-metrics
-smus-cli deploy --targets test --manifest manifest.yaml  # → shared-data-platform-test
-
-cd ../churn-model
-smus-cli deploy --targets test --manifest manifest.yaml  # → shared-data-platform-test
-```
-
-All workflows from both applications appear in the same MWAA environment.
-
-**Benefits:**
-- Shared resources and connections
-- Centralized governance
-- Lower infrastructure costs
-- Easier cross-application workflows
-
-### Isolated Projects Model (create: true)
-
-Each application gets its own dedicated projects. Best for team autonomy and cost isolation.
-
-```
-my-organization/
-├── monthly-metrics/           # Data application 1
-│   ├── manifest.yaml          # Creates monthly-metrics-test/prod
-│   └── workflows/
-│
-├── churn-model/               # Data application 2
-│   ├── manifest.yaml          # Creates churn-model-test/prod
-│   └── workflows/
-│
-└── README.md
-```
-
-**Deployment:**
-```bash
-# Each application creates and deploys to its own projects
-cd monthly-metrics
-smus-cli deploy --stages test --manifest manifest.yaml  # → monthly-metrics-test (created)
-
-cd ../churn-model
-smus-cli deploy --stages test --manifest manifest.yaml  # → churn-model-test (created)
-```
-
-Each application has its own isolated MWAA environment and resources.
-
-**Benefits:**
-- Team autonomy and ownership
-- Different profiles/permissions per application
-- Cost tracking per application
-- No naming conflicts between applications
-
-### Hybrid Model
-
-You can also mix both approaches - shared test, isolated prod:
-
-```yaml
-# manifest.yaml
-stages:
-  test:
-    project:
-      name: shared-test-platform
-      create: false  # Shared test environment
-  
-  prod:
-    project:
-      name: my-app-prod
-      create: true   # Isolated production
-    bootstrap:
-      project:
-        create: true
-        profileName: 'All capabilities'
-        owners: [my-team@example.com]
-```
-
----
-
-## Step 8: Set Up CI/CD Authentication (Optional)
+## Step 6: Set Up CI/CD Authentication (Optional)
 
 If you want to automate deployments via CI/CD, configure authentication between your CI/CD platform and AWS.
 
@@ -609,7 +374,7 @@ aws cloudformation describe-stacks \
 
 ---
 
-## Step 9: Set Up CI/CD Workflows (Optional)
+## Step 7: Set Up CI/CD Workflows (Optional)
 
 Automate deployments using your CI/CD platform. The SMUS CLI commands are the same across all platforms.
 
@@ -732,7 +497,7 @@ jobs:
 
 ---
 
-## Step 10: Validate Deployment with Monitoring
+## Step 8: Validate Deployment with Monitoring
 
 After deployment, use these commands to verify everything works:
 
@@ -789,7 +554,7 @@ All tests passed
 
 ---
 
-## Step 11: Set Up Monitoring and Metrics Integration
+## Step 9: Set Up Monitoring and Metrics Integration
 
 ### CloudWatch Integration
 
@@ -859,7 +624,7 @@ aws cloudwatch put-metric-alarm \
 
 ---
 
-## Step 12: Document for Data Teams
+## Step 10: Document for Data Teams
 
 Create team documentation explaining the setup:
 
@@ -911,7 +676,7 @@ Multiple data applications can deploy to the same project.
 
 1. **Projects are deployment stages** - One SMUS project can host multiple data applications
 2. **Three deployment approaches** - Direct git-based, bundle-based, or hybrid
-3. **Initialization is automatic** - CLI creates projects with proper settings on first deployment
+3. **Projects must exist before deploying** - Create projects manually in the SMUS console before first deployment
 4. **Monitoring is essential** - Use `monitor`, `logs`, and `test` commands to validate deployments
 5. **CI/CD automates flow** - GitHub Actions handles test → prod progression
 

--- a/docs/manifest-schema.md
+++ b/docs/manifest-schema.md
@@ -73,11 +73,6 @@ stages:
         purpose: development
     project:
       name: dev-project        # Required: Project name
-      create: true             # Optional: Auto-create project (default: false)
-      owners:                  # Optional: Project owners (required if create: true)
-        - Eng1
-        - arn:aws:iam::*:role/MyRole
-      contributors: []         # Optional: Project contributors
       role:
         # Option 1: Use existing role
         arn: arn:aws:iam::123456789012:role/MyProjectRole
@@ -221,8 +216,6 @@ stages:
       region: us-east-1
     project:
       name: test-analytics
-      create: true
-      owners: [Eng1]
     environment_variables:
       DATABASE: test_db
   

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -189,17 +189,8 @@ stages:
       region: ${AWS_REGION:us-east-1}
     project:
       name: test-marketing
-      create: true
-      profileName: 'All capabilities'
-      owners: ['alice@company.com']
-      contributors: ['bob@company.com']
       role:
         arn: arn:aws:iam::123456789012:role/MyProjectRole
-      user_parameters:
-        - environment_configuration_name: 'Lakehouse Database'
-          parameters:
-            - name: glueDbName
-              value: test_marketing_db
     
     # Bootstrap actions for project setup
     bootstrap:
@@ -260,10 +251,6 @@ stages:
       region: ${AWS_REGION:us-east-1}
     project:
       name: prod-marketing
-      create: true
-      profileName: 'All capabilities'
-      owners: ['alice@company.com']
-      contributors: []
     
     bootstrap:
       actions:
@@ -437,9 +424,9 @@ stages:
 - `domain.region` (required): AWS region where domain exists
 - `project.name` (required): Project name in the domain
 
-### Target Initialization
+### Bootstrap Actions
 
-Auto-create projects, environments, and connections:
+Configure environments, connections, and post-deployment workflows:
 
 ```yaml
 stages:
@@ -450,15 +437,6 @@ stages:
       region: us-east-1
     project:
       name: test-marketing
-      create: true
-      profileName: 'All capabilities'
-      owners: ['alice@company.com']
-      contributors: ['bob@company.com', 'charlie@company.com']
-      user_parameters:
-        - environment_configuration_name: 'Lakehouse Database'
-          parameters:
-            - name: glueDbName
-              value: my_unique_db_name
     
     bootstrap:
       actions:
@@ -480,12 +458,6 @@ stages:
 ```
 
 **Project Properties:**
-- `create` (optional): Auto-create project (default: `false`)
-- `profileName` (required if create=true): Project profile name
-- `owners` (optional): List of owner email addresses or IAM ARNs
-  - Use `*` as wildcard for account ID: `arn:aws:iam::*:role/MyRole` (replaced with current account)
-- `contributors` (optional): List of contributor email addresses or IAM ARNs
-  - Use `*` as wildcard for account ID: `arn:aws:iam::*:role/MyRole` (replaced with current account)
 - `role` (optional): Customer-provided IAM role for the project
   - `arn`: IAM role ARN (e.g., `arn:aws:iam::123456789012:role/MyProjectRole`)
   - Use `*` as wildcard for account ID: `arn:aws:iam::*:role/MyProjectRole` (replaced with current account)

--- a/docs/q-cli-conversation-examples.md
+++ b/docs/q-cli-conversation-examples.md
@@ -55,9 +55,6 @@ stages:
       region: ${AWS_REGION}
     project:
       name: test-project
-    bootstrap:
-      project:
-        create: true
 
   prod:
     stage: PROD

--- a/examples/DemoMarketingBundle.yaml
+++ b/examples/DemoMarketingBundle.yaml
@@ -61,7 +61,6 @@ stages:
     stage: TEST
     project:
       name: dev-marketing-test
-      create: true
 
     deployment_configuration:
       storage:
@@ -78,7 +77,6 @@ stages:
     stage: PROD
     project:
       name: prod-marketing
-      create: true
 
     deployment_configuration:
       storage:

--- a/examples/TestBundle.yaml
+++ b/examples/TestBundle.yaml
@@ -46,7 +46,6 @@ stages:
       region: ${DEV_DOMAIN_REGION:us-east-1}
     project:
       name: dev-marketing-test
-      create: true
 
     deployment_configuration:
       storage:
@@ -64,7 +63,6 @@ stages:
       region: ${DEV_DOMAIN_REGION:us-east-1}
     project:
       name: dev-marketing-prod
-      create: true
 
     deployment_configuration:
       storage:

--- a/examples/analytic-workflow/genai/manifest.yaml
+++ b/examples/analytic-workflow/genai/manifest.yaml
@@ -29,13 +29,12 @@ stages:
       region: ${TEST_DOMAIN_REGION:us-east-1}
     project:
       name: test-marketing
-      create: true
-      role:
-        arn: arn:aws:iam::372123585851:role/test-marketing-role
       owners:
       - Eng1
       - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests
       - arn:aws:iam::${AWS_ACCOUNT_ID}:role/Admin
+      role:
+        arn: arn:aws:iam::${AWS_ACCOUNT_ID}:role/test-marketing-role
     environment_variables:
       S3_PREFIX: test
     deployment_configuration:

--- a/examples/analytic-workflow/ml/deployment/manifest.yaml
+++ b/examples/analytic-workflow/ml/deployment/manifest.yaml
@@ -35,12 +35,10 @@ stages:
       region: ${TEST_DOMAIN_REGION:us-east-1}
     project:
       name: test-marketing
-      create: true
       owners:
       - Eng1
       - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests
       - arn:aws:iam::${AWS_ACCOUNT_ID}:role/Admin
-      contributors: []
       role:
         arn: arn:aws:iam::${AWS_ACCOUNT_ID}:role/test-marketing-role
     environment_variables:
@@ -71,14 +69,6 @@ stages:
       region: ${PROD_DOMAIN_REGION:us-east-1}
     project:
       name: prod-marketing
-      create: true
-      owners:
-      - Eng1
-      - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests
-      - arn:aws:iam::${AWS_ACCOUNT_ID}:role/Admin
-      contributors: []
-      role:
-        arn: arn:aws:iam::${AWS_ACCOUNT_ID}:role/prod-marketing-role
     environment_variables:
       S3_PREFIX: prod
     deployment_configuration:

--- a/examples/analytic-workflow/ml/training/manifest.yaml
+++ b/examples/analytic-workflow/ml/training/manifest.yaml
@@ -30,19 +30,12 @@ stages:
       region: ${TEST_DOMAIN_REGION:us-east-1}
     project:
       name: test-marketing
-      create: true
       owners:
       - Eng1
       - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests
       - arn:aws:iam::${AWS_ACCOUNT_ID}:role/Admin
-      contributors: []
       role:
         arn: arn:aws:iam::${AWS_ACCOUNT_ID}:role/test-marketing-role
-      userParameters:
-      - EnvironmentConfigurationName: Lakehouse Database
-        parameters:
-        - name: glueDbName
-          value: analytic_workflow_test_db
     environment_variables:
       S3_PREFIX: test
     deployment_configuration:

--- a/examples/demo-manifest.yaml
+++ b/examples/demo-manifest.yaml
@@ -14,19 +14,9 @@ stages:
       region: ${DEV_DOMAIN_REGION:us-east-1}
     project:
       name: test-project-name
-      create: true
-      profileName: All capabilities
-      owners:
-      - arn:aws:iam::123456789012:role/GitHubActionsRole-SMUS-CLI-Tests
-      contributors: []
   prod:
     stage: PROD
     domain:
       region: ${DEV_DOMAIN_REGION:us-east-1}
     project:
       name: prod-project-name
-      create: true
-      profileName: All capabilities
-      owners:
-      - arn:aws:iam::123456789012:role/GitHubActionsRole-SMUS-CLI-Tests
-      contributors: []

--- a/examples/mwaa-example/DemoMarketingPipeline-MWAA.yaml
+++ b/examples/mwaa-example/DemoMarketingPipeline-MWAA.yaml
@@ -58,17 +58,6 @@ stages:
     stage: TEST
     project:
       name: dev-marketing-test
-      create: true
-    initialization:
-      project:
-        create: true
-        profileName: All capabilities
-        owners:
-        - arn:aws:iam::123456789012:role/GitHubActionsRole-SMUS-CLI-Tests
-        - Eng1
-        contributors: []
-      environments:
-      - EnvironmentConfigurationName: OnDemand Workflows
     deployment_configuration:
       storage:
       - connectionName: default.s3_shared
@@ -84,17 +73,6 @@ stages:
     stage: PROD
     project:
       name: prod-marketing
-      create: true
-    initialization:
-      project:
-        create: true
-        profileName: All capabilities
-        owners:
-        - arn:aws:iam::123456789012:role/GitHubActionsRole-SMUS-CLI-Tests
-        - Eng1
-        contributors: []
-      environments:
-      - EnvironmentConfigurationName: OnDemand Workflows
     deployment_configuration:
       catalog:
         disable: true

--- a/examples/serverless-example/DemoMarketingPipeline-Serverless.yaml
+++ b/examples/serverless-example/DemoMarketingPipeline-Serverless.yaml
@@ -48,20 +48,6 @@ stages:
       region: ${DEV_DOMAIN_REGION:us-east-1}
     project:
       name: test-marketing-demo
-    initialization:
-      project:
-        create: true
-        profileName: All capabilities
-        owners:
-        - arn:aws:iam::123456789012:role/GitHubActionsRole-SMUS-CLI-Tests
-        - Eng1
-        contributors: []
-        userParameters:
-        - EnvironmentConfigurationName: Lakehouse Database
-          parameters:
-          - name: glueDbName
-            value: demo-serverless-db
-      environments: []
     environment_variables:
       ENV_NAME: test
       S3_PREFIX: test-data
@@ -81,20 +67,6 @@ stages:
       region: ${PROD_DOMAIN_REGION:us-east-1}
     project:
       name: prod-marketing-demo
-    initialization:
-      project:
-        create: true
-        profileName: All capabilities
-        owners:
-        - arn:aws:iam::123456789012:role/GitHubActionsRole-SMUS-CLI-Tests
-        - Eng1
-        contributors: []
-        userParameters:
-        - EnvironmentConfigurationName: Lakehouse Database
-          parameters:
-          - name: glueDbName
-            value: demo-serverless-prod-db
-      environments: []
     environment_variables:
       ENV_NAME: prod
       S3_PREFIX: prod-data


### PR DESCRIPTION
## Summary

Removes `create: true` flag and `bootstrap.project` (project creation-only fields) from all customer-facing example manifests and documentation.

## Changes

- Remove `create: true`, `bootstrap.project`, `profileName`, `owners`, `contributors`, and `userParameters` from examples and docs — these fields are only meaningful when auto-creating projects and have no effect on existing projects
- Keep `bootstrap.environments` and `bootstrap.connections` since these work on both new and existing projects
- Keep `owners` and `role` fields where they are used independently of project creation
- Update `admin-quickstart.md` messaging to clarify projects must exist before deploying
- Renumber steps in `admin-quickstart.md` after removing the project creation section
- Fix hardcoded role ARN in `examples/analytic-workflow/genai/manifest.yaml` (replaced with `${AWS_ACCOUNT_ID}`)

## Files changed

- `README.md`
- `docs/connections.md`
- `docs/examples-guide.md`
- `docs/getting-started/admin-quickstart.md`
- `docs/manifest-schema.md`
- `docs/manifest.md`
- `docs/q-cli-conversation-examples.md`
- `examples/DemoMarketingBundle.yaml`
- `examples/TestBundle.yaml`
- `examples/analytic-workflow/genai/manifest.yaml`
- `examples/analytic-workflow/ml/deployment/manifest.yaml`
- `examples/analytic-workflow/ml/training/manifest.yaml`
- `examples/demo-manifest.yaml`
- `examples/mwaa-example/DemoMarketingPipeline-MWAA.yaml`
- `examples/serverless-example/DemoMarketingPipeline-Serverless.yaml`

## Notes

- Test manifests under `tests/` are intentionally unchanged — they use `create: true` for integration test setup
- `docs/langs/` translations are auto-generated by the `translate-docs` workflow and will update automatically after merge
- The `translate-docs` workflow has a pre-existing flakiness issue (Bedrock timeout on Hebrew translation) unrelated to these changes