### PR TITLE
fix: update genai workflow to use claude-sonnet-4-6 model

### DIFF
--- a/examples/analytic-workflow/genai/workflows/bedrock_agent_notebook.ipynb
+++ b/examples/analytic-workflow/genai/workflows/bedrock_agent_notebook.ipynb
@@ -31,7 +31,7 @@
    "source": [
     "# Parameters cell - will be replaced by Papermill\n",
     "agent_name = \"calculator_agent\"\n",
-    "agent_llm = \"us.anthropic.claude-3-5-sonnet-20241022-v2:0\"\n",
+    "agent_llm = \"us.anthropic.claude-sonnet-4-6\"\n",
     "force_recreate = True\n",
     "kb_name = \"mortgage-kb\"\n",
     "region = None  # AWS region - injected via domain.region\n"

--- a/examples/analytic-workflow/genai/workflows/genai_dev_workflow.yaml
+++ b/examples/analytic-workflow/genai/workflows/genai_dev_workflow.yaml
@@ -8,7 +8,7 @@ genai_dev_workflow:
         input_path: "genai/bundle/workflows/bedrock_agent_notebook.ipynb"
         input_params:
           agent_name: "calculator_agent"
-          agent_llm: "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+          agent_llm: "us.anthropic.claude-sonnet-4-6"
           force_recreate: "True"
           kb_name: "mortgage-kb"
           region: "{domain.region}"


### PR DESCRIPTION
## Summary

`us.anthropic.claude-3-5-sonnet-20241022-v2:0` is no longer accessible in this account — it returns `ValidationException: The provided model identifier is invalid`.

Updated to `us.anthropic.claude-sonnet-4-6`, which is the latest active Anthropic cross-region inference profile available in the account (verified working via `invoke-model` test).