### PR TITLE
fix: translate workflow creates PR instead of pushing directly to main

### DIFF
--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   id-token: write
   contents: write
+  pull-requests: write
 
 jobs:
   translate:
@@ -63,6 +64,8 @@ jobs:
 
       - name: Commit translations
         if: steps.check-changes.outputs.has-changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
@@ -70,6 +73,13 @@ jobs:
           if git diff --staged --quiet; then
             echo "No translation changes to commit"
           else
+            BRANCH="chore/auto-translate-$(date +%Y%m%d-%H%M%S)"
+            git checkout -b "$BRANCH"
             git commit -m "chore: auto-translate README to multiple languages [skip ci]"
-            git push
+            git push origin "$BRANCH"
+            gh pr create \
+              --title "chore: auto-translate README to multiple languages" \
+              --body "Automated translation update triggered by changes to README or docs." \
+              --base main \
+              --head "$BRANCH"
           fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # SMUS CI/CD Pipeline CLI
-<!-- Translation workflow test -->
 
 [![en](https://img.shields.io/badge/lang-en-brightgreen.svg?style=for-the-badge)](README.md)
 [![pt](https://img.shields.io/badge/lang-pt-gray.svg)](docs/langs/pt/README.md)


### PR DESCRIPTION
## Problem

The `Translate Documentation` workflow was pushing translated files directly to `main`, which is blocked by branch protection rules requiring PRs.

## Fix

- Workflow now creates a timestamped branch (`chore/auto-translate-YYYYMMDD-HHMMSS`) and opens a PR via `gh pr create`
- Added `pull-requests: write` permission to the workflow
- Removed test HTML comment from README