### PR TITLE
Rename PyPI package to smus-cli

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/cicd-for-smus
+      url: https://pypi.org/p/smus-cli
     permissions:
       id-token: write
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "smus-cicd-cli"
+name = "smus-cli"
 version = "1.0.0"
 authors = [
     {name = "AWS SageMaker Unified Studio Team", email = "sagemaker-unified-studio@amazon.com"},

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = smus-cicd-pipeline-cli
+name = smus-cli
 version = 1.0
 description = SMUS CI/CD Pipeline CLI
 long_description = file: README.md

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ dev_requires = [
 ]
 
 setup(
-    name="smus-cicd-cli",
+    name="smus-cli",
     version="1.0.0",
     author="AWS SageMaker Unified Studio Team",
     author_email="sagemaker-unified-studio@amazon.com",


### PR DESCRIPTION
## Summary

Renames the PyPI package from `smus-cicd-cli` / `smus-cicd-pipeline-cli` to `smus-cli` for consistency.

## Changes

- `pyproject.toml`: updated project name to `smus-cli`
- `setup.py`: updated name to `smus-cli`
- `setup.cfg`: updated name to `smus-cli`
- `publish-pypi.yml`: updated PyPI project URL to `https://pypi.org/p/smus-cli`

Note: PyPI Trusted Publisher config will also need to be updated to use `smus-cli` as the project name.
