### PR TITLE
fix: pass boto_session with region to SageMaker SDK calls in notebooks

### DIFF
--- a/examples/analytic-workflow/genai/workflows/bedrock_agent_notebook.ipynb
+++ b/examples/analytic-workflow/genai/workflows/bedrock_agent_notebook.ipynb
@@ -43,6 +43,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "# Set AWS_DEFAULT_REGION so boto3 clients created without explicit region work correctly\n",
+    "os.environ['AWS_DEFAULT_REGION'] = region or boto3.Session().region_name or 'us-east-1'\n",
+    "region = os.environ['AWS_DEFAULT_REGION']\n",
+    "\n",
     "import boto3\n",
     "import time\n",
     "from sagemaker_studio import Project\n",

--- a/examples/analytic-workflow/ml/deployment/workflows/ml_deployment_notebook.ipynb
+++ b/examples/analytic-workflow/ml/deployment/workflows/ml_deployment_notebook.ipynb
@@ -64,21 +64,21 @@
   {
    "cell_type": "code",
    "metadata": {},
-   "source": "import boto3\nimport sagemaker\nfrom sagemaker_studio import Project\nfrom sagemaker.sklearn import SKLearnModel\n\nprint(\"\u2705 Imports successful\")",
+   "source": "import boto3\nimport sagemaker\nfrom sagemaker_studio import Project\nfrom sagemaker.sklearn import SKLearnModel\n\nprint(\"✅ Imports successful\")",
    "outputs": [],
    "execution_count": null
   },
   {
    "cell_type": "code",
    "metadata": {},
-   "source": "from sagemaker_studio import Project\n\n# Get project connections dynamically\nproj = Project()\n\n# Get region\nif not region:\n    region = boto3.Session().region_name\nprint(f\"\u2705 Region: {region}\")\n\n# Get S3 bucket\ns3_shared_conn = proj.connection('default.s3_shared')\nbucket = s3_shared_conn.data.s3_uri.rstrip('/').split('/')[-2]\nprint(f\"\u2705 S3 Bucket: {bucket}\")\n\n# Get IAM role\niam_conn = proj.connection('default.iam')\nrole = iam_conn.iam_role\nprint(f\"\u2705 IAM Role: {role}\")\n\n# Create SageMaker session with explicit bucket to avoid CreateBucket permission issues\nsession = sagemaker.Session(default_bucket=bucket)\nprint(f\"\u2705 SageMaker session created with bucket: {bucket}\")\n",
+   "source": "from sagemaker_studio import Project\n\n# Get project connections dynamically\nproj = Project()\n\n# Get region\nif not region:\n    region = boto3.Session().region_name\nprint(f\"✅ Region: {region}\")\n\n# Get S3 bucket\ns3_shared_conn = proj.connection('default.s3_shared')\nbucket = s3_shared_conn.data.s3_uri.rstrip('/').split('/')[-2]\nprint(f\"✅ S3 Bucket: {bucket}\")\n\n# Get IAM role\niam_conn = proj.connection('default.iam')\nrole = iam_conn.iam_role\nprint(f\"✅ IAM Role: {role}\")\n\n# Create SageMaker session with explicit bucket to avoid CreateBucket permission issues\nboto_session = boto3.Session(region_name=region)\nsession = sagemaker.Session(boto_session=boto_session, default_bucket=bucket)\nprint(f\"✅ SageMaker session created with bucket: {bucket}\")\n",
    "outputs": [],
    "execution_count": null
   },
   {
    "cell_type": "code",
    "metadata": {},
-   "source": "# Cleanup old endpoints from previous runs\nprint(\"\\n\ud83e\uddf9 Cleaning up old endpoints...\")\n\ntry:\n    sm_client = boto3.client('sagemaker', region_name=region)\n    endpoints = sm_client.list_endpoints(NameContains='sagemaker-scikit-learn', MaxResults=10)\n    \n    for endpoint in endpoints['Endpoints']:\n        endpoint_name = endpoint['EndpointName']\n        try:\n            print(f\"   Deleting {endpoint_name}...\")\n            sm_client.delete_endpoint(EndpointName=endpoint_name)\n            sm_client.delete_endpoint_config(EndpointConfigName=endpoint_name)\n        except Exception as e:\n            print(f\"   Could not delete {endpoint_name}: {e}\")\n    \n    if not endpoints['Endpoints']:\n        print(\"   No old endpoints to clean up\")\n    else:\n        print(f\"   \u2705 Cleaned up {len(endpoints['Endpoints'])} endpoints\")\nexcept Exception as e:\n    print(f\"   \u26a0\ufe0f  Cleanup warning: {e}\")",
+   "source": "# Cleanup old endpoints from previous runs\nprint(\"\\n🧹 Cleaning up old endpoints...\")\n\ntry:\n    sm_client = boto3.client('sagemaker', region_name=region)\n    endpoints = sm_client.list_endpoints(NameContains='sagemaker-scikit-learn', MaxResults=10)\n    \n    for endpoint in endpoints['Endpoints']:\n        endpoint_name = endpoint['EndpointName']\n        try:\n            print(f\"   Deleting {endpoint_name}...\")\n            sm_client.delete_endpoint(EndpointName=endpoint_name)\n            sm_client.delete_endpoint_config(EndpointConfigName=endpoint_name)\n        except Exception as e:\n            print(f\"   Could not delete {endpoint_name}: {e}\")\n    \n    if not endpoints['Endpoints']:\n        print(\"   No old endpoints to clean up\")\n    else:\n        print(f\"   ✅ Cleaned up {len(endpoints['Endpoints'])} endpoints\")\nexcept Exception as e:\n    print(f\"   ⚠️  Cleanup warning: {e}\")",
    "outputs": [],
    "execution_count": null
   },
@@ -87,14 +87,14 @@
    "metadata": {},
    "source": [
     "# Get model from S3\n",
-    "print(\"\\n\ud83d\udce6 Using model from S3...\")\n",
+    "print(\"\\n📦 Using model from S3...\")\n",
     "\n",
     "if not model_s3_uri:\n",
     "    raise ValueError(\"model_s3_uri parameter is required\")\n",
     "\n",
     "model_data = model_s3_uri\n",
     "print(f\"   Model S3 URI: {model_data}\")\n",
-    "print(\"   \u2705 Model location retrieved\")"
+    "print(\"   ✅ Model location retrieved\")"
    ],
    "outputs": [],
    "execution_count": null
@@ -102,14 +102,14 @@
   {
    "cell_type": "code",
    "metadata": {},
-   "source": "# Deploy model\nprint(\"\\n\ud83d\ude80 Deploying model...\")\n\n# Download inference.py from S3 to temp directory\nimport tempfile\nimport os\n\ncode_dir = tempfile.mkdtemp()\ninference_file = os.path.join(code_dir, 'inference.py')\n\ns3_client = boto3.client('s3', region_name=region)\ns3_client.download_file(bucket, 'shared/ml/bundle/deployment-code/inference.py', inference_file)\nprint(f\"   Downloaded inference.py to {code_dir}\")\n\nsklearn_model = SKLearnModel(\n    model_data=model_data,\n    role=role,\n    entry_point='inference.py',\n    source_dir=code_dir,\n    framework_version=sklearn_version,\n    py_version=python_version,\n    sagemaker_session=session\n)\n\npredictor = sklearn_model.deploy(\n    initial_instance_count=1,\n    instance_type=inference_instance_type\n)\n\nendpoint_name = predictor.endpoint_name\nprint(f\"   \u2705 Model deployed to endpoint: {endpoint_name}\")",
+   "source": "# Deploy model\nprint(\"\\n🚀 Deploying model...\")\n\n# Download inference.py from S3 to temp directory\nimport tempfile\nimport os\n\ncode_dir = tempfile.mkdtemp()\ninference_file = os.path.join(code_dir, 'inference.py')\n\ns3_client = boto3.client('s3', region_name=region)\ns3_client.download_file(bucket, 'shared/ml/bundle/deployment-code/inference.py', inference_file)\nprint(f\"   Downloaded inference.py to {code_dir}\")\n\nsklearn_model = SKLearnModel(\n    model_data=model_data,\n    role=role,\n    entry_point='inference.py',\n    source_dir=code_dir,\n    framework_version=sklearn_version,\n    py_version=python_version,\n    sagemaker_session=session\n)\n\npredictor = sklearn_model.deploy(\n    initial_instance_count=1,\n    instance_type=inference_instance_type\n)\n\nendpoint_name = predictor.endpoint_name\nprint(f\"   ✅ Model deployed to endpoint: {endpoint_name}\")",
    "outputs": [],
    "execution_count": null
   },
   {
    "cell_type": "code",
    "metadata": {},
-   "source": "# Test inference\nprint(\"\\n\ud83e\uddea Testing inference...\")\n\nfrom sagemaker.serializers import CSVSerializer\nfrom sagemaker.deserializers import CSVDeserializer\npredictor.serializer = CSVSerializer()\npredictor.deserializer = CSVDeserializer()\n\n# Test data with 20 features (matching training)\nimport numpy as np\ntest_data = np.random.randn(2, 20).tolist()\n\ntry:\n    predictions = predictor.predict(test_data)\n    print(f\"   Test input shape: {len(test_data)}x{len(test_data[0])}\")\n    print(f\"   Predictions: {predictions}\")\n    print(\"   \u2705 Inference successful\")\nexcept Exception as e:\n    print(f\"   \u26a0\ufe0f  Inference test failed: {e}\")",
+   "source": "# Test inference\nprint(\"\\n🧪 Testing inference...\")\n\nfrom sagemaker.serializers import CSVSerializer\nfrom sagemaker.deserializers import CSVDeserializer\npredictor.serializer = CSVSerializer()\npredictor.deserializer = CSVDeserializer()\n\n# Test data with 20 features (matching training)\nimport numpy as np\ntest_data = np.random.randn(2, 20).tolist()\n\ntry:\n    predictions = predictor.predict(test_data)\n    print(f\"   Test input shape: {len(test_data)}x{len(test_data[0])}\")\n    print(f\"   Predictions: {predictions}\")\n    print(\"   ✅ Inference successful\")\nexcept Exception as e:\n    print(f\"   ⚠️  Inference test failed: {e}\")",
    "outputs": [],
    "execution_count": null
   }

--- a/examples/analytic-workflow/ml/training/workflows/ml_training_notebook.ipynb
+++ b/examples/analytic-workflow/ml/training/workflows/ml_training_notebook.ipynb
@@ -237,6 +237,7 @@
     "    role=role,\n",
     "    output_path=output_path,\n",
     "    environment=env_vars,\n",
+    "    sagemaker_session=session,\n",
     "    hyperparameters={\n",
     "        'n-estimators': 100, \n",
     "        'max-depth': 10, \n",


### PR DESCRIPTION
## Summary

Follow-up to #134. After the region injection fix, three notebooks were still failing because SageMaker SDK objects were created without an explicit `boto_session`, causing `NoRegionError` in the execution environment.

## Changes

**ml/training** (`ml_training_notebook.ipynb`)
- Added `sagemaker_session=session` to `SKLearn()` call — the session was already created with the correct region but wasn't being passed to the estimator

**ml/deployment** (`ml_deployment_notebook.ipynb`)
- Changed `sagemaker.Session(default_bucket=bucket)` to `sagemaker.Session(boto_session=boto3.Session(region_name=region), default_bucket=bucket)` so the session uses the injected region

**genai** (`bedrock_agent_notebook.ipynb`)
- Added `os.environ['AWS_DEFAULT_REGION'] = region` before the `from utils.bedrock_agent import Agent` import — the `bedrock_agent.py` utility creates all boto3 clients at module import time without an explicit region, so setting the env var ensures they all pick up the correct region