### PR TITLE
debug: add resolver logging and fix MLflow tracking server name in workflows

### DIFF
--- a/.github/workflows/smus-bundle-deploy.yml
+++ b/.github/workflows/smus-bundle-deploy.yml
@@ -326,7 +326,7 @@ jobs:
           DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
           TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
           DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
-          MLFLOW_TRACKING_SERVER_NAME: ${{ inputs.setup_mlflow && steps.mlflow-setup-test.outputs.tracking-server-name || '' }}
+          MLFLOW_TRACKING_SERVER_NAME: ${{ inputs.setup_mlflow && format('smus-integration-mlflow-{0}', vars.DOMAIN_REGION) || '' }}
           STS_REGION: ${{ vars.DOMAIN_REGION }}
           STS_ACCOUNT_ID: ${{ steps.aws-account-test.outputs.account-id }}
           AWS_ACCOUNT_ID: ${{ steps.aws-account-test.outputs.account-id }}
@@ -515,7 +515,7 @@ jobs:
           DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
           PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
           DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
-          MLFLOW_TRACKING_SERVER_NAME: ${{ inputs.setup_mlflow && steps.mlflow-setup-prod.outputs.tracking-server-name || '' }}
+          MLFLOW_TRACKING_SERVER_NAME: ${{ inputs.setup_mlflow && format('smus-integration-mlflow-{0}', vars.DOMAIN_REGION) || '' }}
           STS_REGION: ${{ vars.DOMAIN_REGION }}
           STS_ACCOUNT_ID: ${{ steps.aws-account-prod.outputs.account-id }}
           AWS_ACCOUNT_ID: ${{ steps.aws-account-prod.outputs.account-id }}

--- a/.github/workflows/smus-direct-deploy.yml
+++ b/.github/workflows/smus-direct-deploy.yml
@@ -134,7 +134,7 @@ jobs:
           DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
           TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
           DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
-          MLFLOW_TRACKING_SERVER_NAME: ${{ inputs.setup_mlflow && steps.mlflow-setup.outputs.tracking-server-name || '' }}
+          MLFLOW_TRACKING_SERVER_NAME: ${{ inputs.setup_mlflow && format('smus-integration-mlflow-{0}', vars.DOMAIN_REGION) || '' }}
           MLFLOW_ARTIFACT_LOCATION: s3://amazon-sagemaker-${{ steps.aws-account.outputs.account-id }}-${{ vars.DOMAIN_REGION }}-${{ vars.PROJECT_ID }}/shared/ml/mlflow-artifacts
           STS_REGION: ${{ vars.DOMAIN_REGION }}
           STS_ACCOUNT_ID: ${{ steps.aws-account.outputs.account-id }}

--- a/src/smus_cicd/helpers/context_resolver.py
+++ b/src/smus_cicd/helpers/context_resolver.py
@@ -174,6 +174,12 @@ class ContextResolver:
                     conn_dict = value["connection"]
                     remaining = path[11:]  # Remove "connection."
 
+                    print(
+                        f"🔍 DEBUG resolver: resolving '{{{namespace}.{path}}}', "
+                        f"remaining='{remaining}', "
+                        f"available connections={list(conn_dict.keys())}"
+                    )
+
                     # Try to match connection names (they can have dots)
                     for conn_name in conn_dict.keys():
                         if remaining.startswith(conn_name + "."):
@@ -189,8 +195,17 @@ class ContextResolver:
                                 s3_uri = conn_dict[conn_name]["s3Uri"]
                                 # Extract bucket from s3://bucket-name/path/
                                 bucket = s3_uri.replace("s3://", "").split("/")[0]
+                                print(
+                                    f"🔍 DEBUG resolver: bucket replacing with='{bucket}', "
+                                    f"S3 URI='{s3_uri}'"
+                                )
                                 return bucket
                             else:
+                                print(
+                                    f"⚠️  DEBUG resolver: connection '{conn_name}' matched "
+                                    f"but property '{property_name}' not found. "
+                                    f"Available properties={list(conn_dict[conn_name].keys())}"
+                                )
                                 unresolved.append(f"{{{namespace}.{path}}}")
                                 return match.group(0)
                         elif remaining == conn_name:
@@ -198,6 +213,10 @@ class ContextResolver:
                             return str(conn_dict[conn_name])
 
                     # Connection not found
+                    print(
+                        f"⚠️  DEBUG resolver: no connection matched '{remaining}' "
+                        f"in connections={list(conn_dict.keys())}"
+                    )
                     unresolved.append(f"{{{namespace}.{path}}}")
                     return match.group(0)
                 else:


### PR DESCRIPTION
## Summary

### Fix: MLflow tracking server name in GitHub workflows
- `smus-bundle-deploy.yml` and `smus-direct-deploy.yml`: replace `steps.mlflow-setup*.outputs.tracking-server-name` with `format('smus-integration-mlflow-{0}', vars.DOMAIN_REGION)` — the step output was causing errors in the Training GitHub workflow

### Debug: ContextResolver variable resolution logging
Investigating why `{proj.connection.default.s3_shared.s3Uri}` in `ml_deployment_workflow.yaml` is not being resolved correctly during prod ML deployment, resulting in the test account S3 URI being written to the workflow YAML instead of the prod account URI.

Added debug logging to `ContextResolver.resolve()` that prints:
- The variable being resolved and available connection names (so we can see what DataZone actually returns at runtime)
- Which connection matched (or didn't match)
- Which property was found (or missing)

This logging will be removed once the root cause is confirmed.