### PR TITLE
fix: use local workflow files in ml deployment bundle instead of S3

### DIFF
--- a/examples/analytic-workflow/ml/deployment/manifest.yaml
+++ b/examples/analytic-workflow/ml/deployment/manifest.yaml
@@ -6,9 +6,9 @@ content:
     include:
     - ml/bundle/deployment-code
   - name: deployment-workflows
-    connectionName: default.s3_shared
     include:
-    - ml/bundle/deployment-workflows
+    - workflows/ml_deployment_workflow.yaml
+    - workflows/ml_deployment_notebook.ipynb
   - name: model-artifacts
     connectionName: default.s3_shared
     include:


### PR DESCRIPTION
## Problem

The `deployment-workflows` content item in the ML deployment manifest was configured with `connectionName: default.s3_shared`, causing the `bundle` command to download the workflow YAML from the test account S3 bucket instead of using the local file.

The S3 version already had the template variable resolved to the test account URI (`372123585851`), so the bundle zip always contained the hardcoded test account S3 URI. When deployed to prod, the resolver found no `{...}` patterns to replace, leaving the wrong URI in place.

## Fix

Removed `connectionName` from the `deployment-workflows` storage item and changed `include` to point to the local workflow files:

```yaml
- name: deployment-workflows
  include:
  - workflows/ml_deployment_workflow.yaml
  - workflows/ml_deployment_notebook.ipynb
```

This ensures the bundle always contains the template variable `{proj.connection.default.s3_shared.s3Uri}`, which gets resolved correctly at deploy time for each target account.