### PR TITLE
fix: update default Bedrock models in bedrock_agent.py to claude-sonnet-4-6

### DIFF
--- a/examples/analytic-workflow/genai/job-code/utils/bedrock_agent.py
+++ b/examples/analytic-workflow/genai/job-code/utils/bedrock_agent.py
@@ -53,15 +53,15 @@ suffix = f"{region}-{account_id}"
 bucket_name = f"mac-workshop-{suffix}"
 agent_foundation_models = [
     "us.anthropic.claude-3-haiku-20240307-v1:0",
-    "us.anthropic.claude-3-sonnet-20240307-v1:0",
+    "us.anthropic.claude-3-sonnet-20240229-v1:0",
     "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
     "us.anthropic.claude-3-5-haiku-20241022-v1:0",
     "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
 ]
 
 # DEFAULT_AGENT_MODEL = "us.anthropic.claude-3-5-haiku-20241022-v1:0"
-DEFAULT_AGENT_MODEL = "us.anthropic.claude-3-5-sonnet-20240620-v1:0"
-DEFAULT_SUPERVISOR_MODEL = "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+DEFAULT_AGENT_MODEL = "us.anthropic.claude-sonnet-4-6"
+DEFAULT_SUPERVISOR_MODEL = "us.anthropic.claude-sonnet-4-6"
 
 # "us.anthropic.claude-3-5-sonnet-20240620-v1:0"
 # "us.anthropic.claude-3-5-sonnet-20241022-v1:0"


### PR DESCRIPTION
## Summary

`DEFAULT_AGENT_MODEL` and `DEFAULT_SUPERVISOR_MODEL` in `bedrock_agent.py` were set to `us.anthropic.claude-3-5-sonnet-20241022-v2:0` which is no longer accessible in this account (returns `ValidationException: The provided model identifier is invalid`).

Updated both defaults to `us.anthropic.claude-sonnet-4-6`, the latest active cross-region inference profile (verified working).