### PR TITLE
fix: correct opensearch client package name to opensearch-py

### DIFF
--- a/examples/analytic-workflow/genai/job-code/requirements.txt
+++ b/examples/analytic-workflow/genai/job-code/requirements.txt
@@ -2,6 +2,6 @@ boto3>=1.28.0
 pyyaml
 termcolor
 retrying
-opensearchpy
+opensearch-py
 rich
 pydantic


### PR DESCRIPTION
The OpenSearch Python client pip package is named `opensearch-py`, not `opensearchpy`. The importable module is `opensearchpy`, but `pip install opensearchpy` resolves the wrong package name — `opensearch-py` is the correct install target.

This PR corrects the package name in `requirements.txt`.
