### PR TITLE
fix: skip change detection when translate workflow is triggered manually

### DIFF
--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -24,7 +24,9 @@ jobs:
       - name: Check for changes in README or docs
         id: check-changes
         run: |
-          if git diff --name-only HEAD~1 HEAD | grep -E '^(README\.md|docs/)'; then
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "has-changes=true" >> $GITHUB_OUTPUT
+          elif git diff --name-only HEAD~1 HEAD | grep -E '^(README\.md|docs/)'; then
             echo "has-changes=true" >> $GITHUB_OUTPUT
           else
             echo "has-changes=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

When triggering the `Translate Documentation` workflow via `workflow_dispatch`, the change detection step always returns `has-changes=false` because there's no new commit to diff against — resulting in a no-op.

## Fix

Skip the `HEAD~1` diff check when the trigger is `workflow_dispatch`, so manual runs always proceed with translation.