### PR TITLE
fix: pass region via domain.region to all example workflow notebooks

### DIFF
--- a/examples/analytic-workflow/data-notebooks/notebooks/customer_churn_prediction.ipynb
+++ b/examples/analytic-workflow/data-notebooks/notebooks/customer_churn_prediction.ipynb
@@ -26,6 +26,20 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Parameters cell - will be replaced by Papermill\n",
+    "region = None  # AWS region - injected via domain.region\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
     "ExecuteTime": {
      "end_time": "2025-08-17T17:39:36.862422Z",
      "start_time": "2025-08-17T17:39:36.857900Z"
@@ -77,30 +91,7 @@
    },
    "outputs": [],
    "source": [
-    "# 📥 Load our customer intelligence database\n",
-    "session = boto3.Session()\n",
-    "aws_region = session.region_name or 'us-west-2'\n",
-    "\n",
-    "s3 = boto3.client('s3')\n",
-    "\n",
-    "# Create data directory if it doesn't exist\n",
-    "os.makedirs('notebook_outputs', exist_ok=True)\n",
-    "\n",
-    "s3.download_file(\n",
-    "    f'sagemaker-example-files-prod-{aws_region}',\n",
-    "    'datasets/tabular/synthetic/churn.txt',\n",
-    "    'notebook_outputs/churn.txt'\n",
-    ")\n",
-    "\n",
-    "df = pd.read_csv('notebook_outputs/churn.txt')\n",
-    "\n",
-    "print('🎯 Customer Database Loaded!')\n",
-    "print(f'📊 We have {df.shape[0]:,} customers with {df.shape[1]} data points each')\n",
-    "print(f'💾 Total data points: {df.shape[0] * df.shape[1]:,}')\n",
-    "\n",
-    "# 🔍 First glimpse at our customers\n",
-    "print('\\n👥 Meet our first 5 customers:')\n",
-    "df.head()"
+    "# 📥 Load our customer intelligence database\nsession = boto3.Session()\naws_region = region or boto3.Session().region_name\n\ns3 = boto3.client('s3')\n\n# Create data directory if it doesn't exist\nos.makedirs('notebook_outputs', exist_ok=True)\n\ns3.download_file(\n    f'sagemaker-example-files-prod-{aws_region}',\n    'datasets/tabular/synthetic/churn.txt',\n    'notebook_outputs/churn.txt'\n)\n\ndf = pd.read_csv('notebook_outputs/churn.txt')\n\nprint('🎯 Customer Database Loaded!')\nprint(f'📊 We have {df.shape[0]:,} customers with {df.shape[1]} data points each')\nprint(f'💾 Total data points: {df.shape[0] * df.shape[1]:,}')\n\n# 🔍 First glimpse at our customers\nprint('\\n👥 Meet our first 5 customers:')\ndf.head()"
    ]
   },
   {

--- a/examples/analytic-workflow/data-notebooks/notebooks/customer_segmentation_analysis.ipynb
+++ b/examples/analytic-workflow/data-notebooks/notebooks/customer_segmentation_analysis.ipynb
@@ -16,6 +16,20 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Parameters cell - will be replaced by Papermill\n",
+    "region = None  # AWS region - injected via domain.region\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/examples/analytic-workflow/data-notebooks/notebooks/retail_sales_forecasting.ipynb
+++ b/examples/analytic-workflow/data-notebooks/notebooks/retail_sales_forecasting.ipynb
@@ -20,6 +20,20 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Parameters cell - will be replaced by Papermill\n",
+    "region = None  # AWS region - injected via domain.region\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -32,28 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Install required packages\n",
-    "!pip install -q pandas numpy matplotlib seaborn scikit-learn xgboost boto3 joblib\n",
-    "\n",
-    "import boto3\n",
-    "import pandas as pd\n",
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "import xgboost as xgb\n",
-    "from sklearn.model_selection import train_test_split, GridSearchCV\n",
-    "from sklearn.metrics import mean_squared_error, mean_absolute_error\n",
-    "import os\n",
-    "import time\n",
-    "import joblib\n",
-    "\n",
-    "# Initialize boto3 session\n",
-    "session = boto3.Session()\n",
-    "region = session.region_name or 'us-west-2'\n",
-    "\n",
-    "# Create unique session ID for resource tracking\n",
-    "session_id = f\"{int(time.time())}\"\n",
-    "print(f\"Session ID: {session_id} (for resource cleanup)\")\n",
-    "print(f\"Region: {region}\")"
+    "# Install required packages\n!pip install -q pandas numpy matplotlib seaborn scikit-learn xgboost boto3 joblib\n\nimport boto3\nimport pandas as pd\nimport numpy as np\nimport matplotlib.pyplot as plt\nimport xgboost as xgb\nfrom sklearn.model_selection import train_test_split, GridSearchCV\nfrom sklearn.metrics import mean_squared_error, mean_absolute_error\nimport os\nimport time\nimport joblib\n\n# Initialize boto3 session\nsession = boto3.Session()\nregion = region or boto3.Session().region_name\n\n# Create unique session ID for resource tracking\nsession_id = f\"{int(time.time())}\"\nprint(f\"Session ID: {session_id} (for resource cleanup)\")\nprint(f\"Region: {region}\")"
    ]
   },
   {
@@ -69,25 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Load and preprocess data\n",
-    "current_region = boto3.Session().region_name or \"us-west-2\"\n",
-    "data_url = f\"s3://sagemaker-example-files-prod-{current_region}/datasets/tabular/online_retail/online_retail_II_20k.csv\"\n",
-    "df = pd.read_csv(data_url)\n",
-    "df = df.dropna(subset=[\"Customer ID\"])\n",
-    "df = df[(df[\"Quantity\"] > 0) & (df[\"Price\"] > 0)]\n",
-    "df[\"InvoiceDate\"] = pd.to_datetime(df[\"InvoiceDate\"])\n",
-    "df[\"Revenue\"] = df[\"Quantity\"] * df[\"Price\"]\n",
-    "\n",
-    "# Aggregate daily sales\n",
-    "daily_sales = df.groupby(df['InvoiceDate'].dt.date).agg({\n",
-    "    'Revenue': 'sum', 'Quantity': 'sum', 'Invoice': 'nunique', 'Customer ID': 'nunique'\n",
-    "}).reset_index()\n",
-    "daily_sales.columns = ['Date', 'Revenue', 'Quantity', 'Orders', 'Customers']\n",
-    "daily_sales['Date'] = pd.to_datetime(daily_sales['Date'])\n",
-    "daily_sales = daily_sales.sort_values('Date').reset_index(drop=True)\n",
-    "\n",
-    "print(f'Summary of Revenue')\n",
-    "print(daily_sales)"
+    "# Load and preprocess data\ncurrent_region = region or boto3.Session().region_name\ndata_url = f\"s3://sagemaker-example-files-prod-{current_region}/datasets/tabular/online_retail/online_retail_II_20k.csv\"\ndf = pd.read_csv(data_url)\ndf = df.dropna(subset=[\"Customer ID\"])\ndf = df[(df[\"Quantity\"] > 0) & (df[\"Price\"] > 0)]\ndf[\"InvoiceDate\"] = pd.to_datetime(df[\"InvoiceDate\"])\ndf[\"Revenue\"] = df[\"Quantity\"] * df[\"Price\"]\n\n# Aggregate daily sales\ndaily_sales = df.groupby(df['InvoiceDate'].dt.date).agg({\n    'Revenue': 'sum', 'Quantity': 'sum', 'Invoice': 'nunique', 'Customer ID': 'nunique'\n}).reset_index()\ndaily_sales.columns = ['Date', 'Revenue', 'Quantity', 'Orders', 'Customers']\ndaily_sales['Date'] = pd.to_datetime(daily_sales['Date'])\ndaily_sales = daily_sales.sort_values('Date').reset_index(drop=True)\n\nprint(f'Summary of Revenue')\nprint(daily_sales)"
    ]
   },
   {

--- a/examples/analytic-workflow/data-notebooks/workflows/parallel_notebooks_workflow.yaml
+++ b/examples/analytic-workflow/data-notebooks/workflows/parallel_notebooks_workflow.yaml
@@ -6,7 +6,8 @@ notebooks_workflow:
       retries: 0
       input_config:
         input_path: notebooks/bundle/notebooks/customer_churn_prediction.ipynb
-        input_params: {}
+        input_params:
+          region: "{domain.region}"
       output_config:
         output_formats:
         - NOTEBOOK
@@ -21,7 +22,8 @@ notebooks_workflow:
       retries: 0
       input_config:
         input_path: notebooks/bundle/notebooks/retail_sales_forecasting.ipynb
-        input_params: {}
+        input_params:
+          region: "{domain.region}"
       output_config:
         output_formats:
         - NOTEBOOK
@@ -36,7 +38,8 @@ notebooks_workflow:
       retries: 0
       input_config:
         input_path: notebooks/bundle/notebooks/customer_segmentation_analysis.ipynb
-        input_params: {}
+        input_params:
+          region: "{domain.region}"
       output_config:
         output_formats:
         - NOTEBOOK

--- a/examples/analytic-workflow/genai/workflows/bedrock_agent_notebook.ipynb
+++ b/examples/analytic-workflow/genai/workflows/bedrock_agent_notebook.ipynb
@@ -33,7 +33,8 @@
     "agent_name = \"calculator_agent\"\n",
     "agent_llm = \"us.anthropic.claude-3-5-sonnet-20241022-v2:0\"\n",
     "force_recreate = True\n",
-    "kb_name = \"mortgage-kb\""
+    "kb_name = \"mortgage-kb\"\n",
+    "region = None  # AWS region - injected via domain.region\n"
    ]
   },
   {
@@ -50,7 +51,8 @@
     "\n",
     "# Get project connections dynamically (account-agnostic)\n",
     "proj = Project()\n",
-    "region = boto3.Session().region_name\n",
+    "if not region:\n",
+    "    region = boto3.Session().region_name\n",
     "iam_conn = proj.connection('default.iam')\n",
     "role = iam_conn.iam_role\n",
     "s3_shared_conn = proj.connection('default.s3_shared')\n",

--- a/examples/analytic-workflow/genai/workflows/genai_dev_workflow.yaml
+++ b/examples/analytic-workflow/genai/workflows/genai_dev_workflow.yaml
@@ -11,6 +11,7 @@ genai_dev_workflow:
           agent_llm: "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
           force_recreate: "True"
           kb_name: "mortgage-kb"
+          region: "{domain.region}"
       output_config:
         output_formats: 
           ['NOTEBOOK']

--- a/examples/analytic-workflow/ml/deployment/workflows/ml_deployment_notebook.ipynb
+++ b/examples/analytic-workflow/ml/deployment/workflows/ml_deployment_notebook.ipynb
@@ -26,7 +26,7 @@
      "parameters"
     ]
    },
-   "source": "# Parameters cell - will be replaced by Papermill\nmodel_s3_uri = None\nsklearn_version = \"1.2-1\"\npython_version = \"py3\"\ninference_instance_type = \"ml.m5.large\"\n",
+   "source": "# Parameters cell - will be replaced by Papermill\nmodel_s3_uri = None\nsklearn_version = \"1.2-1\"\npython_version = \"py3\"\ninference_instance_type = \"ml.m5.large\"\nregion = None  # AWS region - injected via domain.region\n",
    "outputs": [],
    "execution_count": null
   },
@@ -71,7 +71,7 @@
   {
    "cell_type": "code",
    "metadata": {},
-   "source": "from sagemaker_studio import Project\n\n# Get project connections dynamically\nproj = Project()\n\n# Get region\nregion = boto3.Session().region_name\nprint(f\"\u2705 Region: {region}\")\n\n# Get S3 bucket\ns3_shared_conn = proj.connection('default.s3_shared')\nbucket = s3_shared_conn.data.s3_uri.rstrip('/').split('/')[-2]\nprint(f\"\u2705 S3 Bucket: {bucket}\")\n\n# Get IAM role\niam_conn = proj.connection('default.iam')\nrole = iam_conn.iam_role\nprint(f\"\u2705 IAM Role: {role}\")\n\n# Create SageMaker session with explicit bucket to avoid CreateBucket permission issues\nsession = sagemaker.Session(default_bucket=bucket)\nprint(f\"\u2705 SageMaker session created with bucket: {bucket}\")\n",
+   "source": "from sagemaker_studio import Project\n\n# Get project connections dynamically\nproj = Project()\n\n# Get region\nif not region:\n    region = boto3.Session().region_name\nprint(f\"\u2705 Region: {region}\")\n\n# Get S3 bucket\ns3_shared_conn = proj.connection('default.s3_shared')\nbucket = s3_shared_conn.data.s3_uri.rstrip('/').split('/')[-2]\nprint(f\"\u2705 S3 Bucket: {bucket}\")\n\n# Get IAM role\niam_conn = proj.connection('default.iam')\nrole = iam_conn.iam_role\nprint(f\"\u2705 IAM Role: {role}\")\n\n# Create SageMaker session with explicit bucket to avoid CreateBucket permission issues\nsession = sagemaker.Session(default_bucket=bucket)\nprint(f\"\u2705 SageMaker session created with bucket: {bucket}\")\n",
    "outputs": [],
    "execution_count": null
   },

--- a/examples/analytic-workflow/ml/deployment/workflows/ml_deployment_workflow.yaml
+++ b/examples/analytic-workflow/ml/deployment/workflows/ml_deployment_workflow.yaml
@@ -11,6 +11,7 @@ ml_deployment_workflow:
           sklearn_version: "1.2-1"
           python_version: "py3"
           inference_instance_type: "ml.m5.large"
+          region: "{domain.region}"
       output_config:
         output_formats: 
           ['NOTEBOOK']

--- a/examples/analytic-workflow/ml/training/workflows/ml_training_notebook.ipynb
+++ b/examples/analytic-workflow/ml/training/workflows/ml_training_notebook.ipynb
@@ -45,6 +45,7 @@
     "training_instance_type = \"ml.m5.large\"\n",
     "inference_instance_type = \"ml.m5.large\"\n",
     "model_name = \"realistic-classifier-v1\"\n",
+    "region = None  # AWS region - injected via domain.region\n",
     ""
    ]
   },
@@ -106,14 +107,11 @@
    "source": [
     "from sagemaker_studio import Project\n",
     "\n",
-    "# Get project connections dynamically\n",
-    "# Get region from execution environment\n",
-    "region = boto3.Session().region_name\n",
-    "\n",
     "proj = Project()\n",
     "\n",
-    "# Get region from boto3 session\n",
-    "region = boto3.Session().region_name\n",
+    "# Use region from injected parameter, fall back to boto3 session\n",
+    "if not region:\n",
+    "    region = boto3.Session().region_name\n",
     "print(f\"\u2705 Region: {region}\")\n",
     "\n",
     "# Get S3 shared bucket from connection\n",

--- a/examples/analytic-workflow/ml/training/workflows/ml_training_workflow.yaml
+++ b/examples/analytic-workflow/ml/training/workflows/ml_training_workflow.yaml
@@ -13,6 +13,7 @@ ml_training_workflow:
           python_version: "py3"
           training_instance_type: "ml.m5.large"
           model_name: "realistic-classifier-v1"
+          region: "{domain.region}"
       output_config:
         output_formats: 
           ['NOTEBOOK']


### PR DESCRIPTION
## Summary

All example workflow notebooks were failing because `boto3.Session().region_name` returns `None` in the SageMaker notebook execution environment, causing `sagemaker.Session()` to raise a `ValueError`.

## Root Cause

The notebooks relied on `boto3.Session().region_name` to detect the region at runtime, but this returns `None` when no default region is configured in the execution environment.

## Fix

Inject `region` as a papermill parameter via `{domain.region}` in each workflow's `input_params`, and add a `parameters` cell to each notebook with `region = None` as the default.

## Changes

- `ml/training`: added `region` to workflow yaml + notebook parameters cell
- `ml/deployment`: added `region` to workflow yaml + notebook parameters cell  
- `genai`: added `region` to workflow yaml + notebook parameters cell
- `data-notebooks`: added `region` to all 3 workflow tasks + parameters cells in all 3 notebooks, removed hardcoded `or 'us-west-2'` fallbacks
- `dashboard-glue-quick`: already correct, no changes needed

## Testing

Validated with a local simulation script that papermill parameter injection correctly resolves `region='us-east-1'` across all 6 notebooks.