### PR TITLE
feat: Add IdC domain support for data-notebooks, ML training, and ML deployment examples

### DIFF
--- a/.github/workflows/analytic-data-notebooks.yml
+++ b/.github/workflows/analytic-data-notebooks.yml
@@ -31,5 +31,5 @@ jobs:
     secrets:
       AWS_ROLE_ARN_TEST: ${{ secrets.AWS_ROLE_ARN_TEST }}
     with:
-      manifest_path: 'examples/analytic-workflow/data-notebooks/manifest.yaml'
+      manifest_path: 'examples/analytic-workflow/data-notebooks/manifest-idc.yaml'
       test_target: 'test-idc'

--- a/.github/workflows/analytic-ml-training.yml
+++ b/.github/workflows/analytic-ml-training.yml
@@ -32,6 +32,6 @@ jobs:
     secrets:
       AWS_ROLE_ARN_TEST: ${{ secrets.AWS_ROLE_ARN_TEST }}
     with:
-      manifest_path: 'examples/analytic-workflow/ml/training/manifest.yaml'
+      manifest_path: 'examples/analytic-workflow/ml/training/manifest-idc.yaml'
       test_target: 'test-idc'
       setup_mlflow: true

--- a/.github/workflows/smus-bundle-deploy.yml
+++ b/.github/workflows/smus-bundle-deploy.yml
@@ -175,7 +175,7 @@ jobs:
       - name: Upload bundle artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.event.repository.name }}-bundle
+          name: ${{ github.event.repository.name }}-bundle-${{ inputs.bundle_from_target }}
           path: ${{ env.BUNDLE_DIR }}/*.zip
           if-no-files-found: error
 
@@ -218,7 +218,7 @@ jobs:
           echo "🔍 TEST_DOMAIN_REGION: $TEST_DOMAIN_REGION"
           echo "🔍 AWS_REGION: $AWS_REGION"
           
-          aws-smus-cicd-cli describe --manifest ${{ inputs.manifest_path }} --targets test --connect
+          aws-smus-cicd-cli describe --manifest ${{ inputs.manifest_path }} --targets ${{ inputs.test_target }} --connect
 
   deploy-test:
     name: Deploy to Test
@@ -233,7 +233,7 @@ jobs:
       - name: Download bundle artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ github.event.repository.name }}-bundle
+          name: ${{ github.event.repository.name }}-bundle-${{ inputs.bundle_from_target }}
           path: ${{ runner.temp }}/smus-bundles-${{ github.run_id }}
       
       - name: Set up Python
@@ -353,15 +353,51 @@ jobs:
         run: |
           
           
-          # Extract workflow name from manifest path
-          WORKFLOW_NAME=$(basename $(dirname ${{ inputs.manifest_path }}))
-          FULL_WORKFLOW_NAME="IntegrationTest${WORKFLOW_NAME^}_test_marketing_*"
+          # Extract workflow name from manifest
+          echo "📥 Downloading workflow output notebooks..."
+          python3 << 'EOF'
+          import yaml
+          import subprocess
+          import sys
           
-          echo "📥 Downloading outputs for workflow: $FULL_WORKFLOW_NAME"
-          python3 tests/scripts/download_workflow_outputs_from_xcom.py \
-            "$FULL_WORKFLOW_NAME" \
-            --region ${{ vars.DOMAIN_REGION }} \
-            --output-dir tests/test-outputs/notebooks || echo "⚠️ No outputs found or download failed"
+          manifest_path = "${{ inputs.manifest_path }}"
+          test_target = "${{ inputs.test_target }}"
+          region = "${{ vars.DOMAIN_REGION }}"
+          
+          try:
+              with open(manifest_path, 'r') as f:
+                  manifest = yaml.safe_load(f)
+              
+              app_name = manifest.get('applicationName', '')
+              stages = manifest.get('stages', {})
+              target_config = stages.get(test_target, {})
+              project_name = target_config.get('project', {}).get('name', '')
+              workflows = manifest.get('content', {}).get('workflows', [])
+              
+              if not workflows or not project_name:
+                  print("No workflows or project name found in manifest")
+                  sys.exit(0)
+              
+              for workflow in workflows:
+                  workflow_name = workflow.get('workflowName', '')
+                  if workflow_name:
+                      full_name = f"{app_name}_{project_name}_{workflow_name}"
+                      print(f"📥 Downloading outputs for: {full_name}")
+                      result = subprocess.run([
+                          'python3', 'tests/scripts/download_workflow_outputs_from_xcom.py',
+                          full_name,
+                          '--region', region,
+                          '--output-dir', 'tests/test-outputs/notebooks'
+                      ], capture_output=True, text=True)
+                      if result.stdout:
+                          print(result.stdout)
+                      if result.returncode == 0:
+                          print(f"✅ Downloaded outputs for {workflow_name}")
+                      else:
+                          print(f"⚠️ No outputs found for {workflow_name}")
+          except Exception as e:
+              print(f"⚠️ Error downloading notebooks: {e}")
+          EOF
 
   test:
     name: Run Tests
@@ -427,7 +463,7 @@ jobs:
       - name: Download bundle artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ github.event.repository.name }}-bundle
+          name: ${{ github.event.repository.name }}-bundle-${{ inputs.bundle_from_target }}
           path: ${{ runner.temp }}/smus-bundles-${{ github.run_id }}
       
       - name: Set up Python

--- a/.github/workflows/smus-direct-deploy.yml
+++ b/.github/workflows/smus-direct-deploy.yml
@@ -152,54 +152,52 @@ jobs:
         run: |
           
           
-          # Extract workflow names from manifest
+          # Extract workflow name from manifest
+          echo "📥 Downloading workflow output notebooks..."
           python3 << 'EOF'
           import yaml
+          import subprocess
           import sys
+          import os
           
           manifest_path = "${{ inputs.manifest_path }}"
+          test_target = "${{ inputs.test_target }}"
+          region = "${{ vars.DOMAIN_REGION }}"
+          
           try:
+              # Resolve env vars in manifest
               with open(manifest_path, 'r') as f:
-                  manifest = yaml.safe_load(f)
+                  manifest = yaml.safe_load(f.read())
               
               app_name = manifest.get('applicationName', '')
+              stages = manifest.get('stages', {})
+              target_config = stages.get(test_target, {})
+              project_name = target_config.get('project', {}).get('name', '')
               workflows = manifest.get('content', {}).get('workflows', [])
               
-              if not workflows:
-                  print("No workflows found in manifest")
+              if not workflows or not project_name:
+                  print("No workflows or project name found in manifest")
                   sys.exit(0)
               
-              # Get project name from test target
-              project_name = "${{ inputs.test_target }}-marketing"
-              
-              # Download outputs for each workflow
               for workflow in workflows:
                   workflow_name = workflow.get('workflowName', '')
                   if workflow_name:
                       full_name = f"{app_name}_{project_name}_{workflow_name}"
-                      print(f"📥 Downloading outputs for workflow: {full_name}")
-                      
-                      import subprocess
+                      print(f"📥 Downloading outputs for: {full_name}")
                       result = subprocess.run([
                           'python3', 'tests/scripts/download_workflow_outputs_from_xcom.py',
                           full_name,
-                          '--region', '${{ vars.DOMAIN_REGION }}',
+                          '--region', region,
                           '--output-dir', 'tests/test-outputs/notebooks'
                       ], capture_output=True, text=True)
-                      
                       if result.stdout:
                           print(result.stdout)
-                      if result.stderr:
-                          print(result.stderr)
-                      
                       if result.returncode == 0:
                           print(f"✅ Downloaded outputs for {workflow_name}")
                       else:
                           print(f"⚠️ No outputs found for {workflow_name}")
-          
           except Exception as e:
-              print(f"❌ Error downloading notebooks: {e}")
-              sys.exit(0)  # Don't fail the workflow
+              print(f"⚠️ Error downloading notebooks: {e}")
           EOF
 
       - name: Upload workflow output notebooks

--- a/examples/analytic-workflow/data-notebooks/idc_domain_project_setup.py
+++ b/examples/analytic-workflow/data-notebooks/idc_domain_project_setup.py
@@ -381,7 +381,7 @@ def main():
     )
     parser.add_argument(
         "--manifest",
-        default="examples/analytic-workflow/data-notebooks/manifest.yaml",
+        default="examples/analytic-workflow/data-notebooks/manifest-idc.yaml",
         help="Path to manifest YAML",
     )
     parser.add_argument("--stage", default=STAGE_NAME, help="Stage name (default: test-idc)")

--- a/examples/analytic-workflow/data-notebooks/manifest-idc.yaml
+++ b/examples/analytic-workflow/data-notebooks/manifest-idc.yaml
@@ -1,4 +1,4 @@
-applicationName: IntegrationTestNotebooks
+applicationName: IntegrationTestNotebooksIdC
 content:
   storage:
   - name: notebooks
@@ -14,16 +14,14 @@ content:
   - workflowName: notebooks_workflow
     connectionName: default.workflow_serverless
 stages:
-  test:
+  test-idc:
     stage: TEST
     domain:
-      tags:
-        purpose: smus-cicd-testing
+      name: smus-idc-test-domain
       region: ${TEST_DOMAIN_REGION}
     project:
       name: test-marketing
       owners:
-      - Eng1
       - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests
       - arn:aws:iam::${AWS_ACCOUNT_ID}:role/Admin
     environment_variables:
@@ -42,7 +40,14 @@ stages:
         name: mlflow-server
         connection_type: MLFLOW
         properties:
-          trackingServerArn: arn:aws:sagemaker:${TEST_DOMAIN_REGION}:${AWS_ACCOUNT_ID}:mlflow-tracking-server/${MLFLOW_TRACKING_SERVER_NAME:smus-integration-mlflow-use2}
+          trackingServerArn: arn:aws:sagemaker:${TEST_DOMAIN_REGION}:${AWS_ACCOUNT_ID}:mlflow-tracking-server/${MLFLOW_TRACKING_SERVER_NAME:smus-integration-mlflow-use1}
+      - type: datazone.create_connection
+        name: default.spark
+        connection_type: SPARK_GLUE
+        properties:
+          glue_version: "5.0"
+          worker_type: G.1X
+          num_workers: 10
       - type: workflow.create
         workflowName: notebooks_workflow
       - type: workflow.run

--- a/examples/analytic-workflow/ml/deployment/manifest-idc.yaml
+++ b/examples/analytic-workflow/ml/deployment/manifest-idc.yaml
@@ -1,4 +1,4 @@
-applicationName: IntegrationTestMLDeployment
+applicationName: IntegrationTestMLDeploymentIdC
 content:
   storage:
   - name: deployment-code

--- a/examples/analytic-workflow/ml/training/app_tests/test_model_registration.py
+++ b/examples/analytic-workflow/ml/training/app_tests/test_model_registration.py
@@ -5,16 +5,43 @@ from botocore.exceptions import ClientError
 from datetime import datetime, timedelta, timezone
 
 
-def test_model_registered():
+def test_model_registered(smus_config):
     """Verify that model artifacts were created in S3 and registered in SageMaker Model Registry."""
-    region = os.environ.get("DOMAIN_REGION", "us-east-1")
+    region = smus_config.get("region", os.environ.get("DOMAIN_REGION", "us-east-1"))
+    account_id = smus_config.get("account_id", "")
+    domain_id = smus_config.get("domain_id", "")
+    project_id = smus_config.get("project_id", "")
+
     s3_client = boto3.client("s3", region_name=region)
     sagemaker_client = boto3.client("sagemaker", region_name=region)
-    
-    # Check for model artifacts at the expected path
-    model_key = "shared/ml/output/model-artifacts/latest/output/model.tar.gz"
-    
-    # Find the project bucket by checking which one has the model artifacts
+
+    # Determine the correct S3 key prefix based on domain type
+    # IdC domains use: dzd-.../project-id/shared/...
+    # IAM domains use: shared/...
+    base_prefix = "shared/"
+    if domain_id and project_id:
+        # Check if this is an IdC domain by looking for a bucket with the domain prefix
+        response = s3_client.list_buckets()
+        for bucket in response["Buckets"]:
+            if "amazon-sagemaker" not in bucket["Name"] or region not in bucket["Name"]:
+                continue
+            try:
+                idc_prefix = f"{domain_id}/{project_id}/shared/"
+                s3_client.list_objects_v2(
+                    Bucket=bucket["Name"], Prefix=idc_prefix, MaxKeys=1
+                )
+                resp = s3_client.list_objects_v2(
+                    Bucket=bucket["Name"], Prefix=idc_prefix, MaxKeys=1
+                )
+                if resp.get("KeyCount", 0) > 0:
+                    base_prefix = idc_prefix
+                    break
+            except ClientError:
+                continue
+
+    model_key = f"{base_prefix}ml/output/model-artifacts/latest/output/model.tar.gz"
+
+    # Find the project bucket
     response = s3_client.list_buckets()
     project_bucket = None
     for bucket in response["Buckets"]:
@@ -25,25 +52,25 @@ def test_model_registered():
                 break
             except ClientError:
                 continue
-    
+
     assert project_bucket, f"No SageMaker bucket with model artifacts found at {model_key}"
-    
+
     obj = s3_client.head_object(Bucket=project_bucket, Key=model_key)
     last_modified = obj["LastModified"]
     size = obj["ContentLength"]
-    
+
     # Verify model was created recently (within last 2 hours)
     cutoff_time = datetime.now(timezone.utc) - timedelta(hours=2)
-    
+
     print(f"✓ Model artifact found: s3://{project_bucket}/{model_key}")
     print(f"✓ Last modified: {last_modified}")
     print(f"✓ Size: {size:,} bytes")
     print(f"✓ Region: {region}")
-    
+
     assert last_modified > cutoff_time, f"Model artifact is too old: {last_modified}"
     assert size > 0, "Model artifact is empty"
-    
-    print(f"✓ Model artifact is recent and valid")
+
+    print("✓ Model artifact is recent and valid")
     
     # Verify model is registered in SageMaker Model Registry
     model_groups = sagemaker_client.list_model_package_groups(

--- a/examples/analytic-workflow/ml/training/idc_domain_project_setup.py
+++ b/examples/analytic-workflow/ml/training/idc_domain_project_setup.py
@@ -142,7 +142,7 @@ def setup_cw_logs_permissions(role_name, region, dry_run=False):
 
 def main():
     parser = argparse.ArgumentParser(description="Setup IdC domain for ML training example")
-    parser.add_argument("--manifest", default="examples/analytic-workflow/ml/training/manifest.yaml")
+    parser.add_argument("--manifest", default="examples/analytic-workflow/ml/training/manifest-idc.yaml")
     parser.add_argument("--stage", default=STAGE_NAME)
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()

--- a/examples/analytic-workflow/ml/training/manifest-idc.yaml
+++ b/examples/analytic-workflow/ml/training/manifest-idc.yaml
@@ -1,52 +1,49 @@
-applicationName: IntegrationTestNotebooks
+# ML Training Application Manifest (IdC Domains)
+applicationName: IntegrationTestMLTrainingIdC
 content:
   storage:
-  - name: notebooks
+  - name: training-code
     include:
-    - notebooks/
-    exclude:
-    - .ipynb_checkpoints/
-    - __pycache__/
-  - name: workflows
+    - code
+  - name: training-workflows
     include:
-    - workflows/
+    - workflows
   workflows:
-  - workflowName: notebooks_workflow
+  - workflowName: ml_training_workflow
     connectionName: default.workflow_serverless
 stages:
-  test:
+  test-idc:
     stage: TEST
     domain:
-      tags:
-        purpose: smus-cicd-testing
+      name: smus-idc-test-domain
       region: ${TEST_DOMAIN_REGION}
     project:
       name: test-marketing
       owners:
-      - Eng1
       - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests
       - arn:aws:iam::${AWS_ACCOUNT_ID}:role/Admin
     environment_variables:
       S3_PREFIX: test
     deployment_configuration:
       storage:
-      - name: notebooks
+      - name: training-code
         connectionName: default.s3_shared
-        targetDirectory: notebooks/bundle/notebooks
-      - name: workflows
+        targetDirectory: ml/bundle/training-code
+        compression: gz
+      - name: training-workflows
         connectionName: default.s3_shared
-        targetDirectory: notebooks/bundle/workflows
+        targetDirectory: ml/bundle/training-workflows
     bootstrap:
       actions:
       - type: datazone.create_connection
         name: mlflow-server
         connection_type: MLFLOW
         properties:
-          trackingServerArn: arn:aws:sagemaker:${TEST_DOMAIN_REGION}:${AWS_ACCOUNT_ID}:mlflow-tracking-server/${MLFLOW_TRACKING_SERVER_NAME:smus-integration-mlflow-use2}
+          trackingServerArn: arn:aws:sagemaker:${TEST_DOMAIN_REGION}:${AWS_ACCOUNT_ID}:mlflow-tracking-server/${MLFLOW_TRACKING_SERVER_NAME:smus-integration-mlflow-us-east-1}
       - type: workflow.create
-        workflowName: notebooks_workflow
+        workflowName: ml_training_workflow
       - type: workflow.run
-        workflowName: notebooks_workflow
+        workflowName: ml_training_workflow
         trailLogs: true
 tests:
-  folder: examples/analytic-workflow/data-notebooks/app_tests/
+  folder: examples/analytic-workflow/ml/training/app_tests/

--- a/examples/analytic-workflow/ml/training/manifest.yaml
+++ b/examples/analytic-workflow/ml/training/manifest.yaml
@@ -59,39 +59,6 @@ stages:
       - type: workflow.run
         workflowName: ml_training_workflow
         trailLogs: true
-  test-idc:
-    stage: TEST
-    domain:
-      name: smus-idc-test-domain
-      region: ${TEST_DOMAIN_REGION}
-    project:
-      name: test-marketing
-      owners:
-      - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests
-      - arn:aws:iam::${AWS_ACCOUNT_ID}:role/Admin
-    environment_variables:
-      S3_PREFIX: test
-    deployment_configuration:
-      storage:
-      - name: training-code
-        connectionName: default.s3_shared
-        targetDirectory: ml/bundle/training-code
-        compression: gz
-      - name: training-workflows
-        connectionName: default.s3_shared
-        targetDirectory: ml/bundle/training-workflows
-    bootstrap:
-      actions:
-      - type: datazone.create_connection
-        name: mlflow-server
-        connection_type: MLFLOW
-        properties:
-          trackingServerArn: arn:aws:sagemaker:${TEST_DOMAIN_REGION}:${AWS_ACCOUNT_ID}:mlflow-tracking-server/${MLFLOW_TRACKING_SERVER_NAME:smus-integration-mlflow-us-east-1}
-      - type: workflow.create
-        workflowName: ml_training_workflow
-      - type: workflow.run
-        workflowName: ml_training_workflow
-        trailLogs: true
 tests:
   folder: examples/analytic-workflow/ml/training/app_tests/
 # Trigger workflow - test domain_name fix

--- a/examples/analytic-workflow/ml/training/workflows/ml_training_workflow.yaml
+++ b/examples/analytic-workflow/ml/training/workflows/ml_training_workflow.yaml
@@ -3,7 +3,7 @@ ml_training_workflow:
   tasks:
     ml_training_notebook:
       operator: "airflow.providers.amazon.aws.operators.sagemaker_unified_studio.SageMakerNotebookOperator"
-      retries: 0
+      retries: 1
       input_config:
         input_path: "ml/bundle/training-workflows/ml_training_notebook.ipynb"
         input_params:


### PR DESCRIPTION
## Summary

Adds IAM Identity Center (IdC) domain support for three example workflows: data-notebooks, ML training, and ML deployment.

## Changes

### IdC Domain Support
- Separate `manifest-idc.yaml` files for each example with distinct `applicationName` to avoid MWAA workflow collisions
- IdC-compatible notebook code: IAM connection fallback (`default.iam` → `project.iam`), dynamic S3 prefix from connection, correct bucket extraction
- Setup scripts for IdC domain infrastructure (`idc_domain_project_setup.py`): VPC networking, Lake Formation permissions, MLflow/CW Logs inline policies
- `deploy-idc` jobs in GitHub workflows for parallel IAM + IdC deployments

### CI/CD Fixes
- Fix hardcoded `--targets test` in `smus-bundle-deploy.yml` validate step (now uses `test_target` input)
- Fix bundle artifact name collision when IAM and IdC jobs run in parallel
- Fix notebook output download to read project name from manifest instead of hardcoding
- Bump ML training/deployment workflow retries to 1 (kernel timeout on first run)

### Documentation
- Replace "IAM Domains Only" banner with "IAM + IdC Domains" across README and all translations
- Add IdC Domain Setup section to main README with setup script references
- Update quickstart and admin-quickstart prerequisites

## Testing
- All three examples (data-notebooks, ML training, ML deployment) tested successfully on IdC domain in test account (372123585851) and prod account (062718313821)
- IAM domain workflows unaffected