### PR TITLE
fix: pin mlflow to 3.1.4, add dependabot ignores, fix translation script

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/examples/analytic-workflow/ml/training/code"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "mlflow"
+        reason: "mlflow>=3.x requires Python >=3.10; training container uses Python 3.9"
+
+  - package-ecosystem: "pip"
+    directory: "/examples/analytic-workflow/data-notebooks/notebooks"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "mlflow"
+        reason: "mlflow>=3.x requires Python >=3.10; training container uses Python 3.9"
+      - dependency-name: "mlflow-skinny"
+        reason: "mlflow>=3.x requires Python >=3.10; training container uses Python 3.9"
+      - dependency-name: "mlflow-tracing"
+        reason: "mlflow>=3.x requires Python >=3.10; training container uses Python 3.9"
+      - dependency-name: "sagemaker-mlflow"
+        reason: "pinned alongside mlflow for compatibility"

--- a/docs/scripts/translate-readme-chunked.py
+++ b/docs/scripts/translate-readme-chunked.py
@@ -16,6 +16,7 @@ LANGUAGES = {
     'he': 'Hebrew',
     'it': 'Italian',
     'ja': 'Japanese',
+    'pt': 'Portuguese',
     'zh': 'Chinese (Simplified)',
 }
 
@@ -125,18 +126,19 @@ def main():
         if lang_code in badge_map:
             idx = badge_map[lang_code]
             badges[idx] = badges[idx].replace('-gray.svg)', '-brightgreen.svg?style=for-the-badge)')
-        
+
         badge_bar = '\n'.join(badges)
-        
+        back_link = '\n\n← [Back to Main README](../../../README.md)'
+
         # Wrap Hebrew in RTL div and fix code blocks
         if lang_code == 'he':
             # Wrap code blocks in LTR divs
             import re
             pattern = r'(```[\s\S]*?```)'
             full_translation = re.sub(pattern, r'<div dir="ltr">\n\n\1\n\n</div>', full_translation)
-            full_translation = f'<div dir="rtl">\n\n{badge_bar}\n\n{full_translation}\n\n</div>'
+            full_translation = f'<div dir="rtl">\n\n{badge_bar}{back_link}\n\n{full_translation}\n\n</div>'
         else:
-            full_translation = f'{badge_bar}\n\n{full_translation}'
+            full_translation = f'{badge_bar}{back_link}\n\n{full_translation}'
         
         # Save
         output_dir = project_root / "docs" / "langs" / lang_code

--- a/examples/analytic-workflow/ml/training/code/requirements.txt
+++ b/examples/analytic-workflow/ml/training/code/requirements.txt
@@ -1,3 +1,3 @@
-mlflow==3.8.0rc0
+mlflow==3.1.4
 sagemaker-mlflow
 matplotlib


### PR DESCRIPTION
## Summary

### mlflow version fix
- Reverts `mlflow==3.8.0rc0` → `mlflow==3.1.4` in `examples/analytic-workflow/ml/training/code/requirements.txt`
- `3.8.0rc0` was bumped by dependabot (#91) but requires Python >=3.10; the SageMaker sklearn training container uses Python 3.9, causing `ml_training_notebook` to fail

### dependabot configuration
- Adds `.github/dependabot.yml` to ignore `mlflow`, `mlflow-skinny`, `mlflow-tracing`, and `sagemaker-mlflow` updates in affected directories, preventing future breakage

### translation script fixes
- Adds Portuguese (`pt`) to the `LANGUAGES` dict in `translate-readme-chunked.py` — it was missing, so `docs/langs/pt/README.md` was never being updated by the workflow
- Preserves the `← [Back to Main README]` back link in all translated READMEs so the CI `validate-docs` back link check continues to pass (the script was overwriting files and dropping the link)