### PR TITLE
chore(catalog-import-export): update manifest domain tag for production

### DIFF
--- a/examples/catalog-import-export/manifest.yaml
+++ b/examples/catalog-import-export/manifest.yaml
@@ -35,7 +35,7 @@ stages:
     domain:
       region: ${PROD_DOMAIN_REGION}
       tags:
-        purpose: smus-cicd-testing
+        purpose: smus-cicd-production
     project:
       name: prod-catalog-project
       profileName: All capabilities


### PR DESCRIPTION
- Change domain purpose tag from 'smus-cicd-testing' to 'smus-cicd-production'
- Aligns manifest configuration with production deployment requirements


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
