### PR TITLE
fix: bug bash fixes — domain resolution, bundle copytree, env var defaults, docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "mlflow"
-        reason: "mlflow>=3.x requires Python >=3.10; training container uses Python 3.9"
 
   - package-ecosystem: "pip"
     directory: "/examples/analytic-workflow/data-notebooks/notebooks"
@@ -14,10 +13,6 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "mlflow"
-        reason: "mlflow>=3.x requires Python >=3.10; training container uses Python 3.9"
       - dependency-name: "mlflow-skinny"
-        reason: "mlflow>=3.x requires Python >=3.10; training container uses Python 3.9"
       - dependency-name: "mlflow-tracing"
-        reason: "mlflow>=3.x requires Python >=3.10; training container uses Python 3.9"
       - dependency-name: "sagemaker-mlflow"
-        reason: "pinned alongside mlflow for compatibility"

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ stages:
     domain:
       tags:
         purpose: smus-cicd-testing
-      region: ${TEST_DOMAIN_REGION:us-east-1}
+      region: ${TEST_DOMAIN_REGION}
     project:
       name: test-marketing
       owners:
@@ -422,7 +422,7 @@ stages:
       - arn:aws:iam::${AWS_ACCOUNT_ID}:role/Admin
     environment_variables:
       S3_PREFIX: test
-      AWS_REGION: ${TEST_DOMAIN_REGION:us-east-1}
+      AWS_REGION: ${TEST_DOMAIN_REGION}
       GRANT_TO: Admin,service-role/aws-quicksight-service-role-v0
     bootstrap:
       actions:
@@ -451,9 +451,9 @@ stages:
         assets:
         - name: TotalDeathByCountry
           owners:
-          - arn:aws:quicksight:${TEST_DOMAIN_REGION:us-east-1}:${AWS_ACCOUNT_ID}:user/default/Admin/*
+          - arn:aws:quicksight:${TEST_DOMAIN_REGION}:${AWS_ACCOUNT_ID}:user/default/Admin/*
           viewers:
-          - arn:aws:quicksight:${TEST_DOMAIN_REGION:us-east-1}:${AWS_ACCOUNT_ID}:user/default/Admin/*
+          - arn:aws:quicksight:${TEST_DOMAIN_REGION}:${AWS_ACCOUNT_ID}:user/default/Admin/*
         overrideParameters:
           ResourceIdOverrideConfiguration:
             PrefixForAllResources: deployed-{stage.name}-covid-
@@ -538,7 +538,7 @@ stages:
           name: mlflow-server
           connection_type: MLFLOW
           properties:
-            trackingServerArn: arn:aws:sagemaker:${STS_REGION}:${STS_ACCOUNT_ID}:mlflow-tracking-server/smus-integration-mlflow-use2
+            trackingServerArn: arn:aws:sagemaker:${TEST_DOMAIN_REGION}:${AWS_ACCOUNT_ID}:mlflow-tracking-server/smus-integration-mlflow-use2
             trackingServerName: smus-integration-mlflow-use2
         - type: workflow.create
           workflowName: parallel_notebooks_execution
@@ -690,7 +690,7 @@ stages:
           name: mlflow-server
           connection_type: MLFLOW
           properties:
-            trackingServerArn: arn:aws:sagemaker:${STS_REGION}:${STS_ACCOUNT_ID}:mlflow-tracking-server/smus-integration-mlflow-use2
+            trackingServerArn: arn:aws:sagemaker:${TEST_DOMAIN_REGION}:${AWS_ACCOUNT_ID}:mlflow-tracking-server/smus-integration-mlflow-use2
         - type: workflow.create
           workflowName: ml_training_workflow
         - type: workflow.run

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -964,7 +964,7 @@ All commands support:
 
 ## Configuration Files
 
-### Bundle Manifest
+### Manifest
 - Default location: `manifest.yaml` (current directory)
 - Override with `--manifest` option
 - See [Manifest Reference](manifest.md) for format

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -967,7 +967,7 @@ All commands support:
 ### Bundle Manifest
 - Default location: `manifest.yaml` (current directory)
 - Override with `--manifest` option
-- See [Bundle Manifest Reference](bundle-manifest.md) for format
+- See [Manifest Reference](manifest.md) for format
 - **Error handling**: CLI will error if the default file doesn't exist and no alternative is specified
 
 ### AWS Configuration

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -625,11 +625,11 @@ aws-smus-cicd-cli run --stages test --workflow test_connections
 
 ## Next Steps
 
-- **[Bundle Manifest Reference](bundle-manifest.md)** - Complete connection schema
+- **[Manifest Reference](manifest.md)** - Complete connection schema
 - **[Substitutions and Variables](substitutions-and-variables.md)** - Variable usage guide
 - **[Admin Quick Start](getting-started/admin-quickstart.md)** - Infrastructure setup
 - **[CLI Commands](cli-commands.md)** - Connection management commands
 
 ---
 
-**Questions?** See [Bundle Manifest Reference - Connections](bundle-manifest.md#connections) for complete schema details.
+**Questions?** See [Manifest Reference - Connections](manifest.md#connections) for complete schema details.

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -59,13 +59,13 @@ You're responsible for configuring CI/CD pipelines (GitHub Actions), managing Sa
 → [Admin Quick Start](admin-quickstart.md)
 
 **Understand how it works first**  
-→ [Bundle Manifest Reference](../bundle-manifest.md)
+→ [Manifest Reference](../manifest.md)
 
 **See examples**  
 → [Examples](../../examples/)
 
 **Read complete documentation**  
-→ [CLI Commands](../cli-commands.md) | [Bundle Manifest](../bundle-manifest.md)
+→ [CLI Commands](../cli-commands.md) | [Manifest](../manifest.md)
 
 ---
 
@@ -87,8 +87,8 @@ All guides assume you have:
 After completing a quick start guide:
 
 1. **Explore Examples** - See [examples/](../../examples/) for real-world scenarios
-2. **Read Concepts** - Understand [bundle manifests](../bundle-manifest.md)
-3. **Reference Docs** - Check [CLI commands](../cli-commands.md) and [manifest syntax](../bundle-manifest.md)
+2. **Read Concepts** - Understand [manifests](../manifest.md)
+3. **Reference Docs** - Check [CLI commands](../cli-commands.md) and [manifest syntax](../manifest.md)
 4. **Set Up CI/CD** - Configure [GitHub Actions](../github-actions-integration.md)
 
 ---

--- a/docs/getting-started/admin-quickstart.md
+++ b/docs/getting-started/admin-quickstart.md
@@ -247,7 +247,7 @@ stages:
   properties: {}
 ```
 
-**See more:** [Bundle Manifest Reference - Connections](../bundle-manifest.md#connections)
+**See more:** [Manifest Reference - Connections](../manifest.md#connections)
 
 ### Create Connections Manually (Console)
 
@@ -660,7 +660,7 @@ Multiple data applications can deploy to the same project.
 - **[Data Team Quick Start](quickstart.md)** - Guide for building and deploying applications
 
 ### Advanced Configuration
-- **[Bundle Manifest Reference](../bundle-manifest.md)** - Complete YAML specification
+- **[Manifest Reference](../manifest.md)** - Complete YAML specification
 - **[CLI Commands Reference](../cli-commands.md)** - All available commands
 - **[Monitoring and Metrics](../monitoring-and-metrics.md)** - Detailed monitoring setup
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -20,6 +20,8 @@
 
 ## Step 1: Install the CLI
 
+Clone the repo from Github
+
 ```bash
 pip install aws-smus-cicd-cli
 ```
@@ -48,12 +50,22 @@ This example includes:
 
 ---
 
-## Step 3: Customize the Manifest
+## Step 3: Set Up Your SageMaker Unified Studio Domain and Project
+
+Before deploying, you need a SageMaker Unified Studio IAM domain and project. You can create these manually in the AWS console:
+
+1. Open the [SageMaker Unified Studio console](https://console.aws.amazon.com/datazone)
+2. Click **Get started** and follow the setup wizard
+3. Once the domain is active, you can use it and the admin project created by default or create a new project.
+
+---
+
+## Step 4: Customize the Manifest
 
 Edit `manifest.yaml` to match your environment:
 
 ```yaml
-applicationName: MyNotebookApp  # Change this
+applicationName: MyNotebookApp
 
 content:
   storage:
@@ -65,30 +77,31 @@ content:
       connectionName: default.workflow_serverless
 
 stages:
-  dev:
+  test:
+    stage: TEST
     domain:
-      region: us-east-1  # Your AWS region
+      tags:                                     # Change domain identifier
+        purpose: smus-cicd-testing
+      region: ${TEST_DOMAIN_REGION}   # Change domain region
     project:
-      name: my-dev-project  # Your project name
+      name: test-marketing                      # Change project name
 ```
 
 **What to change:**
 - `applicationName`: A logical name for this CI/CD manifest environment — not a SMUS resource. This name can be anything.
-- `domain.region`: Your AWS region
-- Domain identifier — use one of:
+- `domain.region`: Your AWS region, change in the manifest or export that region variable.
+- Domain identifier — use one of (omit entirely if you only have 1 domain in your account):
   - `domain.id`: Your domain ID (visible in the SMUS portal)
   - `domain.name`: Your domain name
   - `domain.tags`: Tag key-value pairs to look up the domain
 - `project.name`: Your SageMaker Unified Studio project name
 
+Note: in order to change domain name or tags, you will need to use `aws datazone` CLI because they are not exposed in SMUS portal. Check [this](../../examples/analytic-workflow/dashboard-glue-quick/README.md#4-deploy-to-test-environment) for help with tagging.
 ---
 
-## Step 4: Deploy
+## Step 5: Deploy
 
-The data-notebooks example has two stages with different purposes:
-
-- `dev` — uploads notebooks and workflow files to S3 only (no workflow setup)
-- `test` — deploys files to the project, creates the Airflow workflow, and runs it
+Make sure you are authenticated in your target deployment account with the role that allows creation of SageMaker notebook and Workflow. For simple testing - use Admin role.
 
 To actually create and run the workflow, deploy to the **test** stage:
 
@@ -392,7 +405,7 @@ aws-smus-cicd-cli deploy --stages test --manifest manifest.yaml
 
 The CLI will automatically request subscriptions to catalog assets for your project.
 
-**See more:** [Bundle Manifest Reference - Catalog Assets](../bundle-manifest.md#catalog-assets)
+**See more:** [Manifest Reference - Catalog Assets](../manifest.md#catalog-assets)
 
 ---
 
@@ -510,7 +523,7 @@ Each data application is self-contained with its own bundle manifest and can be 
 ## Next Steps
 
 ### Learn More
-- **[Bundle Manifest Reference](../bundle-manifest.md)** - Complete YAML guide
+- **[Manifest Reference](../manifest.md)** - Complete YAML guide
 - **[Variable Substitution](../substitutions-and-variables.md)** - Dynamic configuration
 - **[CLI Commands](../cli-commands.md)** - All available commands
 - **[GitHub Actions Integration](../github-actions-integration.md)** - CI/CD automation

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -20,8 +20,6 @@
 
 ## Step 1: Install the CLI
 
-Clone the repo from Github
-
 ```bash
 pip install aws-smus-cicd-cli
 ```

--- a/docs/github-actions-integration.md
+++ b/docs/github-actions-integration.md
@@ -700,5 +700,5 @@ This implementation showcases how the SMUS CI/CD CLI's infrastructure management
 
 For more detailed information about CLI commands and bundle configuration, see:
 - [CLI Commands Documentation](cli-commands.md)
-- [Bundle Manifest Guide](bundle-manifest.md)
+- [Manifest Guide](manifest.md)
 - [Development Guide](development.md)

--- a/docs/substitutions-and-variables.md
+++ b/docs/substitutions-and-variables.md
@@ -1,6 +1,6 @@
 # Substitutions and Variables
 
-← [Back to Main README](../README.md) | [Bundle Manifest Reference](bundle-manifest.md)
+← [Back to Main README](../README.md) | [Manifest Reference](manifest.md)
 
 Dynamic variable substitution for workflow YAMLs that resolves project-specific values at deployment time.
 

--- a/examples/DemoMarketingBundle.yaml
+++ b/examples/DemoMarketingBundle.yaml
@@ -73,7 +73,7 @@ stages:
   prod:
     domain:
       name: cicd-test-domain
-      region: ${PROD_DOMAIN_REGION:us-east-1}
+      region: ${PROD_DOMAIN_REGION}
     stage: PROD
     project:
       name: prod-marketing

--- a/examples/analytic-workflow/dashboard-glue-quick/README.md
+++ b/examples/analytic-workflow/dashboard-glue-quick/README.md
@@ -61,7 +61,34 @@ echo "✓ Granted S3 access to QuickSight service role"
 
 **Note**: The S3 bucket pattern `amazon-sagemaker-*-ACCOUNT_ID-*` matches the buckets created by SageMaker/DataZone for data storage.
 
-### 1. Deploy to Dev Environment
+### 1. Set Environment Variables
+
+```bash
+export DEV_DOMAIN_REGION=<your-dev-region>   # e.g. us-east-2
+export QUICKSIGHT_USER=<your-quicksight-user> # e.g. Admin
+```
+
+### 2. Create the Source Dashboard in Dev
+
+Import the reference QuickSight dashboard bundle into your dev environment:
+
+```bash
+python examples/analytic-workflow/dashboard-glue-quick/quicksight/setup_test_dashboard.py
+```
+
+This creates a clean `TotalDeathByCountry` dashboard in your dev QuickSight account that will be used as the source for bundling.
+
+### 3. Bundle from Dev
+
+Export the dashboard from dev QuickSight and package it for deployment:
+
+```bash
+smus-cli bundle --targets dev --manifest examples/analytic-workflow/dashboard-glue-quick/manifest.yaml
+```
+
+This exports the live dashboard from dev QuickSight and packages it into `./artifacts/IntegrationTestETLWorkflow.zip`.
+
+### 4. Deploy to Dev Environment
 
 Deploy the complete application (Glue jobs, workflows, and QuickSight dashboard) to dev:
 
@@ -75,7 +102,7 @@ This will:
 - Create QuickSight dashboard with prefix `deployed-dev-covid-`
 - Refresh the QuickSight dataset with ETL results
 
-### 2. Customize Dashboard in Dev
+### 5. Customize Dashboard in Dev
 
 Open the QuickSight dashboard in the dev account (us-east-2) and make your customizations:
 - Add/modify visuals
@@ -84,7 +111,7 @@ Open the QuickSight dashboard in the dev account (us-east-2) and make your custo
 
 The dashboard will be named `TotalDeathByCountry` with ID prefix `deployed-dev-covid-`.
 
-### 3. Bundle from Dev
+### 6. Re-bundle from Dev (after customization)
 
 Export the customized dashboard from dev QuickSight:
 
@@ -96,7 +123,7 @@ This exports the live dashboard from dev QuickSight and packages it into `./arti
 
 **Note**: The manifest does NOT specify `assetBundle` for the QuickSight dashboard, which means it defaults to "export" mode (exports from live QuickSight).
 
-### 4. Deploy to Test Environment
+### 7. Deploy to Test Environment
 
 **First, switch to your test account credentials**
 ```bash

--- a/examples/analytic-workflow/dashboard-glue-quick/manifest.yaml
+++ b/examples/analytic-workflow/dashboard-glue-quick/manifest.yaml
@@ -29,7 +29,7 @@ stages:
     domain:
       tags:
         purpose: smus-cicd-testing
-      region: ${DEV_DOMAIN_REGION:us-east-2}
+      region: ${DEV_DOMAIN_REGION}
     project:
       name: dev-marketing
       owners:
@@ -38,7 +38,7 @@ stages:
       - arn:aws:iam::${AWS_ACCOUNT_ID}:role/Admin
     environment_variables:
       S3_PREFIX: dev
-      AWS_REGION: ${DEV_DOMAIN_REGION:us-east-2}
+      AWS_REGION: ${DEV_DOMAIN_REGION}
       GRANT_TO: Admin,service-role/aws-quicksight-service-role-v0
     bootstrap:
       actions:
@@ -67,9 +67,9 @@ stages:
         assets:
         - name: TotalDeathByCountry
           owners:
-          - arn:aws:quicksight:${DEV_DOMAIN_REGION:us-east-2}:${AWS_ACCOUNT_ID}:user/default/Admin/*
+          - arn:aws:quicksight:${DEV_DOMAIN_REGION}:${AWS_ACCOUNT_ID}:user/default/Admin/*
           viewers:
-          - arn:aws:quicksight:${DEV_DOMAIN_REGION:us-east-2}:${AWS_ACCOUNT_ID}:user/default/Admin/*
+          - arn:aws:quicksight:${DEV_DOMAIN_REGION}:${AWS_ACCOUNT_ID}:user/default/Admin/*
         overrideParameters:
           ResourceIdOverrideConfiguration:
             PrefixForAllResources: deployed-{stage.name}-covid-
@@ -78,7 +78,7 @@ stages:
     domain:
       tags:
         purpose: smus-cicd-testing
-      region: ${TEST_DOMAIN_REGION:us-east-1}
+      region: ${TEST_DOMAIN_REGION}
     project:
       name: test-marketing
       owners:
@@ -87,7 +87,7 @@ stages:
       - arn:aws:iam::${AWS_ACCOUNT_ID}:role/Admin
     environment_variables:
       S3_PREFIX: test
-      AWS_REGION: ${TEST_DOMAIN_REGION:us-east-1}
+      AWS_REGION: ${TEST_DOMAIN_REGION}
       GRANT_TO: Admin,service-role/aws-quicksight-service-role-v0
     bootstrap:
       actions:
@@ -116,9 +116,9 @@ stages:
         assets:
         - name: TotalDeathByCountry
           owners:
-          - arn:aws:quicksight:${TEST_DOMAIN_REGION:us-east-1}:${AWS_ACCOUNT_ID}:user/default/Admin/*
+          - arn:aws:quicksight:${TEST_DOMAIN_REGION}:${AWS_ACCOUNT_ID}:user/default/Admin/*
           viewers:
-          - arn:aws:quicksight:${TEST_DOMAIN_REGION:us-east-1}:${AWS_ACCOUNT_ID}:user/default/Admin/*
+          - arn:aws:quicksight:${TEST_DOMAIN_REGION}:${AWS_ACCOUNT_ID}:user/default/Admin/*
         overrideParameters:
           ResourceIdOverrideConfiguration:
             PrefixForAllResources: deployed-{stage.name}-covid-
@@ -127,7 +127,7 @@ stages:
     domain:
       tags:
         purpose: smus-cicd-production
-      region: ${PROD_DOMAIN_REGION:us-east-1}
+      region: ${PROD_DOMAIN_REGION}
     project:
       name: prod-marketing
       owners:
@@ -136,7 +136,7 @@ stages:
       - arn:aws:iam::${AWS_ACCOUNT_ID}:role/Admin
     environment_variables:
       S3_PREFIX: prod
-      AWS_REGION: ${PROD_DOMAIN_REGION:us-east-1}
+      AWS_REGION: ${PROD_DOMAIN_REGION}
       GRANT_TO: Admin,service-role/aws-quicksight-service-role-v0
     bootstrap:
       actions:
@@ -165,9 +165,9 @@ stages:
         assets:
         - name: TotalDeathByCountry
           owners:
-          - arn:aws:quicksight:${PROD_DOMAIN_REGION:us-east-1}:${AWS_ACCOUNT_ID}:user/default/Admin/*
+          - arn:aws:quicksight:${PROD_DOMAIN_REGION}:${AWS_ACCOUNT_ID}:user/default/Admin/*
           viewers:
-          - arn:aws:quicksight:${PROD_DOMAIN_REGION:us-east-1}:${AWS_ACCOUNT_ID}:user/default/Admin/*
+          - arn:aws:quicksight:${PROD_DOMAIN_REGION}:${AWS_ACCOUNT_ID}:user/default/Admin/*
         overrideParameters:
           ResourceIdOverrideConfiguration:
             PrefixForAllResources: deployed-{stage.name}-covid-

--- a/examples/analytic-workflow/dashboard-glue-quick/quicksight/setup_test_dashboard.py
+++ b/examples/analytic-workflow/dashboard-glue-quick/quicksight/setup_test_dashboard.py
@@ -26,13 +26,9 @@ def setup_test_dashboard():
     """Import test dashboard to dev environment."""
     
     # Get from environment or use defaults
-    account_id = os.environ.get("AWS_ACCOUNT_ID")
     dev_region = os.environ.get("DEV_DOMAIN_REGION", "us-east-2")
-    
-    if not account_id:
-        # Try to get from STS
-        sts = boto3.client("sts")
-        account_id = sts.get_caller_identity()["Account"]
+    sts = boto3.client("sts")
+    account_id = sts.get_caller_identity()["Account"]
     
     # Configuration
     dashboard_bundle = os.path.join(os.path.dirname(__file__), "TotalDeathByCountry.qs")

--- a/examples/analytic-workflow/data-notebooks/manifest.yaml
+++ b/examples/analytic-workflow/data-notebooks/manifest.yaml
@@ -14,22 +14,12 @@ content:
   - workflowName: notebooks_workflow
     connectionName: default.workflow_serverless
 stages:
-  dev:
-    stage: DEV
-    domain:
-      tags:
-        purpose: smus-cicd-testing
-      region: ${DEV_DOMAIN_REGION:us-east-2}
-    project:
-      name: dev-marketing
-    environment_variables:
-      S3_PREFIX: dev
   test:
     stage: TEST
     domain:
       tags:
         purpose: smus-cicd-testing
-      region: ${TEST_DOMAIN_REGION:us-east-1}
+      region: ${TEST_DOMAIN_REGION}
     project:
       name: test-marketing
       owners:
@@ -52,7 +42,7 @@ stages:
         name: mlflow-server
         connection_type: MLFLOW
         properties:
-          trackingServerArn: arn:aws:sagemaker:${STS_REGION}:${STS_ACCOUNT_ID}:mlflow-tracking-server/${MLFLOW_TRACKING_SERVER_NAME:smus-integration-mlflow-use2}
+          trackingServerArn: arn:aws:sagemaker:${TEST_DOMAIN_REGION}:${AWS_ACCOUNT_ID}:mlflow-tracking-server/${MLFLOW_TRACKING_SERVER_NAME:smus-integration-mlflow-use2}
       - type: workflow.create
         workflowName: notebooks_workflow
       - type: workflow.run
@@ -60,6 +50,3 @@ stages:
         trailLogs: true
 tests:
   folder: examples/analytic-workflow/data-notebooks/app_tests/
-
-
-# Trigger workflow

--- a/examples/analytic-workflow/genai/manifest.yaml
+++ b/examples/analytic-workflow/genai/manifest.yaml
@@ -11,22 +11,12 @@ content:
   - workflowName: genai_dev_workflow
     connectionName: default.workflow_serverless
 stages:
-  dev:
-    stage: DEV
-    domain:
-      tags:
-        purpose: smus-cicd-testing
-      region: ${DEV_DOMAIN_REGION:us-east-2}
-    project:
-      name: dev-marketing
-    environment_variables:
-      S3_PREFIX: dev
   test:
     stage: TEST
     domain:
       tags:
         purpose: smus-cicd-testing
-      region: ${TEST_DOMAIN_REGION:us-east-1}
+      region: ${TEST_DOMAIN_REGION}
     project:
       name: test-marketing
       owners:

--- a/examples/analytic-workflow/ml/deployment/manifest.yaml
+++ b/examples/analytic-workflow/ml/deployment/manifest.yaml
@@ -22,7 +22,7 @@ stages:
     domain:
       tags:
         purpose: smus-cicd-testing
-      region: ${DEV_DOMAIN_REGION:us-east-2}
+      region: ${DEV_DOMAIN_REGION}
     project:
       name: dev-marketing
     environment_variables:
@@ -32,7 +32,7 @@ stages:
     domain:
       tags:
         purpose: smus-cicd-testing
-      region: ${TEST_DOMAIN_REGION:us-east-1}
+      region: ${TEST_DOMAIN_REGION}
     project:
       name: test-marketing
       owners:
@@ -66,7 +66,7 @@ stages:
     domain:
       tags:
         purpose: smus-cicd-production
-      region: ${PROD_DOMAIN_REGION:us-east-1}
+      region: ${PROD_DOMAIN_REGION}
     project:
       name: prod-marketing
     environment_variables:

--- a/examples/analytic-workflow/ml/training/manifest.yaml
+++ b/examples/analytic-workflow/ml/training/manifest.yaml
@@ -17,7 +17,7 @@ stages:
     domain:
       tags:
         purpose: smus-cicd-testing
-      region: ${DEV_DOMAIN_REGION:us-east-1}
+      region: ${DEV_DOMAIN_REGION}
     project:
       name: dev-marketing
     environment_variables:
@@ -27,7 +27,7 @@ stages:
     domain:
       tags:
         purpose: smus-cicd-testing
-      region: ${TEST_DOMAIN_REGION:us-east-1}
+      region: ${TEST_DOMAIN_REGION}
     project:
       name: test-marketing
       owners:
@@ -53,7 +53,7 @@ stages:
         name: mlflow-server
         connection_type: MLFLOW
         properties:
-          trackingServerArn: arn:aws:sagemaker:${STS_REGION}:${STS_ACCOUNT_ID}:mlflow-tracking-server/${MLFLOW_TRACKING_SERVER_NAME:smus-integration-mlflow-use2}
+          trackingServerArn: arn:aws:sagemaker:${TEST_DOMAIN_REGION}:${AWS_ACCOUNT_ID}:mlflow-tracking-server/${MLFLOW_TRACKING_SERVER_NAME:smus-integration-mlflow-use2}
       - type: workflow.create
         workflowName: ml_training_workflow
       - type: workflow.run

--- a/examples/mwaa-example/DemoMarketingPipeline-MWAA.yaml
+++ b/examples/mwaa-example/DemoMarketingPipeline-MWAA.yaml
@@ -69,7 +69,7 @@ stages:
   prod:
     domain:
       name: cicd-test-domain
-      region: ${PROD_DOMAIN_REGION:us-east-1}
+      region: ${PROD_DOMAIN_REGION}
     stage: PROD
     project:
       name: prod-marketing

--- a/examples/quicksight-bootstrap-example.yaml
+++ b/examples/quicksight-bootstrap-example.yaml
@@ -85,14 +85,14 @@ stages:
     domain:
       tags:
         purpose: smus-cicd-production
-      region: ${PROD_DOMAIN_REGION:us-east-1}
+      region: ${PROD_DOMAIN_REGION}
     project:
       name: prod-analytics
       owners:
       - arn:aws:iam::${AWS_ACCOUNT_ID}:role/Admin
     environment_variables:
       S3_PREFIX: prod
-      AWS_REGION: ${PROD_DOMAIN_REGION:us-east-1}
+      AWS_REGION: ${PROD_DOMAIN_REGION}
     bootstrap:
       actions:
       - type: workflow.create
@@ -127,9 +127,9 @@ stages:
         assets:
         - name: SalesDashboard
           owners:
-          - arn:aws:quicksight:${PROD_DOMAIN_REGION:us-east-1}:${AWS_ACCOUNT_ID}:user/default/Admin/*
+          - arn:aws:quicksight:${PROD_DOMAIN_REGION}:${AWS_ACCOUNT_ID}:user/default/Admin/*
           viewers:
-          - arn:aws:quicksight:${PROD_DOMAIN_REGION:us-east-1}:${AWS_ACCOUNT_ID}:user/default/Admin/*
+          - arn:aws:quicksight:${PROD_DOMAIN_REGION}:${AWS_ACCOUNT_ID}:user/default/Admin/*
         overrideParameters:
           ResourceIdOverrideConfiguration:
             PrefixForAllResources: deployed-{stage.name}-sales-

--- a/examples/serverless-example/DemoMarketingPipeline-Serverless.yaml
+++ b/examples/serverless-example/DemoMarketingPipeline-Serverless.yaml
@@ -64,7 +64,7 @@ stages:
     stage: PROD
     domain:
       name: cicd-test-domain
-      region: ${PROD_DOMAIN_REGION:us-east-1}
+      region: ${PROD_DOMAIN_REGION}
     project:
       name: prod-marketing-demo
     environment_variables:

--- a/src/smus_cicd/commands/bundle.py
+++ b/src/smus_cicd/commands/bundle.py
@@ -256,13 +256,11 @@ def bundle_command(
                             files_added += 1
                             typer.echo(f"    Copied file: {pattern}")
                         elif os.path.isdir(source_path):
-                            # Copy directory recursively
-                            dest_path = os.path.join(
-                                target_dir, os.path.basename(pattern)
-                            )
+                            # Copy directory contents directly into target_dir
                             shutil.copytree(
                                 source_path,
-                                dest_path,
+                                target_dir,
+                                dirs_exist_ok=True,
                                 ignore=shutil.ignore_patterns(
                                     "*.pyc",
                                     "__pycache__",
@@ -271,7 +269,7 @@ def bundle_command(
                                 ),
                             )
                             # Count files
-                            for root, dirs, files in os.walk(dest_path):
+                            for root, dirs, files in os.walk(target_dir):
                                 files_added += len(files)
                             typer.echo(f"    Copied directory: {pattern}")
                         else:

--- a/src/smus_cicd/helpers/datazone.py
+++ b/src/smus_cicd/helpers/datazone.py
@@ -149,9 +149,9 @@ def get_project_user_role_arn(project_name: str, domain_name: str, region: str) 
         env_names = [env.get("name") for env in environments_response.get("items", [])]
         typer.echo(f"🔍 DEBUG: Found environments: {env_names}")
 
-        # Find tooling environment
+        # Find an environment with UserRoleArn
         for env in environments_response.get("items", []):
-            typer.echo(f"🔍 DEBUG: Found tooling environment: {env.get('name')}")
+            typer.echo(f"🔍 DEBUG: Found an environment: {env.get('name')}")
             # Get environment details
             env_detail = datazone_client.get_environment(
                 domainIdentifier=domain_id, identifier=env.get("id")
@@ -165,7 +165,7 @@ def get_project_user_role_arn(project_name: str, domain_name: str, region: str) 
                     return role_arn
 
         raise ValueError(
-            f"Project '{project_name}' does not have a Tooling Environment configured. "
+            f"Project '{project_name}' does not have an environment with UserRoleArn configured. "
             "The target project must have a Tooling Environment set up in SageMaker Unified Studio "
             "before it can be used with the SMUS CLI. "
             "Please configure a Tooling Environment for this project in the SMUS portal and try again."

--- a/src/smus_cicd/helpers/datazone.py
+++ b/src/smus_cicd/helpers/datazone.py
@@ -151,19 +151,18 @@ def get_project_user_role_arn(project_name: str, domain_name: str, region: str) 
 
         # Find tooling environment
         for env in environments_response.get("items", []):
-            if "tooling" in env.get("name", "").lower():
-                typer.echo(f"🔍 DEBUG: Found tooling environment: {env.get('name')}")
-                # Get environment details
-                env_detail = datazone_client.get_environment(
-                    domainIdentifier=domain_id, identifier=env.get("id")
-                )
+            typer.echo(f"🔍 DEBUG: Found tooling environment: {env.get('name')}")
+            # Get environment details
+            env_detail = datazone_client.get_environment(
+                domainIdentifier=domain_id, identifier=env.get("id")
+            )
 
-                # Look for userRoleArn in provisioned resources
-                for resource in env_detail.get("provisionedResources", []):
-                    if resource.get("name") == "userRoleArn":
-                        role_arn = resource.get("value")
-                        typer.echo(f"✅ DEBUG: Found userRoleArn={role_arn}")
-                        return role_arn
+            # Look for userRoleArn in provisioned resources
+            for resource in env_detail.get("provisionedResources", []):
+                if resource.get("name") == "userRoleArn":
+                    role_arn = resource.get("value")
+                    typer.echo(f"✅ DEBUG: Found userRoleArn={role_arn}")
+                    return role_arn
 
         raise ValueError(
             f"Project '{project_name}' does not have a Tooling Environment configured. "

--- a/src/smus_cicd/helpers/utils.py
+++ b/src/smus_cicd/helpers/utils.py
@@ -337,7 +337,7 @@ def get_datazone_project_info(
 
         if not domain_id:
             raise Exception(
-                "Domain not found - check domain name/tags in manifest or CloudFormation stack"
+                "Domain not found - check domain id/name/tags in manifest or CloudFormation stack"
             )
 
         project_id = _get_project_id(project_name, domain_id, region)
@@ -405,43 +405,35 @@ def _resolve_domain_id(config: Dict[str, Any], region: str) -> Optional[str]:
 
     logger = get_logger("utils")
 
-    # DEBUG: Log what we're working with
-    logger.debug(f"_resolve_domain_id called with region={region}")
-    logger.debug(f"config keys: {list(config.keys())}")
-    logger.debug(f"config.domain: {config.get('domain', {})}")
-
     # Try to get domain ID from CloudFormation exports first
     domain_id = get_domain_id(config)
-    logger.debug(f"domain_id from CloudFormation: {domain_id}")
+    if domain_id:
+        logger.debug(f"Resolved domain_id from CloudFormation: {domain_id}")
+        return domain_id
 
-    if not domain_id:
-        # Try to resolve domain by id, name, or tags
-        domain_config = config.get("domain", {})
-        domain_direct_id = domain_config.get("id")
-        domain_name = domain_config.get("name")
-        domain_tags = domain_config.get("tags")
+    domain_config = config.get("domain", {})
+    domain_direct_id = domain_config.get("id")
+    domain_name = domain_config.get("name")
+    domain_tags = domain_config.get("tags")
 
-        logger.debug(f"domain_direct_id: {domain_direct_id}")
-        logger.debug(f"domain_name: {domain_name}")
-        logger.debug(f"domain_tags: {domain_tags}")
+    # If a direct ID is provided, use it immediately
+    if domain_direct_id:
+        logger.debug(f"Using domain id directly: {domain_direct_id}")
+        return domain_direct_id
 
-        if domain_direct_id:
-            domain_id = domain_direct_id
-            logger.debug(f"Using domain id directly: {domain_id}")
-        elif domain_name or domain_tags:
-            try:
-                logger.debug(
-                    f"Calling datazone.resolve_domain_id with name={domain_name}, tags={domain_tags}, region={region}"
-                )
-                domain_id, _ = datazone.resolve_domain_id(
-                    domain_name=domain_name, domain_tags=domain_tags, region=region
-                )
-                logger.debug(f"Resolved domain_id: {domain_id}")
-            except Exception as e:
-                logger.error(f"Failed to resolve domain: {str(e)}")
-                raise Exception(f"Failed to resolve domain: {str(e)}")
-
-    return domain_id
+    # Otherwise resolve by name, tags, or auto-detect (single domain in region)
+    try:
+        logger.debug(
+            f"Calling datazone.resolve_domain_id with name={domain_name}, tags={domain_tags}, region={region}"
+        )
+        domain_id, _ = datazone.resolve_domain_id(
+            domain_name=domain_name, domain_tags=domain_tags, region=region
+        )
+        logger.debug(f"Resolved domain_id: {domain_id}")
+        return domain_id
+    except Exception as e:
+        logger.error(f"Failed to resolve domain: {str(e)}")
+        raise Exception(f"Failed to resolve domain: {str(e)}")
 
 
 def _get_project_id(project_name: str, domain_id: str, region: str) -> Optional[str]:

--- a/tests/unit/helpers/test_datazone_domain.py
+++ b/tests/unit/helpers/test_datazone_domain.py
@@ -102,3 +102,64 @@ class TestGetDomainNameById:
         with patch("smus_cicd.helpers.datazone._get_datazone_client", return_value=mock_client):
             with pytest.raises(Exception, match="ResourceNotFoundException"):
                 get_domain_name_by_id("dzd-bad", "us-east-1")
+
+
+class TestResolveDomainIdAutoDetect:
+    """Test _resolve_domain_id auto-detect path in utils (no id/name/tags provided)."""
+
+    def test_auto_detects_single_domain(self):
+        """When no domain id/name/tags are set, resolve_domain_id is called and auto-detects."""
+        from smus_cicd.helpers.utils import _resolve_domain_id
+
+        config = {"domain": {"region": "us-east-1"}}
+
+        with patch("smus_cicd.helpers.utils.get_domain_id", return_value=None):
+            with patch("smus_cicd.helpers.datazone.resolve_domain_id") as mock_resolve:
+                mock_resolve.return_value = ("dzd-autodetected", "auto-domain")
+                result = _resolve_domain_id(config, "us-east-1")
+
+        assert result == "dzd-autodetected"
+        mock_resolve.assert_called_once_with(
+            domain_name=None, domain_tags=None, region="us-east-1"
+        )
+
+    def test_raises_when_multiple_domains_and_no_identifier(self):
+        """When multiple domains exist and no identifier given, raises an exception."""
+        from smus_cicd.helpers.utils import _resolve_domain_id
+
+        config = {"domain": {"region": "us-east-1"}}
+
+        with patch("smus_cicd.helpers.utils.get_domain_id", return_value=None):
+            with patch("smus_cicd.helpers.datazone.resolve_domain_id") as mock_resolve:
+                mock_resolve.side_effect = Exception(
+                    "Multiple domains found in region us-east-1. Please specify domain name or tags."
+                )
+                with pytest.raises(Exception, match="Multiple domains found"):
+                    _resolve_domain_id(config, "us-east-1")
+
+    def test_cfn_result_takes_priority(self):
+        """When CloudFormation returns a domain ID, it is used without calling resolve_domain_id."""
+        from smus_cicd.helpers.utils import _resolve_domain_id
+
+        config = {"domain": {"region": "us-east-1"}}
+
+        with patch("smus_cicd.helpers.utils.get_domain_id", return_value="dzd-from-cfn"):
+            with patch("smus_cicd.helpers.datazone.resolve_domain_id") as mock_resolve:
+                result = _resolve_domain_id(config, "us-east-1")
+
+        assert result == "dzd-from-cfn"
+        mock_resolve.assert_not_called()
+
+    def test_direct_id_skips_resolve(self):
+        """When domain.id is set, resolve_domain_id is not called."""
+        from smus_cicd.helpers.utils import _resolve_domain_id
+
+        config = {"domain": {"id": "dzd-direct", "region": "us-east-1"}}
+
+        with patch("smus_cicd.helpers.utils.get_domain_id", return_value=None):
+            with patch("smus_cicd.helpers.datazone.resolve_domain_id") as mock_resolve:
+                result = _resolve_domain_id(config, "us-east-1")
+
+        assert result == "dzd-direct"
+        mock_resolve.assert_not_called()
+

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -142,3 +142,35 @@ stages:
                 result = runner.invoke(app, ["bundle"])
                 assert result.exit_code == 1
                 assert "Target 'dev' not found in manifest" in result.output
+
+
+def test_bundle_directory_copy_contents_flat():
+    """Test that bundling a directory copies its contents directly into target_dir, not as a subdir."""
+    import os
+    import tempfile
+    import shutil
+    from unittest.mock import patch, MagicMock
+    from smus_cicd.commands.bundle import bundle_command
+
+    with tempfile.TemporaryDirectory() as source_root:
+        # Create source directory with files
+        src_dir = os.path.join(source_root, "notebooks")
+        os.makedirs(src_dir)
+        with open(os.path.join(src_dir, "notebook1.ipynb"), "w") as f:
+            f.write("{}")
+        with open(os.path.join(src_dir, "notebook2.ipynb"), "w") as f:
+            f.write("{}")
+
+        with tempfile.TemporaryDirectory() as target_dir:
+            # Simulate the directory copy logic from bundle.py
+            shutil.copytree(
+                src_dir,
+                target_dir,
+                dirs_exist_ok=True,
+                ignore=shutil.ignore_patterns("*.pyc", "__pycache__", ".ipynb_checkpoints"),
+            )
+
+            # Files should be directly in target_dir, not in target_dir/notebooks/
+            assert os.path.exists(os.path.join(target_dir, "notebook1.ipynb"))
+            assert os.path.exists(os.path.join(target_dir, "notebook2.ipynb"))
+            assert not os.path.exists(os.path.join(target_dir, "notebooks", "notebook1.ipynb"))


### PR DESCRIPTION
## Summary

A collection of fixes found during the SA bug bash session.

## Bug Fixes

**Domain resolution (`utils.py`)**
- Refactored `_resolve_domain_id` to always fall through to `resolve_domain_id` even when no `id`/`name`/`tags` are provided, enabling auto-detection when only one DataZone domain exists in the account.
- Priority order: CloudFormation export → direct `domain.id` → resolve by name/tags/auto-detect.

**DataZone environment lookup (`datazone.py`)**
- Removed the `"tooling"` name filter in `get_project_user_role_arn`. Not all projects name their environment with "tooling", so the filter was preventing role ARN lookup. Now returns the first environment that has a `userRoleArn` provisioned resource.

**Bundle directory copy (`bundle.py`)**
- Fixed `shutil.copytree` to use `dirs_exist_ok=True` and copy contents directly into `target_dir` instead of creating a subdirectory. The old behavior caused a double-nesting bug (`notebooks/notebooks/`) when the include pattern directory name matched the storage item `name`. The zip structure (`{name}/files`) is preserved correctly for deploy.

**Remove env var defaults from manifests**
- Stripped `${VAR:default-region}` defaults from all manifests and examples. The defaults were causing misleading errors (wrong region, project/domain not found) when users forgot to export the variable. Now fails fast with a clear missing-variable error.
- Affected: `dashboard-glue-quick`, `data-notebooks`, `genai`, `ml/training`, `ml/deployment`, `DemoMarketingBundle.yaml`, `quicksight-bootstrap-example.yaml`, MWAA/serverless examples, `README.md`.

**MLflow connection variable cleanup (`ml/training`, `ml/deployment` manifests)**
- Replaced `${STS_REGION}` / `${STS_ACCOUNT_ID}` with `${TEST_DOMAIN_REGION}` / `${AWS_ACCOUNT_ID}` for consistency.

## Documentation

**Quickstart guide**
- Added venv setup steps (create + activate on macOS/Linux/Windows).
- Added Step 3 for setting up a SageMaker Unified Studio domain and project before deploying.
- Clarified that `domain` identifier can be omitted entirely if only one domain exists in the account.
- Fixed broken links: `bundle-manifest.md` → `manifest.md` across all docs.

**Dashboard Glue Quick README**
- Expanded setup steps: env var export, `setup_test_dashboard.py` step, and initial bundle step before deploy. Renumbered steps accordingly.

**`setup_test_dashboard.py`**
- Always resolve account ID via STS instead of optionally falling back to env var.

## Manifest cleanup

- Removed unused `dev` stage from `data-notebooks` and `genai` manifests (not used by integration tests).
- Restored `dev` stage (including `S3_PREFIX` env var) in `ml/training` and `ml/deployment` — required by integration tests for bundling.

## Tests

- Added `TestResolveDomainIdAutoDetect` unit tests: auto-detect single domain, multiple domains error, CloudFormation priority, direct ID short-circuit.
- Added `test_bundle_directory_copy_contents_flat` unit test verifying the copytree fix.