### PR TITLE
Update publish-pypi.yml to follow PyPA GitHub Actions guide

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,3 +1,6 @@
+# Based on the official PyPA guide for publishing package distribution releases using GitHub Actions:
+# https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+
 name: Publish to PyPI
 
 on:
@@ -5,29 +8,46 @@ on:
     types: [published]
 
 jobs:
-  publish:
+  build:
+    name: Build distribution 📦
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write  # Required for trusted publishing
-    
     steps:
     - uses: actions/checkout@v4
-    
-    - name: Set up Python
-      uses: actions/setup-python@v4
       with:
-        python-version: '3.12'
-    
+        persist-credentials: false
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
     - name: Install build dependencies
       run: |
         python -m pip install --upgrade pip
         pip install build
-    
     - name: Build package
       run: |
         python -m build
-    
-    - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
       with:
-        packages-dir: dist/
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/cicd-for-smus
+    permissions:
+      id-token: write
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -7,6 +7,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build distribution 📦


### PR DESCRIPTION
## Summary

Updates the `publish-pypi.yml` GitHub Actions workflow to align with the official PyPA guide:
https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/

## Changes

- Workflow now triggers on GitHub release `published` events
- Uses OIDC Trusted Publishing (no API token required) via `pypa/gh-action-pypi-publish@release/v1`
- Build and publish are split into separate jobs for clarity and security
- `id-token: write` permission is scoped only to the publish job
- Uses `actions/checkout@v4`, `actions/setup-python@v5`, `actions/upload-artifact@v4`, and `actions/download-artifact@v4`
- Added comment at the top of the file referencing the guide