### PR TITLE
refactor: centralize boto3 client creation with create_client helper …

### DIFF
--- a/src/smus_cicd/bootstrap/handlers/datazone_handler.py
+++ b/src/smus_cicd/bootstrap/handlers/datazone_handler.py
@@ -2,10 +2,10 @@
 
 from typing import Any, Dict
 
-import boto3
 import typer
 
 from ...helpers import connections, datazone
+from ...helpers.boto3_client import create_client
 from ...helpers.connection_creator import ConnectionCreator
 from ...helpers.logger import get_logger
 from ..models import BootstrapAction
@@ -87,7 +87,7 @@ def create_connection(
 
     # Use first environment for creation
     environment_id = environments[0].get("id")
-    datazone_client = boto3.client("datazone", region_name=region)
+    datazone_client = create_client("datazone", region=region)
 
     # Check if connection already exists using the connections helper
     # This properly checks both project-level and all environment-level connections

--- a/src/smus_cicd/bootstrap/handlers/quicksight_handler.py
+++ b/src/smus_cicd/bootstrap/handlers/quicksight_handler.py
@@ -38,9 +38,9 @@ def refresh_dataset(action: BootstrapAction, context: Dict[str, Any]) -> Dict[st
         raise ValueError("Missing target_config in context")
 
     # Get AWS account ID from current session
-    import boto3
+    from ...helpers.boto3_client import create_client
 
-    aws_account_id = boto3.client("sts").get_caller_identity()["Account"]
+    aws_account_id = create_client("sts").get_caller_identity()["Account"]
 
     # Get parameters
     refresh_scope = action.parameters.get("refreshScope", "IMPORTED")

--- a/src/smus_cicd/bootstrap/handlers/workflow_create_handler.py
+++ b/src/smus_cicd/bootstrap/handlers/workflow_create_handler.py
@@ -4,10 +4,10 @@ import os
 import tempfile
 from typing import Any, Dict
 
-import boto3
 import typer
 
 from ...helpers import airflow_serverless, datazone
+from ...helpers.boto3_client import create_client
 from ...helpers.bundle_storage import ensure_bundle_local
 from ..models import BootstrapAction
 
@@ -115,7 +115,7 @@ def handle_workflow_create(
 
     typer.echo(f"🔍 Using execution role for workflows: {role_arn}")
 
-    s3_client = boto3.client("s3", region_name=region)
+    s3_client = create_client("s3", region=region)
     workflows_created = []
 
     # Find DAG files in S3

--- a/src/smus_cicd/commands/bundle.py
+++ b/src/smus_cicd/commands/bundle.py
@@ -8,11 +8,11 @@ import tempfile
 import zipfile
 from typing import Optional
 
-import boto3
 import typer
 
 from ..application import ApplicationManifest
 from ..helpers import deployment
+from ..helpers.boto3_client import create_client
 from ..helpers.utils import get_datazone_project_info, load_config
 
 
@@ -177,7 +177,7 @@ def bundle_command(
         with tempfile.TemporaryDirectory(prefix="smus_bundle_") as temp_bundle_dir:
             total_files_added = 0
 
-            s3_client = boto3.client("s3", region_name=region)
+            s3_client = create_client("s3", region=region)
 
             # Process storage bundles (unified - includes workflows)
             storage_bundles = (
@@ -297,7 +297,7 @@ def bundle_command(
                 if not aws_account_id:
                     # Try to get from STS
                     try:
-                        sts = boto3.client("sts", region_name=region)
+                        sts = create_client("sts", region=region)
                         aws_account_id = sts.get_caller_identity()["Account"]
                     except Exception:
                         typer.echo(

--- a/src/smus_cicd/commands/create.py
+++ b/src/smus_cicd/commands/create.py
@@ -3,9 +3,10 @@
 from pathlib import Path
 from typing import List, Optional, Tuple
 
-import boto3
 import typer
 from botocore.exceptions import ClientError
+
+from ..helpers.boto3_client import create_client
 
 
 def create_command(
@@ -163,7 +164,7 @@ def _fetch_aws_resource_names(
     Raises:
         ClientError: If AWS API calls fail
     """
-    datazone_client = boto3.client("datazone", region_name=region)
+    datazone_client = create_client("datazone", region=region)
 
     # Get domain info
     domain_response = datazone_client.get_domain(identifier=domain_id)

--- a/src/smus_cicd/commands/deploy.py
+++ b/src/smus_cicd/commands/deploy.py
@@ -16,11 +16,11 @@ import zipfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-import boto3
 import typer
 
 from ..application import ApplicationManifest
 from ..helpers import datazone, deployment
+from ..helpers.boto3_client import create_client
 from ..helpers.error_handler import handle_error, handle_success
 from ..helpers.project_manager import ProjectManager
 from ..helpers.utils import (  # noqa: F401
@@ -33,7 +33,7 @@ from ..helpers.utils import (  # noqa: F401
 def _fix_airflow_role_cloudwatch_policy(role_arn: str, region: str) -> bool:
     """Fix IAM role by adding CloudWatch logs policy for airflow-serverless."""
     try:
-        iam = boto3.client("iam", region_name=region)
+        iam = create_client("iam", region=region)
 
         # Extract role name from ARN
         role_name = role_arn.split("/")[-1]
@@ -633,13 +633,12 @@ def _resolve_and_upload_workflows(
     """Resolve variables in workflow YAML files and re-upload to S3."""
     import tempfile
 
-    import boto3
     import yaml
 
     from ..helpers.context_resolver import ContextResolver
 
     region = config.get("region", "us-east-1")
-    s3_client = boto3.client("s3", region_name=region)
+    s3_client = create_client("s3", region=region)
     project_name = target_config.project.name
 
     # Get domain_id from project_info
@@ -1823,8 +1822,6 @@ def _upload_dag_to_s3(
         S3 location dictionary or None if failed
     """
     try:
-        import boto3
-
         region = config.get("region", "us-east-1")
 
         # Get S3 bucket from project's default.s3_shared connection
@@ -1843,7 +1840,7 @@ def _upload_dag_to_s3(
         if not bucket_name:
             account_id = config.get("aws", {}).get("account_id")
             if not account_id:
-                sts = boto3.client("sts")
+                sts = create_client("sts")
                 identity = sts.get_caller_identity()
                 account_id = identity["Account"]
             bucket_name = f"smus-airflow-serverless-{account_id}-{region}"
@@ -1851,7 +1848,7 @@ def _upload_dag_to_s3(
         object_key = f"workflows/{workflow_name}.yaml"
 
         # Create S3 client
-        s3_client = boto3.client("s3", region_name=region)
+        s3_client = create_client("s3", region=region)
 
         # Try to create bucket if it doesn't exist
         try:
@@ -2032,9 +2029,7 @@ def _deploy_quicksight_dashboards(
     if not aws_account_id:
         # Try to get from STS
         try:
-            import boto3
-
-            sts = boto3.client("sts", region_name=region)
+            sts = create_client("sts", region=region)
             aws_account_id = sts.get_caller_identity()["Account"]
         except Exception:
             typer.echo(
@@ -2214,7 +2209,6 @@ def _deploy_quicksight_dashboards(
                     typer.echo(f"      Dashboard: {imported_dashboard_id}")
 
                 # List imported datasets and data sources
-                import boto3
 
                 # Find all resources with this prefix using shared helper
                 from ..helpers.quicksight import find_resources_by_prefix

--- a/src/smus_cicd/commands/describe.py
+++ b/src/smus_cicd/commands/describe.py
@@ -2,10 +2,10 @@
 
 import json
 
-import boto3
 import typer
 
 from ..application import ApplicationManifest
+from ..helpers.boto3_client import create_client
 from ..helpers.utils import (  # noqa: F401
     build_domain_config,
     get_datazone_project_info,
@@ -207,7 +207,7 @@ def describe_command(
                                             and "ListConnections" in conn_info
                                         ):
                                             try:
-                                                sts_client = boto3.client("sts")
+                                                sts_client = create_client("sts")
                                                 identity = (
                                                     sts_client.get_caller_identity()
                                                 )
@@ -242,7 +242,7 @@ def describe_command(
                                             and "ListConnections" in error_msg
                                         ):
                                             try:
-                                                sts_client = boto3.client("sts")
+                                                sts_client = create_client("sts")
                                                 identity = (
                                                     sts_client.get_caller_identity()
                                                 )

--- a/src/smus_cicd/commands/dry_run/checkers/catalog_checker.py
+++ b/src/smus_cicd/commands/dry_run/checkers/catalog_checker.py
@@ -17,10 +17,9 @@ import logging
 from collections import Counter
 from typing import Any, List, Set
 
-import boto3
-
 from smus_cicd.commands.dry_run.checkers import is_catalog_disabled
 from smus_cicd.commands.dry_run.models import DryRunContext, Finding, Severity
+from smus_cicd.helpers.boto3_client import create_client
 from smus_cicd.helpers.catalog_import import (
     CREATION_ORDER,
     CROSS_REFERENCE_FIELDS,
@@ -261,7 +260,7 @@ class CatalogChecker:
         if not bundle_form_types:
             return
 
-        client = boto3.client("datazone", region_name=context.target_region)
+        client = create_client("datazone", region=context.target_region)
         for ft_name in bundle_form_types:
             try:
                 resp = client.get_form_type(

--- a/src/smus_cicd/commands/dry_run/checkers/connectivity_checker.py
+++ b/src/smus_cicd/commands/dry_run/checkers/connectivity_checker.py
@@ -14,10 +14,9 @@ from __future__ import annotations
 import logging
 from typing import List, Set
 
-import boto3
-
 from smus_cicd.commands.dry_run.checkers import get_project_connections
 from smus_cicd.commands.dry_run.models import DryRunContext, Finding, Severity
+from smus_cicd.helpers.boto3_client import create_client
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +83,7 @@ class ConnectivityChecker:
             return
 
         try:
-            dz = boto3.client("datazone", region_name=region)
+            dz = create_client("datazone", region=region)
             dz.get_domain(identifier=domain_id)
             findings.append(
                 Finding(
@@ -203,7 +202,7 @@ class ConnectivityChecker:
         if not resolved:
             return
 
-        s3 = boto3.client("s3", region_name=region)
+        s3 = create_client("s3", region=region)
 
         for bucket in sorted(resolved):
             try:

--- a/src/smus_cicd/commands/dry_run/checkers/dependency_checker.py
+++ b/src/smus_cicd/commands/dry_run/checkers/dependency_checker.py
@@ -22,10 +22,9 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, List, Optional, Tuple
 
-import boto3
-
 from smus_cicd.commands.dry_run.checkers import is_catalog_disabled
 from smus_cicd.commands.dry_run.models import DryRunContext, Finding, Severity
+from smus_cicd.helpers.boto3_client import create_client
 from smus_cicd.helpers.catalog_import import (
     DATA_SOURCE_REF_FORM_TYPE,
     DATA_SOURCE_VALID_STATUSES,
@@ -114,7 +113,7 @@ class DependencyChecker:
         findings: List[Finding],
     ) -> None:
         """Validate Glue tables, views, and databases referenced by assets."""
-        glue = boto3.client("glue", region_name=region)
+        glue = create_client("glue", region=region)
 
         for asset in assets:
             asset_name = asset.get("name", "unknown")
@@ -375,7 +374,7 @@ class DependencyChecker:
         if not domain_id or not project_id:
             return
 
-        dz = boto3.client("datazone", region_name=region)
+        dz = create_client("datazone", region=region)
 
         for asset in assets:
             asset_name = asset.get("name", "unknown")
@@ -507,7 +506,7 @@ class DependencyChecker:
         if not domain_id:
             return
 
-        dz = boto3.client("datazone", region_name=region)
+        dz = create_client("datazone", region=region)
 
         for asset_type in asset_types:
             at_name = asset_type.get("name", "unknown")
@@ -583,7 +582,7 @@ class DependencyChecker:
         if not domain_id:
             return
 
-        dz = boto3.client("datazone", region_name=region)
+        dz = create_client("datazone", region=region)
 
         for asset in assets:
             asset_name = asset.get("name", "unknown")
@@ -652,7 +651,7 @@ class DependencyChecker:
         if not domain_id:
             return
 
-        dz = boto3.client("datazone", region_name=region)
+        dz = create_client("datazone", region=region)
 
         for asset in assets:
             asset_name = asset.get("name", "unknown")

--- a/src/smus_cicd/commands/dry_run/checkers/permission_checker.py
+++ b/src/smus_cicd/commands/dry_run/checkers/permission_checker.py
@@ -18,13 +18,12 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, List, Optional
 
-import boto3
-
 from smus_cicd.commands.dry_run.checkers import (
     get_project_connections,
     is_catalog_disabled,
 )
 from smus_cicd.commands.dry_run.models import DryRunContext, Finding, Severity
+from smus_cicd.helpers.boto3_client import create_client
 from smus_cicd.helpers.catalog_import import has_glue_references
 
 logger = logging.getLogger(__name__)
@@ -133,7 +132,7 @@ class PermissionChecker:
         corresponding IAM role ARN (``arn:aws:iam::ACCT:role/ROLE``).
         """
         try:
-            sts = boto3.client("sts", region_name=region)
+            sts = create_client("sts", region=region)
             identity = sts.get_caller_identity()
             caller_arn = identity["Arn"]
             findings.append(
@@ -449,7 +448,7 @@ class PermissionChecker:
         findings: List[Finding],
     ) -> None:
         """Call ``iam:SimulatePrincipalPolicy`` and record findings."""
-        iam = boto3.client("iam", region_name=region)
+        iam = create_client("iam", region=region)
 
         for resource_arn, actions in permissions_map.items():
             # De-duplicate actions for the same resource
@@ -628,7 +627,7 @@ class PermissionChecker:
 
         # --- Resolve domain_unit_id ---
         try:
-            dz = boto3.client("datazone", region_name=region)
+            dz = create_client("datazone", region=region)
             project_resp = dz.get_project(
                 domainIdentifier=domain_id, identifier=project_id
             )

--- a/src/smus_cicd/commands/run.py
+++ b/src/smus_cicd/commands/run.py
@@ -663,8 +663,7 @@ def _execute_airflow_serverless_workflows(
 
 def _get_connection_type(connection_name: str, targets: dict, manifest) -> str:
     """Get connection type from DataZone by looking it up in the first target."""
-    import boto3
-
+    from ..helpers.boto3_client import create_client
     from ..helpers.datazone import get_domain_from_target_config, get_project_id_by_name
 
     # Get first target to lookup connection
@@ -684,7 +683,7 @@ def _get_connection_type(connection_name: str, targets: dict, manifest) -> str:
             return "UNKNOWN"
 
         # List connections and find the one matching the name
-        client = boto3.client("datazone", region_name=region)
+        client = create_client("datazone", region=region)
         response = client.list_connections(
             domainIdentifier=domain_id, projectIdentifier=project_id
         )

--- a/src/smus_cicd/commands/test.py
+++ b/src/smus_cicd/commands/test.py
@@ -168,11 +168,11 @@ def test_command(
             # Get domain name from domain_id if not provided
             domain_name = target_config.domain.name
             if not domain_name and project_info.get("domainId"):
-                import boto3
+                from ..helpers.boto3_client import create_client
 
                 try:
-                    datazone_client = boto3.client(
-                        "datazone", region_name=target_config.domain.region
+                    datazone_client = create_client(
+                        "datazone", region=target_config.domain.region
                     )
                     domain_response = datazone_client.get_domain(
                         identifier=project_info["domainId"]

--- a/src/smus_cicd/helpers/airflow.py
+++ b/src/smus_cicd/helpers/airflow.py
@@ -4,9 +4,9 @@ Airflow/MWAA integration functions for SMUS CI/CD CLI.
 
 import time
 
-import boto3
 import typer
 
+from .boto3_client import create_client
 from .logger import get_logger
 
 
@@ -272,7 +272,7 @@ def wait_for_dags_available(mwaa_env_name, workflows_config, region, max_wait=90
         typer.echo("⚠️  No workflows configured")
         return False
 
-    mwaa_client = boto3.client("mwaa", region_name=region)
+    mwaa_client = create_client("mwaa", region=region)
 
     start_time = time.time()
     while time.time() - start_time < max_wait:

--- a/src/smus_cicd/helpers/airflow_serverless.py
+++ b/src/smus_cicd/helpers/airflow_serverless.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List
 import boto3
 
 from . import boto3_client
+from .boto3_client import create_client
 from .logger import get_logger
 
 # Airflow Serverless (MWAA Serverless) configuration - configurable via environment variables
@@ -47,9 +48,7 @@ def create_airflow_serverless_client(
         f"https://airflow-serverless.{region}.api.aws/"
     )
 
-    return boto3.client(
-        "mwaa-serverless", region_name=region, endpoint_url=endpoint_url
-    )
+    return create_client("mwaa-serverless", region=region, endpoint_url=endpoint_url)
 
 
 def create_workflow(

--- a/src/smus_cicd/helpers/boto3_client.py
+++ b/src/smus_cicd/helpers/boto3_client.py
@@ -16,28 +16,39 @@ def create_client(
     service_name: str,
     connection_info: Optional[Dict[str, Any]] = None,
     region: Optional[str] = None,
+    **kwargs: Any,
 ):
-    """Create a boto3 client with region determined from connection info or explicit region."""
+    """Create a boto3 client with consistent user-agent and optional region.
 
-    # Determine region based on connection info or explicit region
-    client_region = region  # Default to provided region
+    Parameters
+    ----------
+    service_name : str
+        AWS service name (e.g. ``"s3"``, ``"sts"``).
+    connection_info : dict, optional
+        DataZone connection dict; region is extracted from
+        ``physicalEndpoints[0].awsLocation.awsRegion`` when *region* is not
+        given.
+    region : str, optional
+        Explicit AWS region.  When *None* and *connection_info* does not
+        provide a region the client is created without ``region_name``
+        (useful for global services like STS).
+    **kwargs
+        Extra keyword arguments forwarded to ``boto3.client`` (e.g.
+        ``endpoint_url``).
+    """
+    client_region = region
 
     if connection_info and not client_region:
-        # Extract region from common physicalEndpoints pattern
         physical_endpoints = connection_info.get("physicalEndpoints", [])
         if physical_endpoints and len(physical_endpoints) > 0:
             aws_location = physical_endpoints[0].get("awsLocation", {})
             client_region = aws_location.get("awsRegion")
 
-    # Require explicit region - no fallback
-    if not client_region:
-        raise ValueError(
-            "Region must be provided either explicitly or through connection info"
-        )
+    client_kwargs: Dict[str, Any] = {"config": _USER_AGENT_CONFIG, **kwargs}
+    if client_region:
+        client_kwargs["region_name"] = client_region
 
-    return boto3.client(
-        service_name, region_name=client_region, config=_USER_AGENT_CONFIG
-    )
+    return boto3.client(service_name, **client_kwargs)
 
 
 def get_region_from_connection(connection_info: Dict[str, Any]) -> Optional[str]:

--- a/src/smus_cicd/helpers/boto3_client.py
+++ b/src/smus_cicd/helpers/boto3_client.py
@@ -3,6 +3,13 @@
 from typing import Any, Dict, Optional
 
 import boto3
+import botocore.config
+
+from smus_cicd import __version__
+
+_USER_AGENT_CONFIG = botocore.config.Config(
+    user_agent_extra=f"smuscicd/{__version__}",
+)
 
 
 def create_client(
@@ -28,7 +35,9 @@ def create_client(
             "Region must be provided either explicitly or through connection info"
         )
 
-    return boto3.client(service_name, region_name=client_region)
+    return boto3.client(
+        service_name, region_name=client_region, config=_USER_AGENT_CONFIG
+    )
 
 
 def get_region_from_connection(connection_info: Dict[str, Any]) -> Optional[str]:

--- a/src/smus_cicd/helpers/catalog_export.py
+++ b/src/smus_cicd/helpers/catalog_export.py
@@ -14,7 +14,7 @@ import os
 from datetime import datetime, timezone
 from typing import Any, Dict, List
 
-import boto3
+from .boto3_client import create_client
 
 logger = logging.getLogger(__name__)
 
@@ -55,8 +55,8 @@ def _get_datazone_client(region: str):
     """
     endpoint_url = os.environ.get("DATAZONE_ENDPOINT_URL")
     if endpoint_url:
-        return boto3.client("datazone", region_name=region, endpoint_url=endpoint_url)
-    return boto3.client("datazone", region_name=region)
+        return create_client("datazone", region=region, endpoint_url=endpoint_url)
+    return create_client("datazone", region=region)
 
 
 def _search_resources(

--- a/src/smus_cicd/helpers/catalog_import.py
+++ b/src/smus_cicd/helpers/catalog_import.py
@@ -16,8 +16,9 @@ import re
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
-import boto3
 from botocore.exceptions import ClientError
+
+from .boto3_client import create_client
 
 logger = logging.getLogger(__name__)
 
@@ -78,8 +79,8 @@ def _get_datazone_client(region: str):
     """
     endpoint_url = os.environ.get("DATAZONE_ENDPOINT_URL")
     if endpoint_url:
-        return boto3.client("datazone", region_name=region, endpoint_url=endpoint_url)
-    return boto3.client("datazone", region_name=region)
+        return create_client("datazone", region=region, endpoint_url=endpoint_url)
+    return create_client("datazone", region=region)
 
 
 def _validate_catalog_json(catalog_data: Dict[str, Any]) -> None:

--- a/src/smus_cicd/helpers/cloudformation.py
+++ b/src/smus_cicd/helpers/cloudformation.py
@@ -5,17 +5,17 @@ CloudFormation utility functions for SMUS CI/CD CLI.
 import json
 import time
 
-import boto3
 import typer
 
 from . import datazone
+from .boto3_client import create_client
 from .logger import get_logger
 
 
 def get_project_id_from_stack(stack_name, region):
     """Get DataZone project ID from CloudFormation stack outputs."""
     try:
-        cf_client = boto3.client("cloudformation", region_name=region)
+        cf_client = create_client("cloudformation", region=region)
         response = cf_client.describe_stacks(StackName=stack_name)
 
         if not response.get("Stacks"):
@@ -58,8 +58,8 @@ def create_project_via_cloudformation(
         logger.debug(f"profile_name={profile_name}")
         logger.debug(f"user_parameters={user_parameters}")
 
-        cf_client = boto3.client("cloudformation", region_name=region)
-        datazone_client = boto3.client("datazone", region_name=region)
+        cf_client = create_client("cloudformation", region=region)
+        datazone_client = create_client("datazone", region=region)
 
         # Convert userParameters to CloudFormation format
         user_parameters_cf = []
@@ -389,7 +389,7 @@ def create_project_via_cloudformation(
 def wait_for_project_deployment(project_name, project_id, domain_id, region):
     """Wait for project deployment to complete using DataZone API."""
     try:
-        datazone_client = boto3.client("datazone", region_name=region)
+        datazone_client = create_client("datazone", region=region)
 
         # Poll project status until it's active
         max_attempts = 60  # 30 minutes with 30-second intervals
@@ -441,7 +441,7 @@ def delete_project_stack(
         clean_project = project_name.replace("_", "-").replace(" ", "-").lower()
         stack_name = f"SMUS-{clean_pipeline}-{clean_target}-{clean_project}-project"
 
-        cf_client = boto3.client("cloudformation", region_name=region)
+        cf_client = create_client("cloudformation", region=region)
 
         if output.upper() != "JSON":
             typer.echo(f"Deleting CloudFormation stack: {stack_name}")
@@ -478,7 +478,7 @@ def delete_project_stack(
 def update_project_stack_tags(stack_name, region, tags):
     """Update CloudFormation stack tags if stack exists."""
     try:
-        cf_client = boto3.client("cloudformation", region_name=region)
+        cf_client = create_client("cloudformation", region=region)
 
         # Check if stack exists first
         try:

--- a/src/smus_cicd/helpers/connection_creator.py
+++ b/src/smus_cicd/helpers/connection_creator.py
@@ -3,7 +3,7 @@
 import time
 from typing import Any, Dict
 
-import boto3
+from .boto3_client import create_client
 
 
 class ConnectionCreator:
@@ -12,7 +12,7 @@ class ConnectionCreator:
     def __init__(self, domain_id: str, region: str = "us-east-1"):
         self.domain_id = domain_id
         self.region = region
-        self.client = boto3.client("datazone", region_name=region)
+        self.client = create_client("datazone", region=region)
 
     def create_from_config(
         self,

--- a/src/smus_cicd/helpers/datazone.py
+++ b/src/smus_cicd/helpers/datazone.py
@@ -10,8 +10,9 @@ This module provides helper functions for interacting with AWS DataZone using th
 public boto3 DataZone client. All operations use the standard DataZone API.
 """
 
-import boto3
 import typer
+
+from .boto3_client import create_client
 
 
 def _get_datazone_client(region: str):
@@ -33,8 +34,8 @@ def _get_datazone_client(region: str):
     """
     endpoint_url = os.environ.get("DATAZONE_ENDPOINT_URL")
     if endpoint_url:
-        return boto3.client("datazone", region_name=region, endpoint_url=endpoint_url)
-    return boto3.client("datazone", region_name=region)
+        return create_client("datazone", region=region, endpoint_url=endpoint_url)
+    return create_client("datazone", region=region)
 
 
 def resolve_domain_id(
@@ -936,7 +937,7 @@ def get_user_id_by_username(username, domain_id, region):
             return None
 
         # Use SSO Admin to get the Identity Store ID from the instance ARN
-        sso_admin_client = boto3.client("sso-admin", region_name=region)
+        sso_admin_client = create_client("sso-admin", region=region)
         instances_response = sso_admin_client.list_instances()
 
         identity_store_id = None
@@ -950,7 +951,7 @@ def get_user_id_by_username(username, domain_id, region):
             return None
 
         # Use Identity Center APIs to find user
-        identitystore_client = boto3.client("identitystore", region_name=region)
+        identitystore_client = create_client("identitystore", region=region)
 
         # Search for user by username
         response = identitystore_client.list_users(

--- a/src/smus_cicd/helpers/destroy_executor.py
+++ b/src/smus_cicd/helpers/destroy_executor.py
@@ -5,12 +5,12 @@ Executes resource deletion in the required dependency order for a single stage.
 
 from typing import List
 
-import boto3
 from botocore.exceptions import ClientError
 from rich.console import Console
 
 from ..helpers import s3 as s3_helper
 from ..helpers.airflow_serverless import delete_workflow
+from ..helpers.boto3_client import create_client
 from ..helpers.datazone import (
     delete_project,
     get_domain_from_target_config,
@@ -213,7 +213,7 @@ def _destroy_stage(
             )
             continue
         try:
-            dz_client = boto3.client("datazone", region_name=effective_region)
+            dz_client = create_client("datazone", region=effective_region)
             dz_client.delete_connection(
                 domainIdentifier=domain_id, identifier=connection_id
             )
@@ -263,13 +263,13 @@ def _destroy_stage(
     # Step d: Delete QuickSight (dashboards → datasets → data sources)
     # -----------------------------------------------------------------------
     try:
-        account_id = boto3.client(
-            "sts", region_name=effective_region
+        account_id = create_client(
+            "sts", region=effective_region
         ).get_caller_identity()["Account"]
     except Exception:
         account_id = None
 
-    qs_client = boto3.client("quicksight", region_name=effective_region)
+    qs_client = create_client("quicksight", region=effective_region)
 
     for qs_type in (
         "quicksight_dashboard",
@@ -439,7 +439,7 @@ def _destroy_stage(
                 )
                 continue
             try:
-                dz_client = boto3.client("datazone", region_name=effective_region)
+                dz_client = create_client("datazone", region=effective_region)
                 CATALOG_DELETE_API[catalog_type](dz_client, domain_id_cat, resource_id)
                 _log(f"  ✅ Deleted {catalog_type}: {resource_name} ({resource_id})")
                 results.append(

--- a/src/smus_cicd/helpers/destroy_validator.py
+++ b/src/smus_cicd/helpers/destroy_validator.py
@@ -6,7 +6,6 @@ detects collisions, and collects errors/warnings without aborting early.
 
 from typing import Dict, List
 
-import boto3
 import yaml
 
 from ..helpers.airflow_serverless import (
@@ -16,6 +15,7 @@ from ..helpers.airflow_serverless import (
     list_workflow_runs,
     list_workflows,
 )
+from ..helpers.boto3_client import create_client
 from ..helpers.connections import get_project_connections
 from ..helpers.datazone import get_domain_from_target_config, get_project_id_by_name
 from ..helpers.logger import get_logger
@@ -263,8 +263,8 @@ def _validate_stage(
         prefix = resolve_resource_prefix(stage_name, qs_config)
 
         try:
-            account_id = boto3.client(
-                "sts", region_name=effective_region
+            account_id = create_client(
+                "sts", region=effective_region
             ).get_caller_identity()["Account"]
         except Exception as e:
             errors.append(f"[{stage_name}] Could not get AWS account ID: {e}")
@@ -450,7 +450,7 @@ def _validate_stage(
                     _search_target_type_resources,
                 )
 
-                dz_client = boto3.client("datazone", region_name=effective_region)
+                dz_client = create_client("datazone", region=effective_region)
 
                 for item in _search_target_resources(
                     dz_client, domain_id, project_id, "GLOSSARY"

--- a/src/smus_cicd/helpers/eventbridge_client.py
+++ b/src/smus_cicd/helpers/eventbridge_client.py
@@ -3,8 +3,7 @@
 import json
 from typing import Any, Dict, List, Optional
 
-import boto3
-
+from .boto3_client import create_client
 from .logger import get_logger
 
 logger = get_logger("eventbridge_emitter")
@@ -36,7 +35,7 @@ class EventBridgeEmitter:
     def client(self):
         """Lazy-load EventBridge client."""
         if self._client is None and self.enabled:
-            self._client = boto3.client("events", region_name=self.region)
+            self._client = create_client("events", region=self.region)
         return self._client
 
     def emit_event(

--- a/src/smus_cicd/helpers/iam.py
+++ b/src/smus_cicd/helpers/iam.py
@@ -5,8 +5,9 @@ import os
 from datetime import datetime
 from typing import List, Optional
 
-import boto3
 import typer
+
+from .boto3_client import create_client
 
 logger = logging.getLogger("smus_cicd.iam")
 
@@ -52,7 +53,7 @@ def create_or_update_project_role(
     Returns:
         Role ARN (created or provided)
     """
-    iam = boto3.client("iam", region_name=region)
+    iam = create_client("iam", region=region)
 
     if role_arn:
         # Update existing role - attach additional policies

--- a/src/smus_cicd/helpers/operator_registry.py
+++ b/src/smus_cicd/helpers/operator_registry.py
@@ -9,8 +9,9 @@ Adding support for a new operator type requires only a new dict entry —
 no changes to the parser logic in the destroy command.
 """
 
-import boto3
 from botocore.exceptions import ClientError
+
+from .boto3_client import create_client
 
 
 class ResourceNotFoundError(Exception):
@@ -35,7 +36,7 @@ def _delete_glue_job(resource_name: str, region: str) -> None:
         ClientError: For any other AWS API error.
     """
     try:
-        boto3.client("glue", region_name=region).delete_job(JobName=resource_name)
+        create_client("glue", region=region).delete_job(JobName=resource_name)
     except ClientError as e:
         if e.response["Error"]["Code"] == "EntityNotFoundException":
             raise ResourceNotFoundError(f"Glue job '{resource_name}' not found")

--- a/src/smus_cicd/helpers/project_manager.py
+++ b/src/smus_cicd/helpers/project_manager.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional
 import typer
 
 from . import datazone
+from .boto3_client import create_client
 from .error_handler import handle_error, handle_success
 from .utils import get_datazone_project_info
 
@@ -170,11 +171,9 @@ class ProjectManager:
 
         # Handle role creation or policy attachment
         if policy_arns:
-            import boto3
-
             from . import iam
 
-            sts = boto3.client("sts")
+            sts = create_client("sts")
             account_id = sts.get_caller_identity()["Account"]
 
             if not role_arn:
@@ -321,11 +320,9 @@ class ProjectManager:
             policy_arns = self._get_policy_arns(target_config)
 
             if policy_arns or not role_arn:
-                import boto3
-
                 from . import iam
 
-                sts = boto3.client("sts")
+                sts = create_client("sts")
                 account_id = sts.get_caller_identity()["Account"]
 
                 if not role_arn:
@@ -379,9 +376,7 @@ class ProjectManager:
                     handle_error(str(e))
 
             # List project profiles
-            import boto3
-
-            dz_client = boto3.client("datazone", region_name=region)
+            dz_client = create_client("datazone", region=region)
             response = dz_client.list_project_profiles(domainIdentifier=domain_id)
             profiles = response.get("items", [])
 
@@ -619,9 +614,7 @@ class ProjectManager:
 
         # Replace wildcard account ID with current account
         if role_arn and ":*:" in role_arn:
-            import boto3
-
-            sts = boto3.client("sts")
+            sts = create_client("sts")
             account_id = sts.get_caller_identity()["Account"]
             role_arn = role_arn.replace(":*:", f":{account_id}:")
 
@@ -701,9 +694,7 @@ class ProjectManager:
         import json
         import time
 
-        import boto3
-
-        dz_client = boto3.client("datazone", region_name=region)
+        dz_client = create_client("datazone", region=region)
         start_time = time.time()
 
         while time.time() - start_time < max_wait_seconds:
@@ -913,9 +904,7 @@ class ProjectManager:
 
         # Get existing environments in the project
         try:
-            import boto3
-
-            datazone_client = boto3.client("datazone", region_name=region)
+            datazone_client = create_client("datazone", region=region)
 
             existing_envs_response = datazone_client.list_environments(
                 domainIdentifier=domain_id, projectIdentifier=project_id
@@ -965,9 +954,7 @@ class ProjectManager:
     ) -> bool:
         """Create a DataZone environment."""
         try:
-            import boto3
-
-            datazone_client = boto3.client("datazone", region_name=region)
+            datazone_client = create_client("datazone", region=region)
 
             # Get project details to find the project profile ID
             print(f"🔍 DEBUG: Getting project details for project: {project_id}")
@@ -1075,12 +1062,10 @@ class ProjectManager:
         try:
             import time
 
-            import boto3
-
             # Wait a bit for environment to be ready
             time.sleep(5)
 
-            datazone_client = boto3.client("datazone", region_name=region)
+            datazone_client = create_client("datazone", region=region)
 
             # Get project connections to find MWAA connection
             connections_response = datazone_client.list_project_data_sources(
@@ -1112,12 +1097,10 @@ class ProjectManager:
         ):
             return
 
-        import boto3
-
         from .connection_creator import ConnectionCreator
 
         # Get existing connections
-        datazone_client = boto3.client("datazone", region_name=region)
+        datazone_client = create_client("datazone", region=region)
         existing_conns = {}
         try:
             response = datazone_client.list_connections(
@@ -1182,9 +1165,7 @@ class ProjectManager:
             contributors = target_config.project.contributors or []
 
         # Replace wildcard account ID in IAM ARNs
-        import boto3
-
-        sts = boto3.client("sts")
+        sts = create_client("sts")
         account_id = sts.get_caller_identity()["Account"]
 
         owners = [

--- a/src/smus_cicd/helpers/quicksight.py
+++ b/src/smus_cicd/helpers/quicksight.py
@@ -5,9 +5,9 @@ import re
 import time
 from typing import Any, Dict, List, Optional
 
-import boto3
 from botocore.exceptions import ClientError
 
+from .boto3_client import create_client
 from .logger import get_logger
 
 logger = get_logger("quicksight")
@@ -62,7 +62,7 @@ def lookup_dashboard_by_name(
         QuickSightDeploymentError: If dashboard not found
     """
     try:
-        client = boto3.client("quicksight", region_name=region)
+        client = create_client("quicksight", region=region)
         response = client.list_dashboards(AwsAccountId=aws_account_id)
 
         for dashboard in response.get("DashboardSummaryList", []):
@@ -99,7 +99,7 @@ def export_dashboard(
         QuickSightDeploymentError: If export fails
     """
     try:
-        client = boto3.client("quicksight", region_name=region)
+        client = create_client("quicksight", region=region)
 
         response = client.start_asset_bundle_export_job(
             AwsAccountId=aws_account_id,
@@ -140,7 +140,7 @@ def poll_export_job(
     Raises:
         QuickSightDeploymentError: If export fails or times out
     """
-    client = boto3.client("quicksight", region_name=region)
+    client = create_client("quicksight", region=region)
     start_time = time.time()
 
     while time.time() - start_time < timeout:
@@ -198,7 +198,7 @@ def import_dashboard(
         QuickSightDeploymentError: If import fails
     """
     try:
-        client = boto3.client("quicksight", region_name=region)
+        client = create_client("quicksight", region=region)
 
         # Build job ID with application name if provided
         timestamp = int(time.time())
@@ -316,7 +316,7 @@ def poll_import_job(
     Raises:
         QuickSightDeploymentError: If import fails or times out
     """
-    client = boto3.client("quicksight", region_name=region)
+    client = create_client("quicksight", region=region)
     start_time = time.time()
 
     while time.time() - start_time < timeout:
@@ -375,7 +375,7 @@ def grant_dashboard_permissions(
         return True
 
     try:
-        client = boto3.client("quicksight", region_name=region)
+        client = create_client("quicksight", region=region)
 
         grant_permissions = []
         for perm in permissions:
@@ -426,7 +426,7 @@ def grant_dataset_permissions(
 ) -> bool:
     """Grant permissions to QuickSight dataset."""
     try:
-        client = boto3.client("quicksight", region_name=region)
+        client = create_client("quicksight", region=region)
 
         expanded_perms = []
         for perm in permissions:
@@ -457,7 +457,7 @@ def grant_data_source_permissions(
 ) -> bool:
     """Grant permissions to QuickSight data source."""
     try:
-        client = boto3.client("quicksight", region_name=region)
+        client = create_client("quicksight", region=region)
 
         expanded_perms = []
         for perm in permissions:
@@ -495,7 +495,7 @@ def grant_asset_bundle_permissions(
         region: AWS region
         principal: Principal ARN to grant permissions to
     """
-    client = boto3.client("quicksight", region_name=region)
+    client = create_client("quicksight", region=region)
 
     created_arns = import_result.get("CreatedArns", [])
 
@@ -569,8 +569,6 @@ def expand_principal_wildcards(
     Example: arn:aws:quicksight:us-east-2:*:user/default/Admin/*
     Returns: List of actual user ARNs matching the pattern
     """
-    import boto3
-
     if "*" not in principal:
         return [principal]
 
@@ -585,7 +583,7 @@ def expand_principal_wildcards(
     prefix = principal.split("user/default/")[-1].rstrip("/*")
 
     try:
-        client = boto3.client("quicksight", region_name=region)
+        client = create_client("quicksight", region=region)
         response = client.list_users(AwsAccountId=account_id, Namespace="default")
 
         expanded = []
@@ -644,7 +642,7 @@ def trigger_dataset_ingestion(
         QuickSightDeploymentError: If ingestion fails
     """
     try:
-        client = boto3.client("quicksight", region_name=region)
+        client = create_client("quicksight", region=region)
 
         # Create ingestion
         ingestion_id = f"ingestion-{int(time.time())}"
@@ -725,7 +723,7 @@ def list_dashboards(
         QuickSightDeploymentError: If listing fails
     """
     try:
-        client = boto3.client("quicksight", region_name=region)
+        client = create_client("quicksight", region=region)
         dashboards = []
         next_token = None
 
@@ -769,7 +767,7 @@ def list_data_sources(
         QuickSightDeploymentError: If listing fails
     """
     try:
-        client = boto3.client("quicksight", region_name=region)
+        client = create_client("quicksight", region=region)
         data_sources = []
         next_token = None
 
@@ -813,7 +811,7 @@ def list_datasets(
         QuickSightDeploymentError: If listing fails
     """
     try:
-        client = boto3.client("quicksight", region_name=region)
+        client = create_client("quicksight", region=region)
         datasets = []
         next_token = None
 

--- a/src/smus_cicd/helpers/test_config.py
+++ b/src/smus_cicd/helpers/test_config.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict
 
-import boto3
+from .boto3_client import create_client
 
 
 def generate_test_config(
@@ -30,7 +30,7 @@ def generate_test_config(
         Dictionary with test configuration
     """
     # Get AWS account ID
-    sts = boto3.client("sts", region_name=region)
+    sts = create_client("sts", region=region)
     account_id = sts.get_caller_identity()["Account"]
 
     config = {

--- a/src/smus_cicd/helpers/utils.py
+++ b/src/smus_cicd/helpers/utils.py
@@ -4,10 +4,10 @@ import os
 import re
 from typing import Any, Dict, List, Optional, Union
 
-import boto3
 import yaml
 
 from . import datazone
+from .boto3_client import create_client
 
 
 def build_domain_config(target_config) -> Dict[str, Any]:
@@ -118,9 +118,7 @@ def substitute_env_vars(
             # Handle pseudo environment variables
             if var_name in ("STS_ACCOUNT_ID", "AWS_ACCOUNT_ID"):
                 if resolve_aws_pseudo_vars:
-                    import boto3
-
-                    return boto3.client("sts").get_caller_identity()["Account"]
+                    return create_client("sts").get_caller_identity()["Account"]
                 # Fall back to env var, then leave placeholder as-is
                 return os.getenv(var_name) or match.group(0)
 
@@ -239,7 +237,7 @@ def get_domain_id(config: Dict[str, Any]) -> Optional[str]:
     region = _get_region_from_config(config)
     domain_stack_name = config.get("stacks", {}).get("domain", "cicd-test-domain-stack")
 
-    cf_client = boto3.client("cloudformation", region_name=region)
+    cf_client = create_client("cloudformation", region=region)
 
     try:
         # Get stack outputs

--- a/src/smus_cicd/helpers/workflow_utils.py
+++ b/src/smus_cicd/helpers/workflow_utils.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, Optional
 
-import boto3
+from .boto3_client import create_client
 
 
 def get_connection_type(
@@ -21,7 +21,7 @@ def get_connection_type(
         Connection type (e.g., 'WORKFLOWS_SERVERLESS', 'WORKFLOWS_MWAA') or None
     """
     try:
-        client = boto3.client("datazone", region_name=region)
+        client = create_client("datazone", region=region)
         response = client.list_connections(
             domainIdentifier=domain_id, projectIdentifier=project_id
         )

--- a/tests/test_deploy_yaml_resolution.py
+++ b/tests/test_deploy_yaml_resolution.py
@@ -1,140 +1,81 @@
-"""Test that YAML files are resolved during deploy before S3 upload."""
+"""Test that ContextResolver resolves variables in workflow YAML content."""
 
-import os
-import tempfile
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-import pytest
-
-from smus_cicd.commands.deploy import _copy_and_resolve_yaml
+from smus_cicd.helpers.context_resolver import ContextResolver
 
 
-def test_copy_and_resolve_yaml_with_proj_variables():
-    """Test that {proj.*} variables are resolved in YAML files."""
-    # Create a temporary source YAML file with placeholders
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as src:
-        src.write(
-            """
+@patch("smus_cicd.helpers.context_resolver.ContextResolver._build_context")
+def test_resolve_yaml_with_proj_variables(mock_build_context):
+    """Test that {proj.*} variables are resolved in YAML content."""
+    mock_build_context.return_value = {
+        "proj": {
+            "name": "test-project",
+            "iam_role_name": "AmazonSageMakerUserIAMExecutionRole",
+            "connection": {},
+        },
+        "domain": {
+            "id": "test-domain-id",
+            "name": "test-domain",
+            "region": "us-east-1",
+        },
+        "stage": {"name": "test"},
+        "env": {},
+    }
+
+    resolver = ContextResolver(
+        project_name="test-project",
+        domain_id="test-domain-id",
+        region="us-east-1",
+        domain_name="test-domain",
+        stage_name="test",
+        env_vars={},
+    )
+
+    content = """\
 tasks:
   - name: test_task
     iam_role_name: '{proj.iam_role_name}'
     project_name: '{proj.name}'
 """
-        )
-        src_path = src.name
 
-    try:
-        # Create a temporary destination path
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".yaml", delete=False
-        ) as dest:
-            dest_path = dest.name
+    resolved = resolver.resolve(content)
 
-        try:
-            # Mock config
-            config = {
-                "domain_id": "test-domain-id",
-                "region": "us-east-1",
-                "domain_name": "test-domain",
-                "stage_name": "test",
-            }
-
-            # Mock ContextResolver to avoid AWS calls
-            with patch(
-                "smus_cicd.helpers.context_resolver.ContextResolver"
-            ) as mock_resolver_class:
-                mock_resolver = MagicMock()
-                mock_resolver.resolve.return_value = """
-tasks:
-  - name: test_task
-    iam_role_name: 'AmazonSageMakerUserIAMExecutionRole'
-    project_name: 'test-project'
-"""
-                mock_resolver_class.return_value = mock_resolver
-
-                # Call the function
-                _copy_and_resolve_yaml(src_path, dest_path, "test-project", config)
-
-                # Verify resolver was called
-                mock_resolver_class.assert_called_once_with(
-                    project_name="test-project",
-                    domain_id="test-domain-id",
-                    region="us-east-1",
-                    domain_name="test-domain",
-                    stage_name="test",
-                    env_vars={},
-                )
-                mock_resolver.resolve.assert_called_once()
-
-            # Verify the destination file has resolved content
-            with open(dest_path, "r") as f:
-                content = f.read()
-                assert "AmazonSageMakerUserIAMExecutionRole" in content
-                assert "{proj.iam_role_name}" not in content
-
-        finally:
-            if os.path.exists(dest_path):
-                os.unlink(dest_path)
-    finally:
-        if os.path.exists(src_path):
-            os.unlink(src_path)
+    assert "AmazonSageMakerUserIAMExecutionRole" in resolved
+    assert "{proj.iam_role_name}" not in resolved
+    assert "test-project" in resolved
+    assert "{proj.name}" not in resolved
 
 
-def test_copy_and_resolve_yaml_without_variables():
-    """Test that YAML files without variables are copied correctly."""
-    # Create a temporary source YAML file without placeholders
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as src:
-        src.write(
-            """
+@patch("smus_cicd.helpers.context_resolver.ContextResolver._build_context")
+def test_resolve_yaml_without_variables(mock_build_context):
+    """Test that YAML content without variables passes through unchanged."""
+    mock_build_context.return_value = {
+        "proj": {"name": "test-project", "connection": {}},
+        "domain": {
+            "id": "test-domain-id",
+            "name": "test-domain",
+            "region": "us-east-1",
+        },
+        "stage": {"name": ""},
+        "env": {},
+    }
+
+    resolver = ContextResolver(
+        project_name="test-project",
+        domain_id="test-domain-id",
+        region="us-east-1",
+        domain_name="test-domain",
+        env_vars={},
+    )
+
+    content = """\
 tasks:
   - name: test_task
     iam_role_name: 'StaticRole'
 """
-        )
-        src_path = src.name
 
-    try:
-        # Create a temporary destination path
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".yaml", delete=False
-        ) as dest:
-            dest_path = dest.name
+    resolved = resolver.resolve(content)
 
-        try:
-            # Mock config
-            config = {
-                "domain_id": "test-domain-id",
-                "region": "us-east-1",
-                "domain_name": "test-domain",
-            }
-
-            # Mock ContextResolver - resolver is always called now
-            with patch(
-                "smus_cicd.helpers.context_resolver.ContextResolver"
-            ) as mock_resolver_class:
-                mock_resolver = MagicMock()
-                # Return content unchanged when no variables present
-                mock_resolver.resolve.return_value = """
-tasks:
-  - name: test_task
-    iam_role_name: 'StaticRole'
-"""
-                mock_resolver_class.return_value = mock_resolver
-
-                _copy_and_resolve_yaml(src_path, dest_path, "test-project", config)
-
-                # Verify resolver was called (always called now)
-                mock_resolver_class.assert_called_once()
-                mock_resolver.resolve.assert_called_once()
-
-            # Verify the destination file has same content
-            with open(dest_path, "r") as f:
-                content = f.read()
-                assert "StaticRole" in content
-
-        finally:
-            if os.path.exists(dest_path):
-                os.unlink(dest_path)
-    finally:
-        if os.path.exists(src_path):
-            os.unlink(src_path)
+    assert resolved == content
+    assert "StaticRole" in resolved

--- a/tests/unit/commands/dry_run/test_connectivity_checker.py
+++ b/tests/unit/commands/dry_run/test_connectivity_checker.py
@@ -110,11 +110,11 @@ def checker():
 class TestDomainReachability:
     """Tests for DataZone domain reachability via GetDomain."""
 
-    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.boto3")
-    def test_domain_reachable(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.create_client")
+    def test_domain_reachable(self, mock_create_client, checker):
         mock_dz = MagicMock()
         mock_dz.get_domain.return_value = {"id": "dzd_test", "name": "TestDomain"}
-        mock_boto3.client.return_value = mock_dz
+        mock_create_client.return_value = mock_dz
 
         context = _make_context(domain_id="dzd_test")
         findings = checker.check(context)
@@ -126,14 +126,14 @@ class TestDomainReachability:
         assert len(ok_findings) >= 1
         assert "reachable" in ok_findings[0].message.lower()
 
-    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.boto3")
-    def test_domain_unreachable_client_error(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.create_client")
+    def test_domain_unreachable_client_error(self, mock_create_client, checker):
         mock_dz = MagicMock()
         mock_dz.get_domain.side_effect = ClientError(
             {"Error": {"Code": "ResourceNotFoundException", "Message": "Not found"}},
             "GetDomain",
         )
-        mock_boto3.client.return_value = mock_dz
+        mock_create_client.return_value = mock_dz
 
         context = _make_context(domain_id="dzd_missing")
         findings = checker.check(context)
@@ -149,11 +149,11 @@ class TestDomainReachability:
         assert "unreachable" in error_findings[0].message.lower()
         assert error_findings[0].details["error_code"] == "ResourceNotFoundException"
 
-    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.boto3")
-    def test_domain_unreachable_generic_error(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.create_client")
+    def test_domain_unreachable_generic_error(self, mock_create_client, checker):
         mock_dz = MagicMock()
         mock_dz.get_domain.side_effect = Exception("Network timeout")
-        mock_boto3.client.return_value = mock_dz
+        mock_create_client.return_value = mock_dz
 
         context = _make_context(domain_id="dzd_timeout")
         findings = checker.check(context)
@@ -166,8 +166,8 @@ class TestDomainReachability:
         assert len(error_findings) >= 1
         assert "unreachable" in error_findings[0].message.lower()
 
-    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.boto3")
-    def test_no_domain_id_produces_warning(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.create_client")
+    def test_no_domain_id_produces_warning(self, mock_create_client, checker):
         context = _make_context(domain_id=None)
         findings = checker.check(context)
 
@@ -187,22 +187,22 @@ class TestDomainReachability:
 class TestProjectExistence:
     """Tests for DataZone project existence check."""
 
-    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.create_client")
     @patch(
         "smus_cicd.commands.dry_run.checkers.connectivity_checker"
         ".ConnectivityChecker._check_project"
     )
-    def test_project_exists(self, mock_check_project, mock_boto3, checker):
+    def test_project_exists(self, mock_check_project, mock_create_client, checker):
         """Use a direct mock to test project found path."""
         # We'll test _check_project directly instead
         pass
 
     @patch("smus_cicd.helpers.datazone.get_project_by_name")
-    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.boto3")
-    def test_project_found(self, mock_boto3, mock_get_project, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.create_client")
+    def test_project_found(self, mock_create_client, mock_get_project, checker):
         mock_dz = MagicMock()
         mock_dz.get_domain.return_value = {"id": "dzd_test"}
-        mock_boto3.client.return_value = mock_dz
+        mock_create_client.return_value = mock_dz
 
         mock_get_project.return_value = {"id": "proj-123", "name": "test-project"}
 
@@ -220,11 +220,11 @@ class TestProjectExistence:
         assert "exists" in project_ok[0].message.lower()
 
     @patch("smus_cicd.helpers.datazone.get_project_by_name")
-    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.boto3")
-    def test_project_not_found(self, mock_boto3, mock_get_project, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.create_client")
+    def test_project_not_found(self, mock_create_client, mock_get_project, checker):
         mock_dz = MagicMock()
         mock_dz.get_domain.return_value = {"id": "dzd_test"}
-        mock_boto3.client.return_value = mock_dz
+        mock_create_client.return_value = mock_dz
 
         mock_get_project.return_value = None
 
@@ -242,11 +242,11 @@ class TestProjectExistence:
         assert "not found" in project_warnings[0].message.lower()
 
     @patch("smus_cicd.helpers.datazone.get_project_by_name")
-    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.boto3")
-    def test_project_check_error(self, mock_boto3, mock_get_project, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.create_client")
+    def test_project_check_error(self, mock_create_client, mock_get_project, checker):
         mock_dz = MagicMock()
         mock_dz.get_domain.return_value = {"id": "dzd_test"}
-        mock_boto3.client.return_value = mock_dz
+        mock_create_client.return_value = mock_dz
 
         mock_get_project.side_effect = Exception("API error")
 
@@ -261,11 +261,11 @@ class TestProjectExistence:
         assert len(project_errors) >= 1
         assert "failed" in project_errors[0].message.lower()
 
-    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.boto3")
-    def test_no_project_name_produces_warning(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.create_client")
+    def test_no_project_name_produces_warning(self, mock_create_client, checker):
         mock_dz = MagicMock()
         mock_dz.get_domain.return_value = {"id": "dzd_test"}
-        mock_boto3.client.return_value = mock_dz
+        mock_create_client.return_value = mock_dz
 
         context = _make_context(project_name=None, domain_id="dzd_test")
         findings = checker.check(context)
@@ -295,14 +295,14 @@ class TestS3BucketAccessibility:
     @patch(
         "smus_cicd.commands.dry_run.checkers.connectivity_checker.get_project_connections"
     )
-    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.boto3")
-    def test_bucket_accessible(self, mock_boto3, mock_get_conns, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.create_client")
+    def test_bucket_accessible(self, mock_create_client, mock_get_conns, checker):
         mock_dz = MagicMock()
         mock_dz.get_domain.return_value = {"id": "dzd_test"}
         mock_s3 = MagicMock()
         mock_s3.head_bucket.return_value = {}
 
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_dz if svc == "datazone" else mock_s3
         )
         mock_get_conns.return_value = {
@@ -320,8 +320,8 @@ class TestS3BucketAccessibility:
     @patch(
         "smus_cicd.commands.dry_run.checkers.connectivity_checker.get_project_connections"
     )
-    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.boto3")
-    def test_bucket_not_accessible(self, mock_boto3, mock_get_conns, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.create_client")
+    def test_bucket_not_accessible(self, mock_create_client, mock_get_conns, checker):
         mock_dz = MagicMock()
         mock_dz.get_domain.return_value = {"id": "dzd_test"}
         mock_s3 = MagicMock()
@@ -330,7 +330,7 @@ class TestS3BucketAccessibility:
             "HeadBucket",
         )
 
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_dz if svc == "datazone" else mock_s3
         )
         mock_get_conns.return_value = {
@@ -350,14 +350,14 @@ class TestS3BucketAccessibility:
     @patch(
         "smus_cicd.commands.dry_run.checkers.connectivity_checker.get_project_connections"
     )
-    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.boto3")
-    def test_bucket_generic_error(self, mock_boto3, mock_get_conns, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.create_client")
+    def test_bucket_generic_error(self, mock_create_client, mock_get_conns, checker):
         mock_dz = MagicMock()
         mock_dz.get_domain.return_value = {"id": "dzd_test"}
         mock_s3 = MagicMock()
         mock_s3.head_bucket.side_effect = Exception("Connection refused")
 
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_dz if svc == "datazone" else mock_s3
         )
         mock_get_conns.return_value = {
@@ -376,15 +376,17 @@ class TestS3BucketAccessibility:
     @patch(
         "smus_cicd.commands.dry_run.checkers.connectivity_checker.get_project_connections"
     )
-    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.boto3")
-    def test_multiple_buckets_deduplicated(self, mock_boto3, mock_get_conns, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.create_client")
+    def test_multiple_buckets_deduplicated(
+        self, mock_create_client, mock_get_conns, checker
+    ):
         """Two storage items with the same connection resolve to the same bucket."""
         mock_dz = MagicMock()
         mock_dz.get_domain.return_value = {"id": "dzd_test"}
         mock_s3 = MagicMock()
         mock_s3.head_bucket.return_value = {}
 
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_dz if svc == "datazone" else mock_s3
         )
         # Both storage items have connectionName "default.s3_shared"
@@ -403,11 +405,13 @@ class TestS3BucketAccessibility:
     @patch(
         "smus_cicd.commands.dry_run.checkers.connectivity_checker.get_project_connections"
     )
-    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.boto3")
-    def test_no_storage_items_no_s3_findings(self, mock_boto3, mock_get_conns, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.create_client")
+    def test_no_storage_items_no_s3_findings(
+        self, mock_create_client, mock_get_conns, checker
+    ):
         mock_dz = MagicMock()
         mock_dz.get_domain.return_value = {"id": "dzd_test"}
-        mock_boto3.client.return_value = mock_dz
+        mock_create_client.return_value = mock_dz
 
         context = _make_context(storage_names=[])
         findings = checker.check(context)
@@ -418,14 +422,14 @@ class TestS3BucketAccessibility:
     @patch(
         "smus_cicd.commands.dry_run.checkers.connectivity_checker.get_project_connections"
     )
-    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.create_client")
     def test_unresolved_connection_produces_warning(
-        self, mock_boto3, mock_get_conns, checker
+        self, mock_create_client, mock_get_conns, checker
     ):
         """When _get_project_connections returns None, connections are unresolved."""
         mock_dz = MagicMock()
         mock_dz.get_domain.return_value = {"id": "dzd_test"}
-        mock_boto3.client.return_value = mock_dz
+        mock_create_client.return_value = mock_dz
         mock_get_conns.return_value = None
 
         context = _make_context(storage_names=["data"])
@@ -441,14 +445,14 @@ class TestS3BucketAccessibility:
     @patch(
         "smus_cicd.commands.dry_run.checkers.connectivity_checker.get_project_connections"
     )
-    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.create_client")
     def test_connection_without_s3uri_is_unresolved(
-        self, mock_boto3, mock_get_conns, checker
+        self, mock_create_client, mock_get_conns, checker
     ):
         """Connection exists but has no s3Uri → treated as unresolved."""
         mock_dz = MagicMock()
         mock_dz.get_domain.return_value = {"id": "dzd_test"}
-        mock_boto3.client.return_value = mock_dz
+        mock_create_client.return_value = mock_dz
         mock_get_conns.return_value = {
             "default.s3_shared": {"type": "S3"},  # no s3Uri
         }
@@ -472,11 +476,11 @@ class TestAirflowReachability:
     """Tests for Airflow environment reachability."""
 
     @patch("smus_cicd.helpers.airflow_serverless.list_workflows")
-    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.boto3")
-    def test_airflow_reachable(self, mock_boto3, mock_list_workflows, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.create_client")
+    def test_airflow_reachable(self, mock_create_client, mock_list_workflows, checker):
         mock_dz = MagicMock()
         mock_dz.get_domain.return_value = {"id": "dzd_test"}
-        mock_boto3.client.return_value = mock_dz
+        mock_create_client.return_value = mock_dz
 
         mock_list_workflows.return_value = []
 
@@ -492,11 +496,13 @@ class TestAirflowReachability:
         assert "reachable" in airflow_ok[0].message.lower()
 
     @patch("smus_cicd.helpers.airflow_serverless.list_workflows")
-    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.boto3")
-    def test_airflow_unreachable(self, mock_boto3, mock_list_workflows, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.create_client")
+    def test_airflow_unreachable(
+        self, mock_create_client, mock_list_workflows, checker
+    ):
         mock_dz = MagicMock()
         mock_dz.get_domain.return_value = {"id": "dzd_test"}
-        mock_boto3.client.return_value = mock_dz
+        mock_create_client.return_value = mock_dz
 
         mock_list_workflows.side_effect = Exception("Service unavailable")
 
@@ -511,11 +517,11 @@ class TestAirflowReachability:
         assert len(airflow_errors) >= 1
         assert "unreachable" in airflow_errors[0].message.lower()
 
-    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.boto3")
-    def test_no_workflow_actions_skips_airflow(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.create_client")
+    def test_no_workflow_actions_skips_airflow(self, mock_create_client, checker):
         mock_dz = MagicMock()
         mock_dz.get_domain.return_value = {"id": "dzd_test"}
-        mock_boto3.client.return_value = mock_dz
+        mock_create_client.return_value = mock_dz
 
         context = _make_context(bootstrap_actions=["quicksight.refresh_dataset"])
         findings = checker.check(context)
@@ -523,11 +529,11 @@ class TestAirflowReachability:
         airflow_findings = [f for f in findings if f.service == "airflow-serverless"]
         assert len(airflow_findings) == 0
 
-    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.boto3")
-    def test_no_bootstrap_skips_airflow(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.create_client")
+    def test_no_bootstrap_skips_airflow(self, mock_create_client, checker):
         mock_dz = MagicMock()
         mock_dz.get_domain.return_value = {"id": "dzd_test"}
-        mock_boto3.client.return_value = mock_dz
+        mock_create_client.return_value = mock_dz
 
         context = _make_context(bootstrap_actions=None)
         findings = checker.check(context)
@@ -536,13 +542,13 @@ class TestAirflowReachability:
         assert len(airflow_findings) == 0
 
     @patch("smus_cicd.helpers.airflow_serverless.list_workflows")
-    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.create_client")
     def test_workflow_monitor_triggers_airflow_check(
-        self, mock_boto3, mock_list_workflows, checker
+        self, mock_create_client, mock_list_workflows, checker
     ):
         mock_dz = MagicMock()
         mock_dz.get_domain.return_value = {"id": "dzd_test"}
-        mock_boto3.client.return_value = mock_dz
+        mock_create_client.return_value = mock_dz
 
         mock_list_workflows.return_value = []
 
@@ -565,14 +571,16 @@ class TestAirflowReachability:
 class TestErrorReporting:
     """Tests that error findings include resource identifier and service."""
 
-    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.boto3")
-    def test_domain_error_includes_resource_and_service(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.create_client")
+    def test_domain_error_includes_resource_and_service(
+        self, mock_create_client, checker
+    ):
         mock_dz = MagicMock()
         mock_dz.get_domain.side_effect = ClientError(
             {"Error": {"Code": "AccessDeniedException", "Message": "Denied"}},
             "GetDomain",
         )
-        mock_boto3.client.return_value = mock_dz
+        mock_create_client.return_value = mock_dz
 
         context = _make_context(domain_id="dzd_denied")
         findings = checker.check(context)
@@ -588,9 +596,9 @@ class TestErrorReporting:
     @patch(
         "smus_cicd.commands.dry_run.checkers.connectivity_checker.get_project_connections"
     )
-    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.connectivity_checker.create_client")
     def test_s3_error_includes_bucket_name_and_service(
-        self, mock_boto3, mock_get_conns, checker
+        self, mock_create_client, mock_get_conns, checker
     ):
         mock_dz = MagicMock()
         mock_dz.get_domain.return_value = {"id": "dzd_test"}
@@ -600,7 +608,7 @@ class TestErrorReporting:
             "HeadBucket",
         )
 
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_dz if svc == "datazone" else mock_s3
         )
         mock_get_conns.return_value = {

--- a/tests/unit/commands/dry_run/test_dependency_checker.py
+++ b/tests/unit/commands/dry_run/test_dependency_checker.py
@@ -154,13 +154,13 @@ class TestDependencyCheckerSkipPaths:
 
 
 class TestGlueDatabaseValidation:
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_existing_database_no_error(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_existing_database_no_error(self, mock_create_client, checker):
         glue = MagicMock()
         glue.get_database.return_value = {}
         glue.get_table.return_value = {}
         glue.get_partitions.return_value = {}
-        mock_boto3.client.return_value = glue
+        mock_create_client.return_value = glue
 
         asset = _glue_asset("mydb", "mytable")
         ctx = _make_context(catalog_data={"assets": [asset]})
@@ -170,11 +170,11 @@ class TestGlueDatabaseValidation:
         assert len(errors) == 0
         glue.get_database.assert_called_once_with(Name="mydb")
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_missing_database_produces_error(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_missing_database_produces_error(self, mock_create_client, checker):
         glue = MagicMock()
         glue.get_database.side_effect = _client_error("EntityNotFoundException")
-        mock_boto3.client.return_value = glue
+        mock_create_client.return_value = glue
 
         asset = _glue_asset("missing_db", "mytable")
         ctx = _make_context(catalog_data={"assets": [asset]})
@@ -188,11 +188,11 @@ class TestGlueDatabaseValidation:
         assert len(db_errors) >= 1
         assert "missing_db" in db_errors[0].message
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_database_access_denied_produces_error(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_database_access_denied_produces_error(self, mock_create_client, checker):
         glue = MagicMock()
         glue.get_database.side_effect = _client_error("AccessDeniedException")
-        mock_boto3.client.return_value = glue
+        mock_create_client.return_value = glue
 
         asset = _glue_asset("secret_db", "mytable")
         ctx = _make_context(catalog_data={"assets": [asset]})
@@ -205,11 +205,13 @@ class TestGlueDatabaseValidation:
         ]
         assert len(errors) >= 1
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_database_generic_exception_produces_error(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_database_generic_exception_produces_error(
+        self, mock_create_client, checker
+    ):
         glue = MagicMock()
         glue.get_database.side_effect = RuntimeError("boom")
-        mock_boto3.client.return_value = glue
+        mock_create_client.return_value = glue
 
         asset = _glue_asset("bad_db", "mytable")
         ctx = _make_context(catalog_data={"assets": [asset]})
@@ -229,12 +231,12 @@ class TestGlueDatabaseValidation:
 
 
 class TestGlueTableValidation:
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_missing_table_produces_error(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_missing_table_produces_error(self, mock_create_client, checker):
         glue = MagicMock()
         glue.get_database.return_value = {}
         glue.get_table.side_effect = _client_error("EntityNotFoundException")
-        mock_boto3.client.return_value = glue
+        mock_create_client.return_value = glue
 
         asset = _glue_asset("mydb", "missing_tbl")
         ctx = _make_context(catalog_data={"assets": [asset]})
@@ -248,12 +250,12 @@ class TestGlueTableValidation:
         assert len(tbl_errors) >= 1
         assert "missing_tbl" in tbl_errors[0].message
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_missing_view_produces_error(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_missing_view_produces_error(self, mock_create_client, checker):
         glue = MagicMock()
         glue.get_database.return_value = {}
         glue.get_table.side_effect = _client_error("EntityNotFoundException")
-        mock_boto3.client.return_value = glue
+        mock_create_client.return_value = glue
 
         asset = _glue_asset("mydb", "missing_view", table_type="VIRTUAL_VIEW")
         ctx = _make_context(catalog_data={"assets": [asset]})
@@ -266,13 +268,13 @@ class TestGlueTableValidation:
         ]
         assert len(view_errors) >= 1
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_existing_table_no_error(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_existing_table_no_error(self, mock_create_client, checker):
         glue = MagicMock()
         glue.get_database.return_value = {}
         glue.get_table.return_value = {}
         glue.get_partitions.return_value = {}
-        mock_boto3.client.return_value = glue
+        mock_create_client.return_value = glue
 
         asset = _glue_asset("mydb", "good_tbl")
         ctx = _make_context(catalog_data={"assets": [asset]})
@@ -281,12 +283,12 @@ class TestGlueTableValidation:
         errors = [f for f in findings if f.severity == Severity.ERROR]
         assert len(errors) == 0
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_table_access_denied_produces_error(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_table_access_denied_produces_error(self, mock_create_client, checker):
         glue = MagicMock()
         glue.get_database.return_value = {}
         glue.get_table.side_effect = _client_error("AccessDeniedException")
-        mock_boto3.client.return_value = glue
+        mock_create_client.return_value = glue
 
         asset = _glue_asset("mydb", "secret_tbl")
         ctx = _make_context(catalog_data={"assets": [asset]})
@@ -299,12 +301,12 @@ class TestGlueTableValidation:
         ]
         assert len(errors) >= 1
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_view_skips_partition_check(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_view_skips_partition_check(self, mock_create_client, checker):
         glue = MagicMock()
         glue.get_database.return_value = {}
         glue.get_table.return_value = {}
-        mock_boto3.client.return_value = glue
+        mock_create_client.return_value = glue
 
         asset = _glue_asset("mydb", "my_view", table_type="VIEW")
         ctx = _make_context(catalog_data={"assets": [asset]})
@@ -319,13 +321,13 @@ class TestGlueTableValidation:
 
 
 class TestPartitionAccessibility:
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_accessible_partitions_no_warning(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_accessible_partitions_no_warning(self, mock_create_client, checker):
         glue = MagicMock()
         glue.get_database.return_value = {}
         glue.get_table.return_value = {}
         glue.get_partitions.return_value = {}
-        mock_boto3.client.return_value = glue
+        mock_create_client.return_value = glue
 
         asset = _glue_asset("mydb", "mytable")
         ctx = _make_context(catalog_data={"assets": [asset]})
@@ -338,13 +340,13 @@ class TestPartitionAccessibility:
         ]
         assert len(warnings) == 0
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_inaccessible_partitions_produce_warning(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_inaccessible_partitions_produce_warning(self, mock_create_client, checker):
         glue = MagicMock()
         glue.get_database.return_value = {}
         glue.get_table.return_value = {}
         glue.get_partitions.side_effect = _client_error("AccessDeniedException")
-        mock_boto3.client.return_value = glue
+        mock_create_client.return_value = glue
 
         asset = _glue_asset("mydb", "mytable")
         ctx = _make_context(catalog_data={"assets": [asset]})
@@ -358,13 +360,15 @@ class TestPartitionAccessibility:
         assert len(warnings) == 1
         assert "inaccessible" in warnings[0].message.lower()
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_partition_generic_exception_produces_warning(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_partition_generic_exception_produces_warning(
+        self, mock_create_client, checker
+    ):
         glue = MagicMock()
         glue.get_database.return_value = {}
         glue.get_table.return_value = {}
         glue.get_partitions.side_effect = RuntimeError("timeout")
-        mock_boto3.client.return_value = glue
+        mock_create_client.return_value = glue
 
         asset = _glue_asset("mydb", "mytable")
         ctx = _make_context(catalog_data={"assets": [asset]})
@@ -384,8 +388,8 @@ class TestPartitionAccessibility:
 
 
 class TestDataSourceValidation:
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_matching_data_source_no_warning(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_matching_data_source_no_warning(self, mock_create_client, checker):
         glue = MagicMock()
         glue.get_database.return_value = {}
         glue.get_table.return_value = {}
@@ -399,7 +403,7 @@ class TestDataSourceValidation:
         def _client_factory(service, **kw):
             return glue if service == "glue" else dz
 
-        mock_boto3.client.side_effect = _client_factory
+        mock_create_client.side_effect = _client_factory
 
         asset = _glue_asset("mydb", "mytable", ds_form=True)
         ctx = _make_context(catalog_data={"assets": [asset]})
@@ -412,8 +416,8 @@ class TestDataSourceValidation:
         ]
         assert len(ds_warnings) == 0
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_missing_data_source_produces_warning(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_missing_data_source_produces_warning(self, mock_create_client, checker):
         glue = MagicMock()
         glue.get_database.return_value = {}
         glue.get_table.return_value = {}
@@ -425,7 +429,7 @@ class TestDataSourceValidation:
         def _client_factory(service, **kw):
             return glue if service == "glue" else dz
 
-        mock_boto3.client.side_effect = _client_factory
+        mock_create_client.side_effect = _client_factory
 
         asset = _glue_asset("mydb", "mytable", ds_form=True)
         ctx = _make_context(catalog_data={"assets": [asset]})
@@ -438,8 +442,10 @@ class TestDataSourceValidation:
         ]
         assert len(ds_warnings) >= 1
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_data_source_api_failure_produces_warning(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_data_source_api_failure_produces_warning(
+        self, mock_create_client, checker
+    ):
         glue = MagicMock()
         glue.get_database.return_value = {}
         glue.get_table.return_value = {}
@@ -451,7 +457,7 @@ class TestDataSourceValidation:
         def _client_factory(service, **kw):
             return glue if service == "glue" else dz
 
-        mock_boto3.client.side_effect = _client_factory
+        mock_create_client.side_effect = _client_factory
 
         asset = _glue_asset("mydb", "mytable", ds_form=True)
         ctx = _make_context(catalog_data={"assets": [asset]})
@@ -464,13 +470,13 @@ class TestDataSourceValidation:
         ]
         assert len(ds_warnings) >= 1
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_no_domain_id_skips_data_source_check(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_no_domain_id_skips_data_source_check(self, mock_create_client, checker):
         glue = MagicMock()
         glue.get_database.return_value = {}
         glue.get_table.return_value = {}
         glue.get_partitions.return_value = {}
-        mock_boto3.client.return_value = glue
+        mock_create_client.return_value = glue
 
         asset = _glue_asset("mydb", "mytable", ds_form=True)
         ctx = _make_context(catalog_data={"assets": [asset]}, domain_id="")
@@ -486,8 +492,8 @@ class TestDataSourceValidation:
 
 
 class TestCustomFormTypeValidation:
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_existing_form_type_no_error(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_existing_form_type_no_error(self, mock_create_client, checker):
         glue = MagicMock()
         dz = MagicMock()
         dz.get_form_type.return_value = {"name": "MyForm", "revision": "1"}
@@ -495,7 +501,7 @@ class TestCustomFormTypeValidation:
         def _client_factory(service, **kw):
             return glue if service == "glue" else dz
 
-        mock_boto3.client.side_effect = _client_factory
+        mock_create_client.side_effect = _client_factory
 
         at = _asset_type_resource(
             forms_input={"myForm": {"typeIdentifier": "custom.MyFormType"}}
@@ -510,8 +516,8 @@ class TestCustomFormTypeValidation:
         ]
         assert len(ft_errors) == 0
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_missing_form_type_produces_error(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_missing_form_type_produces_error(self, mock_create_client, checker):
         glue = MagicMock()
         dz = MagicMock()
         dz.get_form_type.side_effect = _client_error("ResourceNotFoundException")
@@ -519,7 +525,7 @@ class TestCustomFormTypeValidation:
         def _client_factory(service, **kw):
             return glue if service == "glue" else dz
 
-        mock_boto3.client.side_effect = _client_factory
+        mock_create_client.side_effect = _client_factory
 
         at = _asset_type_resource(
             forms_input={"myForm": {"typeIdentifier": "custom.MissingForm"}}
@@ -534,15 +540,15 @@ class TestCustomFormTypeValidation:
         ]
         assert len(ft_errors) >= 1
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_managed_form_type_skipped(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_managed_form_type_skipped(self, mock_create_client, checker):
         glue = MagicMock()
         dz = MagicMock()
 
         def _client_factory(service, **kw):
             return glue if service == "glue" else dz
 
-        mock_boto3.client.side_effect = _client_factory
+        mock_create_client.side_effect = _client_factory
 
         at = _asset_type_resource(
             forms_input={"managed": {"typeIdentifier": "amazon.datazone.SomeFormType"}}
@@ -558,8 +564,8 @@ class TestCustomFormTypeValidation:
         assert len(ft_errors) == 0
         dz.get_form_type.assert_not_called()
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_typeName_fallback(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_typeName_fallback(self, mock_create_client, checker):
         glue = MagicMock()
         dz = MagicMock()
         dz.get_form_type.return_value = {"name": "FallbackForm", "revision": "1"}
@@ -567,7 +573,7 @@ class TestCustomFormTypeValidation:
         def _client_factory(service, **kw):
             return glue if service == "glue" else dz
 
-        mock_boto3.client.side_effect = _client_factory
+        mock_create_client.side_effect = _client_factory
 
         at = _asset_type_resource(
             forms_input={"myForm": {"typeName": "custom.FallbackForm"}}
@@ -589,8 +595,8 @@ class TestCustomFormTypeValidation:
 
 
 class TestCustomAssetTypeValidation:
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_existing_asset_type_no_error(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_existing_asset_type_no_error(self, mock_create_client, checker):
         glue = MagicMock()
         dz = MagicMock()
         dz.search_types.return_value = {"items": [{"name": "CustomAsset"}]}
@@ -598,7 +604,7 @@ class TestCustomAssetTypeValidation:
         def _client_factory(service, **kw):
             return glue if service == "glue" else dz
 
-        mock_boto3.client.side_effect = _client_factory
+        mock_create_client.side_effect = _client_factory
 
         asset = {
             "type": "assets",
@@ -617,8 +623,8 @@ class TestCustomAssetTypeValidation:
         ]
         assert len(at_errors) == 0
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_missing_asset_type_produces_error(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_missing_asset_type_produces_error(self, mock_create_client, checker):
         glue = MagicMock()
         dz = MagicMock()
         dz.search_types.return_value = {"items": []}
@@ -626,7 +632,7 @@ class TestCustomAssetTypeValidation:
         def _client_factory(service, **kw):
             return glue if service == "glue" else dz
 
-        mock_boto3.client.side_effect = _client_factory
+        mock_create_client.side_effect = _client_factory
 
         asset = {
             "type": "assets",
@@ -645,15 +651,15 @@ class TestCustomAssetTypeValidation:
         ]
         assert len(at_errors) >= 1
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_managed_asset_type_skipped(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_managed_asset_type_skipped(self, mock_create_client, checker):
         glue = MagicMock()
         dz = MagicMock()
 
         def _client_factory(service, **kw):
             return glue if service == "glue" else dz
 
-        mock_boto3.client.side_effect = _client_factory
+        mock_create_client.side_effect = _client_factory
 
         asset = {
             "type": "assets",
@@ -673,8 +679,8 @@ class TestCustomAssetTypeValidation:
         assert len(at_errors) == 0
         dz.search_types.assert_not_called()
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_search_types_api_failure_produces_error(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_search_types_api_failure_produces_error(self, mock_create_client, checker):
         glue = MagicMock()
         dz = MagicMock()
         dz.search_types.side_effect = RuntimeError("api error")
@@ -682,7 +688,7 @@ class TestCustomAssetTypeValidation:
         def _client_factory(service, **kw):
             return glue if service == "glue" else dz
 
-        mock_boto3.client.side_effect = _client_factory
+        mock_create_client.side_effect = _client_factory
 
         asset = {
             "type": "assets",
@@ -708,8 +714,8 @@ class TestCustomAssetTypeValidation:
 
 
 class TestFormTypeRevisionValidation:
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_matching_revision_no_warning(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_matching_revision_no_warning(self, mock_create_client, checker):
         glue = MagicMock()
         dz = MagicMock()
         dz.get_form_type.return_value = {"name": "MyForm", "revision": "3"}
@@ -717,7 +723,7 @@ class TestFormTypeRevisionValidation:
         def _client_factory(service, **kw):
             return glue if service == "glue" else dz
 
-        mock_boto3.client.side_effect = _client_factory
+        mock_create_client.side_effect = _client_factory
 
         asset = {
             "type": "assets",
@@ -741,8 +747,8 @@ class TestFormTypeRevisionValidation:
         ]
         assert len(rev_warnings) == 0
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_mismatched_revision_produces_warning(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_mismatched_revision_produces_warning(self, mock_create_client, checker):
         glue = MagicMock()
         dz = MagicMock()
         dz.get_form_type.return_value = {"name": "MyForm", "revision": "5"}
@@ -750,7 +756,7 @@ class TestFormTypeRevisionValidation:
         def _client_factory(service, **kw):
             return glue if service == "glue" else dz
 
-        mock_boto3.client.side_effect = _client_factory
+        mock_create_client.side_effect = _client_factory
 
         asset = {
             "type": "assets",
@@ -775,8 +781,8 @@ class TestFormTypeRevisionValidation:
         assert len(rev_warnings) >= 1
         assert "does not match" in rev_warnings[0].message.lower()
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_unresolvable_revision_produces_warning(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_unresolvable_revision_produces_warning(self, mock_create_client, checker):
         glue = MagicMock()
         dz = MagicMock()
         # Form type exists but has no revision field
@@ -785,7 +791,7 @@ class TestFormTypeRevisionValidation:
         def _client_factory(service, **kw):
             return glue if service == "glue" else dz
 
-        mock_boto3.client.side_effect = _client_factory
+        mock_create_client.side_effect = _client_factory
 
         asset = {
             "type": "assets",
@@ -810,8 +816,8 @@ class TestFormTypeRevisionValidation:
         assert len(rev_warnings) >= 1
         assert "cannot be resolved" in rev_warnings[0].message.lower()
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_missing_form_type_skips_revision_check(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_missing_form_type_skips_revision_check(self, mock_create_client, checker):
         glue = MagicMock()
         dz = MagicMock()
         dz.get_form_type.side_effect = _client_error("ResourceNotFoundException")
@@ -819,7 +825,7 @@ class TestFormTypeRevisionValidation:
         def _client_factory(service, **kw):
             return glue if service == "glue" else dz
 
-        mock_boto3.client.side_effect = _client_factory
+        mock_create_client.side_effect = _client_factory
 
         asset = {
             "type": "assets",
@@ -844,15 +850,15 @@ class TestFormTypeRevisionValidation:
         ]
         assert len(rev_warnings) == 0
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_managed_form_type_revision_skipped(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_managed_form_type_revision_skipped(self, mock_create_client, checker):
         glue = MagicMock()
         dz = MagicMock()
 
         def _client_factory(service, **kw):
             return glue if service == "glue" else dz
 
-        mock_boto3.client.side_effect = _client_factory
+        mock_create_client.side_effect = _client_factory
 
         asset = {
             "type": "assets",
@@ -884,13 +890,15 @@ class TestFormTypeRevisionValidation:
 
 
 class TestCachingBehaviour:
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_database_cache_prevents_duplicate_api_calls(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_database_cache_prevents_duplicate_api_calls(
+        self, mock_create_client, checker
+    ):
         glue = MagicMock()
         glue.get_database.return_value = {}
         glue.get_table.return_value = {}
         glue.get_partitions.return_value = {}
-        mock_boto3.client.return_value = glue
+        mock_create_client.return_value = glue
 
         # Two assets referencing the same database
         asset1 = _glue_asset("shared_db", "tbl1", asset_name="asset1")
@@ -901,13 +909,15 @@ class TestCachingBehaviour:
         # get_database should be called only once for "shared_db"
         assert glue.get_database.call_count == 1
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_table_cache_prevents_duplicate_api_calls(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_table_cache_prevents_duplicate_api_calls(
+        self, mock_create_client, checker
+    ):
         glue = MagicMock()
         glue.get_database.return_value = {}
         glue.get_table.return_value = {}
         glue.get_partitions.return_value = {}
-        mock_boto3.client.return_value = glue
+        mock_create_client.return_value = glue
 
         # Two assets referencing the same table
         asset1 = _glue_asset("mydb", "shared_tbl", asset_name="asset1")
@@ -918,13 +928,15 @@ class TestCachingBehaviour:
         # get_table should be called only once for ("mydb", "shared_tbl")
         assert glue.get_table.call_count == 1
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_partition_cache_prevents_duplicate_api_calls(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_partition_cache_prevents_duplicate_api_calls(
+        self, mock_create_client, checker
+    ):
         glue = MagicMock()
         glue.get_database.return_value = {}
         glue.get_table.return_value = {}
         glue.get_partitions.return_value = {}
-        mock_boto3.client.return_value = glue
+        mock_create_client.return_value = glue
 
         asset1 = _glue_asset("mydb", "tbl", asset_name="asset1")
         asset2 = _glue_asset("mydb", "tbl", asset_name="asset2")
@@ -933,13 +945,13 @@ class TestCachingBehaviour:
 
         assert glue.get_partitions.call_count == 1
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
     def test_missing_database_cache_still_reports_for_second_asset(
-        self, mock_boto3, checker
+        self, mock_create_client, checker
     ):
         glue = MagicMock()
         glue.get_database.side_effect = _client_error("EntityNotFoundException")
-        mock_boto3.client.return_value = glue
+        mock_create_client.return_value = glue
 
         asset1 = _glue_asset("gone_db", "tbl1", asset_name="asset1")
         asset2 = _glue_asset("gone_db", "tbl2", asset_name="asset2")
@@ -958,8 +970,10 @@ class TestCachingBehaviour:
         # But only one API call
         assert glue.get_database.call_count == 1
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_form_type_cache_prevents_duplicate_api_calls(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_form_type_cache_prevents_duplicate_api_calls(
+        self, mock_create_client, checker
+    ):
         glue = MagicMock()
         dz = MagicMock()
         dz.get_form_type.return_value = {"name": "MyForm", "revision": "1"}
@@ -967,7 +981,7 @@ class TestCachingBehaviour:
         def _client_factory(service, **kw):
             return glue if service == "glue" else dz
 
-        mock_boto3.client.side_effect = _client_factory
+        mock_create_client.side_effect = _client_factory
 
         # Two asset types referencing the same form type
         at1 = _asset_type_resource(
@@ -983,8 +997,10 @@ class TestCachingBehaviour:
 
         assert dz.get_form_type.call_count == 1
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_asset_type_cache_prevents_duplicate_api_calls(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_asset_type_cache_prevents_duplicate_api_calls(
+        self, mock_create_client, checker
+    ):
         glue = MagicMock()
         dz = MagicMock()
         dz.search_types.return_value = {"items": [{"name": "CustomAsset"}]}
@@ -992,7 +1008,7 @@ class TestCachingBehaviour:
         def _client_factory(service, **kw):
             return glue if service == "glue" else dz
 
-        mock_boto3.client.side_effect = _client_factory
+        mock_create_client.side_effect = _client_factory
 
         asset1 = {
             "type": "assets",
@@ -1013,8 +1029,10 @@ class TestCachingBehaviour:
 
         assert dz.search_types.call_count == 1
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_data_source_cache_prevents_duplicate_api_calls(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_data_source_cache_prevents_duplicate_api_calls(
+        self, mock_create_client, checker
+    ):
         glue = MagicMock()
         glue.get_database.return_value = {}
         glue.get_table.return_value = {}
@@ -1028,7 +1046,7 @@ class TestCachingBehaviour:
         def _client_factory(service, **kw):
             return glue if service == "glue" else dz
 
-        mock_boto3.client.side_effect = _client_factory
+        mock_create_client.side_effect = _client_factory
 
         asset1 = _glue_asset("mydb", "tbl1", asset_name="a1", ds_form=True)
         asset2 = _glue_asset("mydb", "tbl2", asset_name="a2", ds_form=True)
@@ -1075,11 +1093,11 @@ class TestParseFormContent:
 
 
 class TestFindingMetadata:
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_glue_error_has_service_and_resource(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_glue_error_has_service_and_resource(self, mock_create_client, checker):
         glue = MagicMock()
         glue.get_database.side_effect = _client_error("EntityNotFoundException")
-        mock_boto3.client.return_value = glue
+        mock_create_client.return_value = glue
 
         asset = _glue_asset("mydb", "mytable")
         ctx = _make_context(catalog_data={"assets": [asset]})
@@ -1095,8 +1113,8 @@ class TestFindingMetadata:
         assert db_errors[0].details is not None
         assert db_errors[0].details["resource_type"] == "database"
 
-    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.boto3")
-    def test_form_type_error_has_service_and_details(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.dependency_checker.create_client")
+    def test_form_type_error_has_service_and_details(self, mock_create_client, checker):
         glue = MagicMock()
         dz = MagicMock()
         dz.get_form_type.side_effect = _client_error("ResourceNotFoundException")
@@ -1104,7 +1122,7 @@ class TestFindingMetadata:
         def _client_factory(service, **kw):
             return glue if service == "glue" else dz
 
-        mock_boto3.client.side_effect = _client_factory
+        mock_create_client.side_effect = _client_factory
 
         at = _asset_type_resource(
             forms_input={"f": {"typeIdentifier": "custom.MissingForm"}}

--- a/tests/unit/commands/dry_run/test_permission_checker.py
+++ b/tests/unit/commands/dry_run/test_permission_checker.py
@@ -206,11 +206,11 @@ def checker():
 class TestPermissionCheckerCallerIdentity:
     """Tests for STS get_caller_identity."""
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
-    def test_sts_failure_returns_error(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
+    def test_sts_failure_returns_error(self, mock_create_client, checker):
         mock_sts = MagicMock()
         mock_sts.get_caller_identity.side_effect = Exception("STS unavailable")
-        mock_boto3.client.return_value = mock_sts
+        mock_create_client.return_value = mock_sts
 
         context = _make_context(storage_names=["data"])
         findings = checker.check(context)
@@ -223,8 +223,10 @@ class TestPermissionCheckerCallerIdentity:
         "smus_cicd.commands.dry_run.checkers.permission_checker.get_project_connections",
         return_value={},
     )
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
-    def test_sts_success_records_caller_arn(self, mock_boto3, mock_conns, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
+    def test_sts_success_records_caller_arn(
+        self, mock_create_client, mock_conns, checker
+    ):
         mock_sts = MagicMock()
         mock_sts.get_caller_identity.return_value = {
             "Arn": "arn:aws:iam::123456789012:user/testuser"
@@ -237,7 +239,7 @@ class TestPermissionCheckerCallerIdentity:
                 kw["ResourceArns"],
             )
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -250,12 +252,12 @@ class TestPermissionCheckerCallerIdentity:
         ]
         assert len(caller_findings) == 1
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
     @patch(
         "smus_cicd.commands.dry_run.checkers.permission_checker.get_project_connections"
     )
     def test_assumed_role_arn_converted_to_iam_role(
-        self, mock_conns, mock_boto3, checker
+        self, mock_conns, mock_create_client, checker
     ):
         """STS assumed-role ARN should be converted to IAM role ARN for
         SimulatePrincipalPolicy."""
@@ -274,7 +276,7 @@ class TestPermissionCheckerCallerIdentity:
             )
 
         mock_iam.simulate_principal_policy.side_effect = capture_simulate
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -296,11 +298,11 @@ class TestPermissionCheckerCallerIdentity:
 class TestPermissionCheckerS3:
     """Tests for S3 storage permission verification."""
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
     @patch(
         "smus_cicd.commands.dry_run.checkers.permission_checker.get_project_connections"
     )
-    def test_s3_permissions_checked(self, mock_conns, mock_boto3, checker):
+    def test_s3_permissions_checked(self, mock_conns, mock_create_client, checker):
         mock_conns.return_value = {
             "default.s3_shared": {"s3Uri": "s3://real-bucket-123"}
         }
@@ -316,7 +318,7 @@ class TestPermissionCheckerS3:
                 kw["ResourceArns"],
             )
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -328,11 +330,11 @@ class TestPermissionCheckerS3:
         assert any("s3:PutObject" in m for m in ok_msgs)
         assert any("s3:GetObject" in m for m in ok_msgs)
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
     @patch(
         "smus_cicd.commands.dry_run.checkers.permission_checker.get_project_connections"
     )
-    def test_s3_denied_produces_error(self, mock_conns, mock_boto3, checker):
+    def test_s3_denied_produces_error(self, mock_conns, mock_create_client, checker):
         mock_conns.return_value = {
             "default.s3_shared": {"s3Uri": "s3://real-bucket-123"}
         }
@@ -348,7 +350,7 @@ class TestPermissionCheckerS3:
                 kw["ResourceArns"],
             )
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -358,11 +360,11 @@ class TestPermissionCheckerS3:
         error_findings = [f for f in findings if f.severity == Severity.ERROR]
         assert len(error_findings) >= 2  # s3:PutObject + s3:GetObject denied
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
     @patch(
         "smus_cicd.commands.dry_run.checkers.permission_checker.get_project_connections"
     )
-    def test_s3_uses_real_bucket_arn(self, mock_conns, mock_boto3, checker):
+    def test_s3_uses_real_bucket_arn(self, mock_conns, mock_create_client, checker):
         """Verify the S3 ARN uses the resolved bucket name, not the connection suffix."""
         mock_conns.return_value = {
             "default.s3_shared": {"s3Uri": "s3://my-actual-bucket"}
@@ -381,7 +383,7 @@ class TestPermissionCheckerS3:
             )
 
         mock_iam.simulate_principal_policy.side_effect = capture_simulate
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -393,12 +395,12 @@ class TestPermissionCheckerS3:
         # Should NOT contain the old naive split result
         assert not any("s3_shared" in a for a in s3_arns)
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
     @patch(
         "smus_cicd.commands.dry_run.checkers.permission_checker.get_project_connections"
     )
     def test_s3_unresolved_falls_back_to_wildcard(
-        self, mock_conns, mock_boto3, checker
+        self, mock_conns, mock_create_client, checker
     ):
         """When connection can't be resolved, fall back to wildcard S3 ARN."""
         mock_conns.return_value = None
@@ -416,7 +418,7 @@ class TestPermissionCheckerS3:
             )
 
         mock_iam.simulate_principal_policy.side_effect = capture_simulate
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -435,8 +437,8 @@ class TestPermissionCheckerS3:
 class TestPermissionCheckerDataZone:
     """Tests for DataZone permission verification."""
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
-    def test_datazone_permissions_checked(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
+    def test_datazone_permissions_checked(self, mock_create_client, checker):
         mock_sts = MagicMock()
         mock_sts.get_caller_identity.return_value = {
             "Arn": "arn:aws:iam::123456789012:user/testuser"
@@ -449,7 +451,7 @@ class TestPermissionCheckerDataZone:
                 kw["ResourceArns"],
             )
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -470,8 +472,8 @@ class TestPermissionCheckerDataZone:
 class TestPermissionCheckerCatalog:
     """Tests for catalog import and grant permission verification."""
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
-    def test_catalog_permissions_checked(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
+    def test_catalog_permissions_checked(self, mock_create_client, checker):
         mock_sts = MagicMock()
         mock_sts.get_caller_identity.return_value = {
             "Arn": "arn:aws:iam::123456789012:user/testuser"
@@ -484,7 +486,7 @@ class TestPermissionCheckerCatalog:
                 kw["ResourceArns"],
             )
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -512,8 +514,10 @@ class TestPermissionCheckerCatalog:
 class TestPermissionCheckerIAM:
     """Tests for IAM role creation permission verification."""
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
-    def test_iam_permissions_checked_when_role_configured(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
+    def test_iam_permissions_checked_when_role_configured(
+        self, mock_create_client, checker
+    ):
         mock_sts = MagicMock()
         mock_sts.get_caller_identity.return_value = {
             "Arn": "arn:aws:iam::123456789012:user/testuser"
@@ -526,7 +530,7 @@ class TestPermissionCheckerIAM:
                 kw["ResourceArns"],
             )
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -538,8 +542,8 @@ class TestPermissionCheckerIAM:
         assert any("iam:AttachRolePolicy" in m for m in ok_msgs)
         assert any("iam:PutRolePolicy" in m for m in ok_msgs)
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
-    def test_no_iam_permissions_when_no_role(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
+    def test_no_iam_permissions_when_no_role(self, mock_create_client, checker):
         mock_sts = MagicMock()
         mock_sts.get_caller_identity.return_value = {
             "Arn": "arn:aws:iam::123456789012:user/testuser"
@@ -552,7 +556,7 @@ class TestPermissionCheckerIAM:
                 kw["ResourceArns"],
             )
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -571,8 +575,8 @@ class TestPermissionCheckerIAM:
 class TestPermissionCheckerQuickSight:
     """Tests for QuickSight permission verification."""
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
-    def test_quicksight_permissions_checked(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
+    def test_quicksight_permissions_checked(self, mock_create_client, checker):
         mock_sts = MagicMock()
         mock_sts.get_caller_identity.return_value = {
             "Arn": "arn:aws:iam::123456789012:user/testuser"
@@ -585,7 +589,7 @@ class TestPermissionCheckerQuickSight:
                 kw["ResourceArns"],
             )
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -606,8 +610,8 @@ class TestPermissionCheckerQuickSight:
 class TestPermissionCheckerBootstrap:
     """Tests for bootstrap action permission verification."""
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
-    def test_workflow_create_permissions(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
+    def test_workflow_create_permissions(self, mock_create_client, checker):
         mock_sts = MagicMock()
         mock_sts.get_caller_identity.return_value = {
             "Arn": "arn:aws:iam::123456789012:user/testuser"
@@ -620,7 +624,7 @@ class TestPermissionCheckerBootstrap:
                 kw["ResourceArns"],
             )
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -631,8 +635,8 @@ class TestPermissionCheckerBootstrap:
         assert any("airflow-serverless:CreateWorkflow" in m for m in ok_msgs)
         assert any("airflow-serverless:GetWorkflow" in m for m in ok_msgs)
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
-    def test_all_bootstrap_action_types(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
+    def test_all_bootstrap_action_types(self, mock_create_client, checker):
         """Verify all bootstrap action types from BOOTSTRAP_PERMISSION_MAP are checked."""
         mock_sts = MagicMock()
         mock_sts.get_caller_identity.return_value = {
@@ -646,7 +650,7 @@ class TestPermissionCheckerBootstrap:
                 kw["ResourceArns"],
             )
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -675,9 +679,9 @@ class TestPermissionCheckerGlue:
         "smus_cicd.commands.dry_run.checkers.permission_checker.get_project_connections",
         return_value={},
     )
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
     def test_glue_permissions_added_for_glue_refs(
-        self, mock_boto3, mock_conns, checker
+        self, mock_create_client, mock_conns, checker
     ):
         mock_sts = MagicMock()
         mock_sts.get_caller_identity.return_value = {
@@ -691,7 +695,7 @@ class TestPermissionCheckerGlue:
                 kw["ResourceArns"],
             )
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -703,8 +707,8 @@ class TestPermissionCheckerGlue:
         assert any("glue:GetDatabase" in m for m in ok_msgs)
         assert any("glue:GetPartitions" in m for m in ok_msgs)
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
-    def test_no_glue_permissions_without_glue_refs(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
+    def test_no_glue_permissions_without_glue_refs(self, mock_create_client, checker):
         mock_sts = MagicMock()
         mock_sts.get_caller_identity.return_value = {
             "Arn": "arn:aws:iam::123456789012:user/testuser"
@@ -717,7 +721,7 @@ class TestPermissionCheckerGlue:
                 kw["ResourceArns"],
             )
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -750,9 +754,9 @@ class TestPermissionCheckerAccessDeniedFallback:
         "smus_cicd.commands.dry_run.checkers.permission_checker.get_project_connections",
         return_value={},
     )
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
     def test_access_denied_produces_warning_not_error(
-        self, mock_boto3, mock_conns, checker
+        self, mock_create_client, mock_conns, checker
     ):
         from botocore.exceptions import ClientError
 
@@ -765,7 +769,7 @@ class TestPermissionCheckerAccessDeniedFallback:
             {"Error": {"Code": "AccessDenied", "Message": "Not authorized"}},
             "SimulatePrincipalPolicy",
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -789,9 +793,9 @@ class TestPermissionCheckerAccessDeniedFallback:
         "smus_cicd.commands.dry_run.checkers.permission_checker.get_project_connections",
         return_value={},
     )
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
     def test_access_denied_exception_also_produces_warning(
-        self, mock_boto3, mock_conns, checker
+        self, mock_create_client, mock_conns, checker
     ):
         from botocore.exceptions import ClientError
 
@@ -809,7 +813,7 @@ class TestPermissionCheckerAccessDeniedFallback:
             },
             "SimulatePrincipalPolicy",
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -828,8 +832,8 @@ class TestPermissionCheckerAccessDeniedFallback:
 class TestPermissionCheckerEmptyConfig:
     """Tests for empty deployment configuration."""
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
-    def test_empty_config_still_checks_datazone(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
+    def test_empty_config_still_checks_datazone(self, mock_create_client, checker):
         """Even with no storage/catalog/etc, DataZone base permissions are checked."""
         mock_sts = MagicMock()
         mock_sts.get_caller_identity.return_value = {
@@ -843,7 +847,7 @@ class TestPermissionCheckerEmptyConfig:
                 kw["ResourceArns"],
             )
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -866,8 +870,10 @@ class TestPermissionCheckerMixedResults:
         "smus_cicd.commands.dry_run.checkers.permission_checker.get_project_connections",
         return_value={},
     )
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
-    def test_mixed_results_report_each_action(self, mock_boto3, mock_conns, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
+    def test_mixed_results_report_each_action(
+        self, mock_create_client, mock_conns, checker
+    ):
         mock_sts = MagicMock()
         mock_sts.get_caller_identity.return_value = {
             "Arn": "arn:aws:iam::123456789012:user/testuser"
@@ -888,7 +894,7 @@ class TestPermissionCheckerMixedResults:
             return {"EvaluationResults": results}
 
         mock_iam.simulate_principal_policy.side_effect = mixed_simulate
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -910,9 +916,9 @@ class TestPermissionCheckerMixedResults:
         "smus_cicd.commands.dry_run.checkers.permission_checker.get_project_connections",
         return_value={},
     )
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
     def test_denied_finding_contains_action_and_resource(
-        self, mock_boto3, mock_conns, checker
+        self, mock_create_client, mock_conns, checker
     ):
         mock_sts = MagicMock()
         mock_sts.get_caller_identity.return_value = {
@@ -926,7 +932,7 @@ class TestPermissionCheckerMixedResults:
                 kw["ResourceArns"],
             )
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -983,12 +989,12 @@ class TestBootstrapPermissionMap:
 class TestPermissionCheckerDataZoneGrants:
     """Tests for DataZone policy grant verification on domain units."""
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
     @patch(
         "smus_cicd.commands.dry_run.checkers.permission_checker.PermissionChecker._check_datazone_policy_grants"
     )
     def test_grant_check_called_when_catalog_data_present(
-        self, mock_grant_check, mock_boto3, checker
+        self, mock_grant_check, mock_create_client, checker
     ):
         """Verify _check_datazone_policy_grants is called during check()."""
         mock_sts = MagicMock()
@@ -1003,7 +1009,7 @@ class TestPermissionCheckerDataZoneGrants:
                 kw["ResourceArns"],
             )
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -1013,8 +1019,8 @@ class TestPermissionCheckerDataZoneGrants:
 
         mock_grant_check.assert_called_once()
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
-    def test_no_grant_check_without_catalog_data(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
+    def test_no_grant_check_without_catalog_data(self, mock_create_client, checker):
         """Grant check should be skipped when catalog_data is None."""
         mock_sts = MagicMock()
         mock_sts.get_caller_identity.return_value = {
@@ -1028,7 +1034,7 @@ class TestPermissionCheckerDataZoneGrants:
                 kw["ResourceArns"],
             )
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -1039,11 +1045,11 @@ class TestPermissionCheckerDataZoneGrants:
         grant_findings = [f for f in findings if "policy grant" in f.message.lower()]
         assert len(grant_findings) == 0
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
     @patch("smus_cicd.helpers.utils._resolve_domain_id")
     @patch("smus_cicd.helpers.datazone.get_project_id_by_name")
     def test_missing_grant_produces_error(
-        self, mock_get_project_id, mock_resolve_domain, mock_boto3, checker
+        self, mock_get_project_id, mock_resolve_domain, mock_create_client, checker
     ):
         """Missing policy grant should produce an ERROR finding."""
         mock_resolve_domain.return_value = "dzd-test123"
@@ -1066,7 +1072,7 @@ class TestPermissionCheckerDataZoneGrants:
         # All grants missing (empty grantList)
         mock_dz.list_policy_grants.return_value = {"grantList": []}
 
-        mock_boto3.client.side_effect = lambda svc, **kw: {
+        mock_create_client.side_effect = lambda svc, **kw: {
             "sts": mock_sts,
             "iam": mock_iam,
             "datazone": mock_dz,
@@ -1096,11 +1102,11 @@ class TestPermissionCheckerDataZoneGrants:
             "CREATE_ASSET_TYPE",
         }
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
     @patch("smus_cicd.helpers.utils._resolve_domain_id")
     @patch("smus_cicd.helpers.datazone.get_project_id_by_name")
     def test_present_grant_produces_ok(
-        self, mock_get_project_id, mock_resolve_domain, mock_boto3, checker
+        self, mock_get_project_id, mock_resolve_domain, mock_create_client, checker
     ):
         """Existing policy grant should produce an OK finding."""
         mock_resolve_domain.return_value = "dzd-test123"
@@ -1123,7 +1129,7 @@ class TestPermissionCheckerDataZoneGrants:
         # All grants present
         mock_dz.list_policy_grants.return_value = {"grantList": [{"detail": {}}]}
 
-        mock_boto3.client.side_effect = lambda svc, **kw: {
+        mock_create_client.side_effect = lambda svc, **kw: {
             "sts": mock_sts,
             "iam": mock_iam,
             "datazone": mock_dz,
@@ -1145,11 +1151,11 @@ class TestPermissionCheckerDataZoneGrants:
         ]
         assert len(grant_ok) == 3
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
     @patch("smus_cicd.helpers.utils._resolve_domain_id")
     @patch("smus_cicd.helpers.datazone.get_project_id_by_name")
     def test_grant_only_checked_for_present_resource_types(
-        self, mock_get_project_id, mock_resolve_domain, mock_boto3, checker
+        self, mock_get_project_id, mock_resolve_domain, mock_create_client, checker
     ):
         """Grants should only be checked for resource types present in catalog."""
         mock_resolve_domain.return_value = "dzd-test123"
@@ -1171,7 +1177,7 @@ class TestPermissionCheckerDataZoneGrants:
         mock_dz.get_project.return_value = {"domainUnitId": "du-xyz"}
         mock_dz.list_policy_grants.return_value = {"grantList": []}
 
-        mock_boto3.client.side_effect = lambda svc, **kw: {
+        mock_create_client.side_effect = lambda svc, **kw: {
             "sts": mock_sts,
             "iam": mock_iam,
             "datazone": mock_dz,
@@ -1194,10 +1200,10 @@ class TestPermissionCheckerDataZoneGrants:
         assert len(error_findings) == 1
         assert error_findings[0].resource == "CREATE_GLOSSARY"
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
     @patch("smus_cicd.helpers.utils._resolve_domain_id")
     def test_domain_resolution_failure_produces_warning(
-        self, mock_resolve_domain, mock_boto3, checker
+        self, mock_resolve_domain, mock_create_client, checker
     ):
         """Failed domain resolution should produce WARNING, not crash."""
         mock_resolve_domain.side_effect = Exception("Cannot resolve domain")
@@ -1214,7 +1220,7 @@ class TestPermissionCheckerDataZoneGrants:
                 kw["ResourceArns"],
             )
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -1234,11 +1240,11 @@ class TestPermissionCheckerDataZoneGrants:
         ]
         assert len(warn_findings) == 1
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
     @patch("smus_cicd.helpers.utils._resolve_domain_id")
     @patch("smus_cicd.helpers.datazone.get_project_id_by_name")
     def test_access_denied_on_list_grants_produces_warning(
-        self, mock_get_project_id, mock_resolve_domain, mock_boto3, checker
+        self, mock_get_project_id, mock_resolve_domain, mock_create_client, checker
     ):
         """AccessDenied on list_policy_grants should produce WARNING."""
         from botocore.exceptions import ClientError
@@ -1265,7 +1271,7 @@ class TestPermissionCheckerDataZoneGrants:
             "ListPolicyGrants",
         )
 
-        mock_boto3.client.side_effect = lambda svc, **kw: {
+        mock_create_client.side_effect = lambda svc, **kw: {
             "sts": mock_sts,
             "iam": mock_iam,
             "datazone": mock_dz,
@@ -1302,12 +1308,12 @@ class TestPermissionCheckerSkipMissingResources:
     """Tests that permission checks are skipped when the bundle doesn't
     contain files for the declared resource type."""
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
     @patch(
         "smus_cicd.commands.dry_run.checkers.permission_checker.get_project_connections"
     )
     def test_s3_permissions_skipped_when_bundle_has_no_storage_files(
-        self, mock_conns, mock_boto3, checker
+        self, mock_conns, mock_create_client, checker
     ):
         """S3 permissions should be skipped when bundle_files is populated
         but contains no files matching any storage item."""
@@ -1326,7 +1332,7 @@ class TestPermissionCheckerSkipMissingResources:
             )
 
         mock_iam.simulate_principal_policy.side_effect = capture_simulate
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -1343,12 +1349,12 @@ class TestPermissionCheckerSkipMissingResources:
         assert not any("s3:PutObject" in m for m in all_msgs)
         assert not any("s3:GetObject" in m for m in all_msgs)
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
     @patch(
         "smus_cicd.commands.dry_run.checkers.permission_checker.get_project_connections"
     )
     def test_s3_permissions_checked_when_bundle_has_storage_files(
-        self, mock_conns, mock_boto3, checker
+        self, mock_conns, mock_create_client, checker
     ):
         """S3 permissions should still be checked when bundle has matching
         storage files."""
@@ -1363,7 +1369,7 @@ class TestPermissionCheckerSkipMissingResources:
                 kw["PolicySourceArn"], kw["ActionNames"], kw["ResourceArns"]
             )
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -1376,9 +1382,9 @@ class TestPermissionCheckerSkipMissingResources:
         assert any("s3:PutObject" in m for m in ok_msgs)
         assert any("s3:GetObject" in m for m in ok_msgs)
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
     def test_quicksight_permissions_skipped_when_bundle_has_no_qs_files(
-        self, mock_boto3, checker
+        self, mock_create_client, checker
     ):
         """QuickSight permissions should be skipped when bundle_files is
         populated but contains no quicksight/ files."""
@@ -1392,7 +1398,7 @@ class TestPermissionCheckerSkipMissingResources:
                 kw["PolicySourceArn"], kw["ActionNames"], kw["ResourceArns"]
             )
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -1406,9 +1412,9 @@ class TestPermissionCheckerSkipMissingResources:
         assert not any("quicksight:CreateDashboard" in m for m in all_msgs)
         assert not any("quicksight:UpdateDashboard" in m for m in all_msgs)
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
     def test_quicksight_permissions_checked_when_bundle_has_qs_files(
-        self, mock_boto3, checker
+        self, mock_create_client, checker
     ):
         """QuickSight permissions should be checked when bundle has
         quicksight/ files."""
@@ -1422,7 +1428,7 @@ class TestPermissionCheckerSkipMissingResources:
                 kw["PolicySourceArn"], kw["ActionNames"], kw["ResourceArns"]
             )
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -1434,12 +1440,12 @@ class TestPermissionCheckerSkipMissingResources:
         ok_msgs = [f.message for f in findings if f.severity == Severity.OK]
         assert any("quicksight:DescribeDashboard" in m for m in ok_msgs)
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
     @patch(
         "smus_cicd.commands.dry_run.checkers.permission_checker.get_project_connections"
     )
     def test_s3_permissions_still_checked_when_bundle_not_explored(
-        self, mock_conns, mock_boto3, checker
+        self, mock_conns, mock_create_client, checker
     ):
         """When bundle_files is empty (bundle not yet explored), S3
         permissions should still be checked — we don't know what's in
@@ -1455,7 +1461,7 @@ class TestPermissionCheckerSkipMissingResources:
                 kw["PolicySourceArn"], kw["ActionNames"], kw["ResourceArns"]
             )
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -1479,8 +1485,8 @@ class TestDataZoneArnWildcardFallback:
     ``arn:aws:datazone:…:*:domain/*`` which causes ``SimulatePrincipalPolicy``
     to return ``implicitDeny`` even for admin roles."""
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
-    def test_wildcard_domain_uses_star_arn(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
+    def test_wildcard_domain_uses_star_arn(self, mock_create_client, checker):
         """When domain_id defaults to '*', the resource ARN passed to
         SimulatePrincipalPolicy should be '*' (not a constructed ARN)."""
         mock_sts = MagicMock()
@@ -1493,7 +1499,7 @@ class TestDataZoneArnWildcardFallback:
                 kw["PolicySourceArn"], kw["ActionNames"], kw["ResourceArns"]
             )
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 
@@ -1522,8 +1528,8 @@ class TestDataZoneArnWildcardFallback:
             "arn:aws:datazone" in a and ":*:" in a for a in resource_arns
         ), "Should not construct partial-wildcard DataZone ARNs"
 
-    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.boto3")
-    def test_real_domain_uses_full_arn(self, mock_boto3, checker):
+    @patch("smus_cicd.commands.dry_run.checkers.permission_checker.create_client")
+    def test_real_domain_uses_full_arn(self, mock_create_client, checker):
         """When domain_id and account_id are real values, a fully-qualified
         DataZone ARN should be used."""
         mock_sts = MagicMock()
@@ -1536,7 +1542,7 @@ class TestDataZoneArnWildcardFallback:
                 kw["PolicySourceArn"], kw["ActionNames"], kw["ResourceArns"]
             )
         )
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
 

--- a/tests/unit/commands/dry_run/test_properties.py
+++ b/tests/unit/commands/dry_run/test_properties.py
@@ -811,12 +811,12 @@ def test_property_9_permission_set_correctness(
     mock_iam.simulate_principal_policy.side_effect = capture_simulate
 
     with patch(
-        "smus_cicd.commands.dry_run.checkers.permission_checker.boto3"
-    ) as mock_boto3, patch(
+        "smus_cicd.commands.dry_run.checkers.permission_checker.create_client"
+    ) as mock_create_client, patch(
         "smus_cicd.commands.dry_run.checkers.permission_checker.get_project_connections",
         return_value={},
     ):
-        mock_boto3.client.side_effect = lambda svc, **kw: (
+        mock_create_client.side_effect = lambda svc, **kw: (
             mock_sts if svc == "sts" else mock_iam
         )
         checker = PermissionChecker()
@@ -992,15 +992,15 @@ def test_property_14_s3_bucket_reachability(bucket_names, fail_flags):
 
     # Mock get_project_by_name and _get_project_connections
     with patch(
-        "smus_cicd.commands.dry_run.checkers.connectivity_checker.boto3"
-    ) as mock_boto3, patch(
+        "smus_cicd.commands.dry_run.checkers.connectivity_checker.create_client"
+    ) as mock_create_client, patch(
         "smus_cicd.helpers.datazone.get_project_by_name",
         return_value={"name": "test-project"},
     ), patch(
         "smus_cicd.commands.dry_run.checkers.connectivity_checker.get_project_connections",
         return_value=mock_connections,
     ):
-        mock_boto3.client.side_effect = lambda svc, **kw: {
+        mock_create_client.side_effect = lambda svc, **kw: {
             "datazone": mock_dz,
             "s3": mock_s3,
         }.get(svc, MagicMock())

--- a/tests/unit/commands/test_destroy.py
+++ b/tests/unit/commands/test_destroy.py
@@ -10,20 +10,29 @@ Covers:
 """
 
 import json
+from unittest.mock import MagicMock, call, patch
+
 import pytest
-from unittest.mock import MagicMock, patch, call
 from botocore.exceptions import ClientError
 from typer.testing import CliRunner
 
-from smus_cicd.cli import app
-from smus_cicd.helpers.operator_registry import OPERATOR_REGISTRY, _delete_glue_job
-from smus_cicd.helpers.quicksight import (
-    QuickSightDeploymentError,
-    list_dashboards,
-    list_data_sources,
+from smus_cicd.application.application_manifest import (
+    ApplicationManifest,
+    ContentConfig,
+    DeploymentConfiguration,
+    DomainConfig,
+    GitTargetConfig,
+    ProjectConfig,
+    QuickSightDashboardConfig,
+    StageConfig,
+    StorageConfig,
 )
+from smus_cicd.cli import app
 from smus_cicd.commands.destroy import (
     destroy_command,
+)
+from smus_cicd.helpers.destroy_executor import (
+    _destroy_stage,
 )
 from smus_cicd.helpers.destroy_models import (
     ResourceResult,
@@ -36,21 +45,12 @@ from smus_cicd.helpers.destroy_validator import (
     _resolve_s3_targets,
     _validate_stage,
 )
-from smus_cicd.helpers.destroy_executor import (
-    _destroy_stage,
+from smus_cicd.helpers.operator_registry import OPERATOR_REGISTRY, _delete_glue_job
+from smus_cicd.helpers.quicksight import (
+    QuickSightDeploymentError,
+    list_dashboards,
+    list_data_sources,
 )
-from smus_cicd.application.application_manifest import (
-    ApplicationManifest,
-    ContentConfig,
-    DeploymentConfiguration,
-    DomainConfig,
-    GitTargetConfig,
-    ProjectConfig,
-    QuickSightDashboardConfig,
-    StageConfig,
-    StorageConfig,
-)
-
 
 # ---------------------------------------------------------------------------
 # Shared constants and helpers
@@ -67,21 +67,25 @@ PATCH_DELETE_WF = "smus_cicd.helpers.destroy_executor.delete_workflow"
 PATCH_DOMAIN = "smus_cicd.helpers.destroy_validator.get_domain_from_target_config"
 PATCH_PROJECT_ID = "smus_cicd.helpers.destroy_validator.get_project_id_by_name"
 PATCH_DELETE_PROJECT = "smus_cicd.helpers.destroy_executor.delete_project"
-PATCH_BOTO3 = "smus_cicd.helpers.destroy_executor.boto3"
+PATCH_BOTO3 = "smus_cicd.helpers.destroy_executor.create_client"
 PATCH_CONNECTIONS = "smus_cicd.helpers.destroy_validator.get_project_connections"
 PATCH_FIND_QS = "smus_cicd.helpers.destroy_validator.find_resources_by_prefix"
 PATCH_LIST_WORKFLOWS = "smus_cicd.helpers.destroy_validator.list_workflows"
 PATCH_LIST_RUNS = "smus_cicd.helpers.destroy_validator.list_workflow_runs"
 PATCH_IS_ACTIVE = "smus_cicd.helpers.destroy_validator.is_workflow_run_active"
 PATCH_GET_WF_DEF = "smus_cicd.helpers.destroy_validator.get_workflow_definition"
-PATCH_STS = "smus_cicd.helpers.destroy_validator.boto3"
+PATCH_STS = "smus_cicd.helpers.destroy_validator.create_client"
 
 
-def _make_manifest(app_name="TestApp", quicksight_assets=None, workflows=None, storage=None):
+def _make_manifest(
+    app_name="TestApp", quicksight_assets=None, workflows=None, storage=None
+):
     return ApplicationManifest(
         application_name=app_name,
         content=ContentConfig(
-            quicksight=[QuickSightDashboardConfig(name=q) for q in (quicksight_assets or [])],
+            quicksight=[
+                QuickSightDashboardConfig(name=q) for q in (quicksight_assets or [])
+            ],
             workflows=workflows or [],
             storage=storage or [],
         ),
@@ -109,13 +113,19 @@ def _make_stage_config(
         }
     dc = DeploymentConfiguration(
         storage=[
-            StorageConfig(name=s["name"], connectionName=s["connectionName"],
-                          targetDirectory=s.get("targetDirectory", ""))
+            StorageConfig(
+                name=s["name"],
+                connectionName=s["connectionName"],
+                targetDirectory=s.get("targetDirectory", ""),
+            )
             for s in (storage or [])
         ],
         git=[
-            GitTargetConfig(name=g["name"], connectionName=g["connectionName"],
-                            targetDirectory=g.get("targetDirectory", ""))
+            GitTargetConfig(
+                name=g["name"],
+                connectionName=g["connectionName"],
+                targetDirectory=g.get("targetDirectory", ""),
+            )
             for g in (git or [])
         ],
         quicksight=qs_config,
@@ -139,7 +149,7 @@ def _make_vr(resources=None, active_runs=None, errors=None):
 
 def _make_manifest_mock(stages=None, app_name="TestApp", workflows=None):
     stages_dict = {}
-    for name in (stages or ["dev"]):
+    for name in stages or ["dev"]:
         stages_dict[name] = StageConfig(
             project=ProjectConfig(name=f"{name}-project"),
             domain=DomainConfig(region="us-east-1"),
@@ -161,6 +171,7 @@ def _ok_results():
 # Level 1: Operator registry (U1–U6)
 # ---------------------------------------------------------------------------
 
+
 class TestOperatorRegistry:
     def test_u1_registry_contains_glue_operator(self):
         assert GLUE_OPERATOR_KEY in OPERATOR_REGISTRY
@@ -174,31 +185,34 @@ class TestOperatorRegistry:
     def test_u3_glue_entry_delete_fn_is_callable(self):
         assert callable(OPERATOR_REGISTRY[GLUE_OPERATOR_KEY]["delete_fn"])
 
-    @patch("smus_cicd.helpers.operator_registry.boto3")
+    @patch("smus_cicd.helpers.operator_registry.create_client")
     def test_u4_delete_glue_job_calls_correct_api(self, mock_boto3):
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
+        mock_boto3.return_value = mock_client
         _delete_glue_job("my-glue-job", "us-east-1")
-        mock_boto3.client.assert_called_once_with("glue", region_name="us-east-1")
+        mock_boto3.assert_called_once_with("glue", region="us-east-1")
         mock_client.delete_job.assert_called_once_with(JobName="my-glue-job")
 
-    @patch("smus_cicd.helpers.operator_registry.boto3")
+    @patch("smus_cicd.helpers.operator_registry.create_client")
     def test_u5_entity_not_found_raises_resource_not_found_error(self, mock_boto3):
         from smus_cicd.helpers.operator_registry import ResourceNotFoundError
+
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
+        mock_boto3.return_value = mock_client
         mock_client.delete_job.side_effect = ClientError(
-            {"Error": {"Code": "EntityNotFoundException", "Message": "Not found"}}, "DeleteJob"
+            {"Error": {"Code": "EntityNotFoundException", "Message": "Not found"}},
+            "DeleteJob",
         )
         with pytest.raises(ResourceNotFoundError):
             _delete_glue_job("missing-job", "us-east-1")
 
-    @patch("smus_cicd.helpers.operator_registry.boto3")
+    @patch("smus_cicd.helpers.operator_registry.create_client")
     def test_u6_other_errors_propagated(self, mock_boto3):
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
+        mock_boto3.return_value = mock_client
         mock_client.delete_job.side_effect = ClientError(
-            {"Error": {"Code": "AccessDeniedException", "Message": "Denied"}}, "DeleteJob"
+            {"Error": {"Code": "AccessDeniedException", "Message": "Denied"}},
+            "DeleteJob",
         )
         with pytest.raises(ClientError):
             _delete_glue_job("some-job", "us-east-1")
@@ -208,20 +222,24 @@ class TestOperatorRegistry:
 # Level 2: QuickSight list helpers (U7–U14)
 # ---------------------------------------------------------------------------
 
+
 class TestListDashboards:
-    @patch("smus_cicd.helpers.quicksight.boto3")
+    @patch("smus_cicd.helpers.quicksight.create_client")
     def test_u7_single_page(self, mock_boto3):
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
+        mock_boto3.return_value = mock_client
         mock_client.list_dashboards.return_value = {
             "DashboardSummaryList": [{"DashboardId": "d1"}, {"DashboardId": "d2"}]
         }
-        assert list_dashboards("123456789012", "us-east-1") == [{"DashboardId": "d1"}, {"DashboardId": "d2"}]
+        assert list_dashboards("123456789012", "us-east-1") == [
+            {"DashboardId": "d1"},
+            {"DashboardId": "d2"},
+        ]
 
-    @patch("smus_cicd.helpers.quicksight.boto3")
+    @patch("smus_cicd.helpers.quicksight.create_client")
     def test_u8_multi_page_follows_next_token(self, mock_boto3):
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
+        mock_boto3.return_value = mock_client
         mock_client.list_dashboards.side_effect = [
             {"DashboardSummaryList": [{"DashboardId": "d1"}], "NextToken": "tok"},
             {"DashboardSummaryList": [{"DashboardId": "d2"}]},
@@ -230,38 +248,42 @@ class TestListDashboards:
         assert result == [{"DashboardId": "d1"}, {"DashboardId": "d2"}]
         assert mock_client.list_dashboards.call_count == 2
 
-    @patch("smus_cicd.helpers.quicksight.boto3")
+    @patch("smus_cicd.helpers.quicksight.create_client")
     def test_u9_empty_response(self, mock_boto3):
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
+        mock_boto3.return_value = mock_client
         mock_client.list_dashboards.return_value = {"DashboardSummaryList": []}
         assert list_dashboards("123456789012", "us-east-1") == []
 
-    @patch("smus_cicd.helpers.quicksight.boto3")
+    @patch("smus_cicd.helpers.quicksight.create_client")
     def test_u10_client_error_raises(self, mock_boto3):
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
+        mock_boto3.return_value = mock_client
         mock_client.list_dashboards.side_effect = ClientError(
-            {"Error": {"Code": "AccessDeniedException", "Message": "Denied"}}, "ListDashboards"
+            {"Error": {"Code": "AccessDeniedException", "Message": "Denied"}},
+            "ListDashboards",
         )
         with pytest.raises(QuickSightDeploymentError):
             list_dashboards("123456789012", "us-east-1")
 
 
 class TestListDataSources:
-    @patch("smus_cicd.helpers.quicksight.boto3")
+    @patch("smus_cicd.helpers.quicksight.create_client")
     def test_u11_single_page(self, mock_boto3):
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
+        mock_boto3.return_value = mock_client
         mock_client.list_data_sources.return_value = {
             "DataSources": [{"DataSourceId": "ds1"}, {"DataSourceId": "ds2"}]
         }
-        assert list_data_sources("123456789012", "us-east-1") == [{"DataSourceId": "ds1"}, {"DataSourceId": "ds2"}]
+        assert list_data_sources("123456789012", "us-east-1") == [
+            {"DataSourceId": "ds1"},
+            {"DataSourceId": "ds2"},
+        ]
 
-    @patch("smus_cicd.helpers.quicksight.boto3")
+    @patch("smus_cicd.helpers.quicksight.create_client")
     def test_u12_multi_page_follows_next_token(self, mock_boto3):
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
+        mock_boto3.return_value = mock_client
         mock_client.list_data_sources.side_effect = [
             {"DataSources": [{"DataSourceId": "ds1"}], "NextToken": "tok"},
             {"DataSources": [{"DataSourceId": "ds2"}]},
@@ -270,19 +292,20 @@ class TestListDataSources:
         assert result == [{"DataSourceId": "ds1"}, {"DataSourceId": "ds2"}]
         assert mock_client.list_data_sources.call_count == 2
 
-    @patch("smus_cicd.helpers.quicksight.boto3")
+    @patch("smus_cicd.helpers.quicksight.create_client")
     def test_u13_empty_response(self, mock_boto3):
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
+        mock_boto3.return_value = mock_client
         mock_client.list_data_sources.return_value = {"DataSources": []}
         assert list_data_sources("123456789012", "us-east-1") == []
 
-    @patch("smus_cicd.helpers.quicksight.boto3")
+    @patch("smus_cicd.helpers.quicksight.create_client")
     def test_u14_client_error_raises(self, mock_boto3):
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
+        mock_boto3.return_value = mock_client
         mock_client.list_data_sources.side_effect = ClientError(
-            {"Error": {"Code": "AccessDeniedException", "Message": "Denied"}}, "ListDataSources"
+            {"Error": {"Code": "AccessDeniedException", "Message": "Denied"}},
+            "ListDataSources",
         )
         with pytest.raises(QuickSightDeploymentError):
             list_data_sources("123456789012", "us-east-1")
@@ -299,7 +322,8 @@ class TestDiscoverWorkflowCreatedResources:
 
     def test_u18_glue_operator_returns_glue_job(self):
         result = _discover_workflow_created_resources(
-            self._yaml({"t1": {"operator": GLUE_OPERATOR_KEY, "job_name": "my-job"}}), "dev"
+            self._yaml({"t1": {"operator": GLUE_OPERATOR_KEY, "job_name": "my-job"}}),
+            "dev",
         )
         assert len(result) == 1
         assert result[0].resource_type == "glue_job"
@@ -314,17 +338,25 @@ class TestDiscoverWorkflowCreatedResources:
 
     def test_u20_template_variable_in_job_name_skipped(self):
         result = _discover_workflow_created_resources(
-            self._yaml({"t1": {"operator": GLUE_OPERATOR_KEY, "job_name": "{proj.name}-job"}}), "dev"
+            self._yaml(
+                {"t1": {"operator": GLUE_OPERATOR_KEY, "job_name": "{proj.name}-job"}}
+            ),
+            "dev",
         )
         assert result[0].resource_type == "skipped"
         assert "template variable" in result[0].metadata["reason"]
 
     def test_u21_mixed_operators_correct_counts(self):
-        result = _discover_workflow_created_resources(self._yaml({
-            "g": {"operator": GLUE_OPERATOR_KEY, "job_name": "real-job"},
-            "n": {"operator": "SageMakerNotebookOperator"},
-            "t": {"operator": GLUE_OPERATOR_KEY, "job_name": "{x}-job"},
-        }), "dev")
+        result = _discover_workflow_created_resources(
+            self._yaml(
+                {
+                    "g": {"operator": GLUE_OPERATOR_KEY, "job_name": "real-job"},
+                    "n": {"operator": "SageMakerNotebookOperator"},
+                    "t": {"operator": GLUE_OPERATOR_KEY, "job_name": "{x}-job"},
+                }
+            ),
+            "dev",
+        )
         assert len(result) == 3
         assert sum(1 for r in result if r.resource_type == "glue_job") == 1
         assert sum(1 for r in result if r.resource_type == "skipped") == 2
@@ -335,21 +367,33 @@ class TestDiscoverWorkflowCreatedResources:
 
 class TestResolveS3Targets:
     def _connections(self, entries):
-        return {name: {"s3Uri": uri, "bucket_name": uri.replace("s3://", "").split("/")[0]}
-                for name, uri in entries}
+        return {
+            name: {"s3Uri": uri, "bucket_name": uri.replace("s3://", "").split("/")[0]}
+            for name, uri in entries
+        }
 
     def test_u23_two_non_overlapping_entries(self):
         sc = _make_stage_config(
-            storage=[{"name": "a", "connectionName": "c1", "targetDirectory": "a/bundle"},
-                     {"name": "b", "connectionName": "c2", "targetDirectory": "b/files"}]
+            storage=[
+                {"name": "a", "connectionName": "c1", "targetDirectory": "a/bundle"},
+                {"name": "b", "connectionName": "c2", "targetDirectory": "b/files"},
+            ]
         )
-        result = _resolve_s3_targets(sc, self._connections([("c1", "s3://bkt/base/"), ("c2", "s3://bkt/base/")]))
+        result = _resolve_s3_targets(
+            sc, self._connections([("c1", "s3://bkt/base/"), ("c2", "s3://bkt/base/")])
+        )
         assert len(result) == 2
 
     def test_u24_overlapping_prefixes_deduplicates(self):
         sc = _make_stage_config(
-            storage=[{"name": "bundle", "connectionName": "c1", "targetDirectory": "bundle"},
-                     {"name": "wf", "connectionName": "c1", "targetDirectory": "bundle/workflows"}]
+            storage=[
+                {"name": "bundle", "connectionName": "c1", "targetDirectory": "bundle"},
+                {
+                    "name": "wf",
+                    "connectionName": "c1",
+                    "targetDirectory": "bundle/workflows",
+                },
+            ]
         )
         result = _resolve_s3_targets(sc, self._connections([("c1", "s3://bkt/base/")]))
         assert len(result) == 1
@@ -363,14 +407,19 @@ class TestResolveS3Targets:
         assert len(result) == 2
 
     def test_u26_no_deployment_configuration_returns_empty(self):
-        sc = StageConfig(project=ProjectConfig(name="p"), domain=DomainConfig(region="us-east-1"),
-                         stage="DEV", deployment_configuration=None)
+        sc = StageConfig(
+            project=ProjectConfig(name="p"),
+            domain=DomainConfig(region="us-east-1"),
+            stage="DEV",
+            deployment_configuration=None,
+        )
         assert _resolve_s3_targets(sc, {}) == []
 
 
 # ---------------------------------------------------------------------------
 # Level 4: Validation phase (U27–U36)
 # ---------------------------------------------------------------------------
+
 
 class TestValidateStageClean:
     @patch(PATCH_GET_WF_DEF, return_value="")
@@ -380,7 +429,9 @@ class TestValidateStageClean:
     @patch(PATCH_PROJECT_ID, return_value="proj-123")
     @patch(PATCH_DOMAIN, return_value=("dom-123", "my-domain"))
     def test_u27_clean_stage_no_errors(self, *_):
-        result = _validate_stage("dev", _make_stage_config(), _make_manifest(), "us-east-1")
+        result = _validate_stage(
+            "dev", _make_stage_config(), _make_manifest(), "us-east-1"
+        )
         assert result.errors == []
 
 
@@ -388,55 +439,89 @@ class TestValidateStageQuickSightCollisions:
     def _sts_mock(self, mock_boto3):
         sts = MagicMock()
         sts.get_caller_identity.return_value = {"Account": "111122223333"}
-        mock_boto3.client.return_value = sts
+        mock_boto3.return_value = sts
 
     @patch(PATCH_FIND_QS)
     @patch(PATCH_CONNECTIONS, return_value={})
     @patch(PATCH_PROJECT_ID, return_value="proj-123")
     @patch(PATCH_DOMAIN, return_value=("dom-123", "my-domain"))
     @patch(PATCH_STS)
-    def test_u28_dashboard_collision(self, mock_boto3, mock_domain, mock_project, mock_conns, mock_find_qs):
+    def test_u28_dashboard_collision(
+        self, mock_boto3, mock_domain, mock_project, mock_conns, mock_find_qs
+    ):
         self._sts_mock(mock_boto3)
         mock_find_qs.return_value = {
-            "dashboards": [{"DashboardId": "deployed-dev-covid-d1"}, {"DashboardId": "deployed-dev-covid-d2"}],
+            "dashboards": [
+                {"DashboardId": "deployed-dev-covid-d1"},
+                {"DashboardId": "deployed-dev-covid-d2"},
+            ],
             "datasets": [],
             "data_sources": [],
         }
-        result = _validate_stage("dev", _make_stage_config(has_quicksight=True),
-                                 _make_manifest(quicksight_assets=["TotalDeathByCountry"]), "us-east-1")
-        assert any("dashboard" in e.lower() or "collision" in e.lower() for e in result.errors)
+        result = _validate_stage(
+            "dev",
+            _make_stage_config(has_quicksight=True),
+            _make_manifest(quicksight_assets=["TotalDeathByCountry"]),
+            "us-east-1",
+        )
+        assert any(
+            "dashboard" in e.lower() or "collision" in e.lower() for e in result.errors
+        )
 
     @patch(PATCH_FIND_QS)
     @patch(PATCH_CONNECTIONS, return_value={})
     @patch(PATCH_PROJECT_ID, return_value="proj-123")
     @patch(PATCH_DOMAIN, return_value=("dom-123", "my-domain"))
     @patch(PATCH_STS)
-    def test_u29_dataset_collision(self, mock_boto3, mock_domain, mock_project, mock_conns, mock_find_qs):
+    def test_u29_dataset_collision(
+        self, mock_boto3, mock_domain, mock_project, mock_conns, mock_find_qs
+    ):
         self._sts_mock(mock_boto3)
         mock_find_qs.return_value = {
             "dashboards": [],
-            "datasets": [{"DataSetId": "deployed-dev-covid-ds1"}, {"DataSetId": "deployed-dev-covid-ds2"}],
+            "datasets": [
+                {"DataSetId": "deployed-dev-covid-ds1"},
+                {"DataSetId": "deployed-dev-covid-ds2"},
+            ],
             "data_sources": [],
         }
-        result = _validate_stage("dev", _make_stage_config(has_quicksight=True),
-                                 _make_manifest(quicksight_assets=["TotalDeathByCountry"]), "us-east-1")
-        assert any("dataset" in e.lower() or "collision" in e.lower() for e in result.errors)
+        result = _validate_stage(
+            "dev",
+            _make_stage_config(has_quicksight=True),
+            _make_manifest(quicksight_assets=["TotalDeathByCountry"]),
+            "us-east-1",
+        )
+        assert any(
+            "dataset" in e.lower() or "collision" in e.lower() for e in result.errors
+        )
 
     @patch(PATCH_FIND_QS)
     @patch(PATCH_CONNECTIONS, return_value={})
     @patch(PATCH_PROJECT_ID, return_value="proj-123")
     @patch(PATCH_DOMAIN, return_value=("dom-123", "my-domain"))
     @patch(PATCH_STS)
-    def test_u30_data_source_collision(self, mock_boto3, mock_domain, mock_project, mock_conns, mock_find_qs):
+    def test_u30_data_source_collision(
+        self, mock_boto3, mock_domain, mock_project, mock_conns, mock_find_qs
+    ):
         self._sts_mock(mock_boto3)
         mock_find_qs.return_value = {
             "dashboards": [],
             "datasets": [],
-            "data_sources": [{"DataSourceId": "deployed-dev-covid-s1"}, {"DataSourceId": "deployed-dev-covid-s2"}],
+            "data_sources": [
+                {"DataSourceId": "deployed-dev-covid-s1"},
+                {"DataSourceId": "deployed-dev-covid-s2"},
+            ],
         }
-        result = _validate_stage("dev", _make_stage_config(has_quicksight=True),
-                                 _make_manifest(quicksight_assets=["TotalDeathByCountry"]), "us-east-1")
-        assert any("data_source" in e.lower() or "collision" in e.lower() for e in result.errors)
+        result = _validate_stage(
+            "dev",
+            _make_stage_config(has_quicksight=True),
+            _make_manifest(quicksight_assets=["TotalDeathByCountry"]),
+            "us-east-1",
+        )
+        assert any(
+            "data_source" in e.lower() or "collision" in e.lower()
+            for e in result.errors
+        )
 
 
 class TestQuickSightExactIdResolution:
@@ -445,9 +530,12 @@ class TestQuickSightExactIdResolution:
     def _sts_mock(self, mock_boto3):
         sts = MagicMock()
         sts.get_caller_identity.return_value = {"Account": "111122223333"}
-        mock_boto3.client.return_value = sts
+        mock_boto3.return_value = sts
 
-    @patch(PATCH_FIND_QS, return_value={"dashboards": [], "datasets": [], "data_sources": []})
+    @patch(
+        PATCH_FIND_QS,
+        return_value={"dashboards": [], "datasets": [], "data_sources": []},
+    )
     @patch(PATCH_CONNECTIONS, return_value={})
     @patch(PATCH_PROJECT_ID, return_value="proj-123")
     @patch(PATCH_DOMAIN, return_value=("dom-123", "my-domain"))
@@ -457,15 +545,29 @@ class TestQuickSightExactIdResolution:
         self._sts_mock(mock_boto3)
         sc = _make_stage_config(
             has_quicksight=True,
-            qs_overrides={"Dashboards": [{"DashboardId": "TotalDeathByCountry", "Name": "Deaths"}]},
+            qs_overrides={
+                "Dashboards": [{"DashboardId": "TotalDeathByCountry", "Name": "Deaths"}]
+            },
         )
-        result = _validate_stage("dev", sc,
-                                 _make_manifest(quicksight_assets=["TotalDeathByCountry"]), "us-east-1")
-        dashboard_resources = [r for r in result.resources if r.resource_type == "quicksight_dashboard"]
+        result = _validate_stage(
+            "dev",
+            sc,
+            _make_manifest(quicksight_assets=["TotalDeathByCountry"]),
+            "us-east-1",
+        )
+        dashboard_resources = [
+            r for r in result.resources if r.resource_type == "quicksight_dashboard"
+        ]
         assert len(dashboard_resources) == 1
-        assert dashboard_resources[0].resource_id == "deployed-dev-covid-TotalDeathByCountry"
+        assert (
+            dashboard_resources[0].resource_id
+            == "deployed-dev-covid-TotalDeathByCountry"
+        )
 
-    @patch(PATCH_FIND_QS, return_value={"dashboards": [], "datasets": [], "data_sources": []})
+    @patch(
+        PATCH_FIND_QS,
+        return_value={"dashboards": [], "datasets": [], "data_sources": []},
+    )
     @patch(PATCH_CONNECTIONS, return_value={})
     @patch(PATCH_PROJECT_ID, return_value="proj-123")
     @patch(PATCH_DOMAIN, return_value=("dom-123", "my-domain"))
@@ -483,12 +585,39 @@ class TestQuickSightExactIdResolution:
                 "DataSources": [{"DataSourceId": "src1", "Name": "S1"}],
             },
         )
-        result = _validate_stage("dev", sc,
-                                 _make_manifest(quicksight_assets=["TotalDeathByCountry"]), "us-east-1")
+        result = _validate_stage(
+            "dev",
+            sc,
+            _make_manifest(quicksight_assets=["TotalDeathByCountry"]),
+            "us-east-1",
+        )
         mock_find_qs.assert_not_called()
-        assert len([r for r in result.resources if r.resource_type == "quicksight_dashboard"]) == 1
-        assert len([r for r in result.resources if r.resource_type == "quicksight_dataset"]) == 1
-        assert len([r for r in result.resources if r.resource_type == "quicksight_data_source"]) == 1
+        assert (
+            len(
+                [
+                    r
+                    for r in result.resources
+                    if r.resource_type == "quicksight_dashboard"
+                ]
+            )
+            == 1
+        )
+        assert (
+            len(
+                [r for r in result.resources if r.resource_type == "quicksight_dataset"]
+            )
+            == 1
+        )
+        assert (
+            len(
+                [
+                    r
+                    for r in result.resources
+                    if r.resource_type == "quicksight_data_source"
+                ]
+            )
+            == 1
+        )
 
     @patch(PATCH_FIND_QS)
     @patch(PATCH_CONNECTIONS, return_value={})
@@ -509,13 +638,34 @@ class TestQuickSightExactIdResolution:
             has_quicksight=True,
             qs_overrides={"Dashboards": [{"DashboardId": "d1", "Name": "D1"}]},
         )
-        result = _validate_stage("dev", sc,
-                                 _make_manifest(quicksight_assets=["TotalDeathByCountry"]), "us-east-1")
+        result = _validate_stage(
+            "dev",
+            sc,
+            _make_manifest(quicksight_assets=["TotalDeathByCountry"]),
+            "us-east-1",
+        )
         mock_find_qs.assert_called_once()
-        assert len([r for r in result.resources if r.resource_type == "quicksight_dashboard"]) == 1
-        assert len([r for r in result.resources if r.resource_type == "quicksight_dataset"]) == 1
+        assert (
+            len(
+                [
+                    r
+                    for r in result.resources
+                    if r.resource_type == "quicksight_dashboard"
+                ]
+            )
+            == 1
+        )
+        assert (
+            len(
+                [r for r in result.resources if r.resource_type == "quicksight_dataset"]
+            )
+            == 1
+        )
 
-    @patch(PATCH_FIND_QS, return_value={"dashboards": [], "datasets": [], "data_sources": []})
+    @patch(
+        PATCH_FIND_QS,
+        return_value={"dashboards": [], "datasets": [], "data_sources": []},
+    )
     @patch(PATCH_CONNECTIONS, return_value={})
     @patch(PATCH_PROJECT_ID, return_value="proj-123")
     @patch(PATCH_DOMAIN, return_value=("dom-123", "my-domain"))
@@ -527,11 +677,19 @@ class TestQuickSightExactIdResolution:
         self._sts_mock(mock_boto3)
         sc = _make_stage_config(
             has_quicksight=True,
-            qs_overrides={"Dashboards": [{"DashboardId": "dash-{stage.name}", "Name": "D"}]},
+            qs_overrides={
+                "Dashboards": [{"DashboardId": "dash-{stage.name}", "Name": "D"}]
+            },
         )
-        result = _validate_stage("test", sc,
-                                 _make_manifest(quicksight_assets=["TotalDeathByCountry"]), "us-east-1")
-        dashboard_resources = [r for r in result.resources if r.resource_type == "quicksight_dashboard"]
+        result = _validate_stage(
+            "test",
+            sc,
+            _make_manifest(quicksight_assets=["TotalDeathByCountry"]),
+            "us-east-1",
+        )
+        dashboard_resources = [
+            r for r in result.resources if r.resource_type == "quicksight_dashboard"
+        ]
         assert dashboard_resources[0].resource_id == "deployed-test-covid-dash-test"
 
 
@@ -542,15 +700,22 @@ class TestValidateStageWorkflows:
     @patch(PATCH_CONNECTIONS, return_value={})
     @patch(PATCH_PROJECT_ID, return_value="proj-123")
     @patch(PATCH_DOMAIN, return_value=("dom-123", "my-domain"))
-    def test_u31_workflow_name_collision(self, mock_domain, mock_project, mock_conns, mock_wf, *_):
+    def test_u31_workflow_name_collision(
+        self, mock_domain, mock_project, mock_conns, mock_wf, *_
+    ):
         mock_wf.return_value = [
             {"name": "TestApp_test_project_my_dag", "workflow_arn": "arn:1"},
             {"name": "TestApp_test_project_my_dag", "workflow_arn": "arn:2"},
         ]
-        result = _validate_stage("dev", _make_stage_config(project_name="test-project"),
-                                 _make_manifest(app_name="TestApp", workflows=[{"workflowName": "my-dag"}]),
-                                 "us-east-1")
-        assert any("collision" in e.lower() or "workflow" in e.lower() for e in result.errors)
+        result = _validate_stage(
+            "dev",
+            _make_stage_config(project_name="test-project"),
+            _make_manifest(app_name="TestApp", workflows=[{"workflowName": "my-dag"}]),
+            "us-east-1",
+        )
+        assert any(
+            "collision" in e.lower() or "workflow" in e.lower() for e in result.errors
+        )
 
     @patch(PATCH_GET_WF_DEF, return_value="")
     @patch(PATCH_IS_ACTIVE, return_value=True)
@@ -559,29 +724,58 @@ class TestValidateStageWorkflows:
     @patch(PATCH_CONNECTIONS, return_value={})
     @patch(PATCH_PROJECT_ID, return_value="proj-123")
     @patch(PATCH_DOMAIN, return_value=("dom-123", "my-domain"))
-    def test_u32_active_runs_populated(self, mock_domain, mock_project, mock_conns, mock_wf, mock_runs, *_):
-        mock_wf.return_value = [{"name": "TestApp_test_project_my_dag", "workflow_arn": "arn:wf1"}]
-        mock_runs.return_value = [{"run_id": "run-001", "status": "RUNNING", "ended_at": None}]
-        result = _validate_stage("dev", _make_stage_config(project_name="test-project"),
-                                 _make_manifest(app_name="TestApp", workflows=[{"workflowName": "my-dag"}]),
-                                 "us-east-1")
-        assert "run-001" in result.active_workflow_runs.get("TestApp_test_project_my_dag", [])
+    def test_u32_active_runs_populated(
+        self, mock_domain, mock_project, mock_conns, mock_wf, mock_runs, *_
+    ):
+        mock_wf.return_value = [
+            {"name": "TestApp_test_project_my_dag", "workflow_arn": "arn:wf1"}
+        ]
+        mock_runs.return_value = [
+            {"run_id": "run-001", "status": "RUNNING", "ended_at": None}
+        ]
+        result = _validate_stage(
+            "dev",
+            _make_stage_config(project_name="test-project"),
+            _make_manifest(app_name="TestApp", workflows=[{"workflowName": "my-dag"}]),
+            "us-east-1",
+        )
+        assert "run-001" in result.active_workflow_runs.get(
+            "TestApp_test_project_my_dag", []
+        )
 
     @patch(PATCH_LIST_RUNS, return_value=[])
     @patch(PATCH_LIST_WORKFLOWS)
     @patch(PATCH_CONNECTIONS, return_value={})
     @patch(PATCH_PROJECT_ID, return_value="proj-123")
     @patch(PATCH_DOMAIN, return_value=("dom-123", "my-domain"))
-    def test_u33_yaml_not_found_warning(self, mock_domain, mock_project, mock_conns, mock_wf, mock_runs):
-        mock_wf.return_value = [{"name": "TestApp_test_project_my_dag", "workflow_arn": "arn:wf1"}]
-        sc = _make_stage_config(project_name="test-project",
-                                storage=[{"name": "workflows", "connectionName": "c1", "targetDirectory": "wf"}])
-        with patch(PATCH_CONNECTIONS, return_value={"c1": {"s3Uri": "s3://bkt/base/", "bucket_name": "bkt"}}):
+    def test_u33_yaml_not_found_warning(
+        self, mock_domain, mock_project, mock_conns, mock_wf, mock_runs
+    ):
+        mock_wf.return_value = [
+            {"name": "TestApp_test_project_my_dag", "workflow_arn": "arn:wf1"}
+        ]
+        sc = _make_stage_config(
+            project_name="test-project",
+            storage=[
+                {"name": "workflows", "connectionName": "c1", "targetDirectory": "wf"}
+            ],
+        )
+        with patch(
+            PATCH_CONNECTIONS,
+            return_value={"c1": {"s3Uri": "s3://bkt/base/", "bucket_name": "bkt"}},
+        ):
             with patch(PATCH_GET_WF_DEF, return_value=""):
-                result = _validate_stage("dev", sc,
-                                         _make_manifest(app_name="TestApp", workflows=[{"workflowName": "my-dag"}]),
-                                         "us-east-1")
-        assert any("yaml" in w.lower() or "workflow" in w.lower() for w in result.warnings)
+                result = _validate_stage(
+                    "dev",
+                    sc,
+                    _make_manifest(
+                        app_name="TestApp", workflows=[{"workflowName": "my-dag"}]
+                    ),
+                    "us-east-1",
+                )
+        assert any(
+            "yaml" in w.lower() or "workflow" in w.lower() for w in result.warnings
+        )
         assert result.errors == []
 
     @patch(PATCH_GET_WF_DEF, return_value="")
@@ -590,23 +784,35 @@ class TestValidateStageWorkflows:
     @patch(PATCH_CONNECTIONS, return_value={})
     @patch(PATCH_PROJECT_ID, return_value="proj-123")
     @patch(PATCH_DOMAIN, return_value=("dom-123", "my-domain"))
-    def test_u34_multiple_stages_all_errors_collected(self, mock_domain, mock_project, mock_conns, mock_wf, *_):
-        mock_wf.return_value = [{"name": "TestApp_proj_dag1", "workflow_arn": "arn:1"},
-                                 {"name": "TestApp_proj_dag1", "workflow_arn": "arn:2"}]
-        manifest = _make_manifest(app_name="TestApp", workflows=[{"workflowName": "dag1"}])
+    def test_u34_multiple_stages_all_errors_collected(
+        self, mock_domain, mock_project, mock_conns, mock_wf, *_
+    ):
+        mock_wf.return_value = [
+            {"name": "TestApp_proj_dag1", "workflow_arn": "arn:1"},
+            {"name": "TestApp_proj_dag1", "workflow_arn": "arn:2"},
+        ]
+        manifest = _make_manifest(
+            app_name="TestApp", workflows=[{"workflowName": "dag1"}]
+        )
         sc = _make_stage_config(project_name="proj")
         r1 = _validate_stage("dev", sc, manifest, "us-east-1")
         r2 = _validate_stage("test", sc, manifest, "us-east-1")
         assert len(r1.errors + r2.errors) >= 2
 
     def test_u35_no_deployment_configuration_resolve_s3_empty(self):
-        sc = StageConfig(project=ProjectConfig(name="p"), domain=DomainConfig(region="us-east-1"),
-                         stage="DEV", deployment_configuration=None)
+        sc = StageConfig(
+            project=ProjectConfig(name="p"),
+            domain=DomainConfig(region="us-east-1"),
+            stage="DEV",
+            deployment_configuration=None,
+        )
         assert _resolve_s3_targets(sc, {}) == []
 
     @patch(PATCH_DOMAIN, side_effect=Exception("Domain not found"))
     def test_u36_domain_failure_records_error(self, _):
-        result = _validate_stage("dev", _make_stage_config(), _make_manifest(), "us-east-1")
+        result = _validate_stage(
+            "dev", _make_stage_config(), _make_manifest(), "us-east-1"
+        )
         assert any("domain" in e.lower() for e in result.errors)
 
 
@@ -614,82 +820,165 @@ class TestValidateStageWorkflows:
 # Level 5: Destruction phase (U37–U49)
 # ---------------------------------------------------------------------------
 
+
 def _simple_manifest():
-    return ApplicationManifest(application_name="App", content=ContentConfig(), stages={})
+    return ApplicationManifest(
+        application_name="App", content=ContentConfig(), stages={}
+    )
 
 
 class TestDestroyOrdering:
     @patch(PATCH_DELETE_PROJECT)
-    @patch("smus_cicd.helpers.destroy_executor.get_project_id_by_name", return_value="proj-123")
-    @patch("smus_cicd.helpers.destroy_executor.get_domain_from_target_config", return_value=("dom-123", "my-domain"))
+    @patch(
+        "smus_cicd.helpers.destroy_executor.get_project_id_by_name",
+        return_value="proj-123",
+    )
+    @patch(
+        "smus_cicd.helpers.destroy_executor.get_domain_from_target_config",
+        return_value=("dom-123", "my-domain"),
+    )
     @patch(PATCH_BOTO3)
     @patch(PATCH_DELETE_WF)
-    def test_u37_destruction_order(self, mock_delete_wf,
-                                   mock_boto3, mock_domain, mock_project_id, mock_delete_project):
+    def test_u37_destruction_order(
+        self,
+        mock_delete_wf,
+        mock_boto3,
+        mock_domain,
+        mock_project_id,
+        mock_delete_project,
+    ):
         """U37: glue_delete → delete_workflow → QS → S3 → delete_project."""
         call_order = []
-        mock_delete_wf.side_effect = lambda arn, region: call_order.append("delete_workflow")
+        mock_delete_wf.side_effect = lambda arn, region: call_order.append(
+            "delete_workflow"
+        )
 
         sts_client = MagicMock()
         sts_client.get_caller_identity.return_value = {"Account": "111122223333"}
         qs_client = MagicMock()
 
-        def client_factory(service, region_name=None):
+        def client_factory(service, **kw):
             if service == "sts":
                 return sts_client
             if service == "quicksight":
-                qs_client.delete_dashboard.side_effect = lambda **kw: call_order.append("delete_dashboard")
+                qs_client.delete_dashboard.side_effect = lambda **kw: call_order.append(
+                    "delete_dashboard"
+                )
                 return qs_client
             return MagicMock()
 
-        mock_boto3.client.side_effect = client_factory
-        mock_delete_project.side_effect = lambda *a, **kw: call_order.append("delete_project")
+        mock_boto3.side_effect = client_factory
+        mock_delete_project.side_effect = lambda *a, **kw: call_order.append(
+            "delete_project"
+        )
 
         glue_client = MagicMock()
-        glue_client.delete_job.side_effect = lambda **kw: call_order.append("delete_glue")
+        glue_client.delete_job.side_effect = lambda **kw: call_order.append(
+            "delete_glue"
+        )
 
-        with patch("smus_cicd.helpers.operator_registry.boto3") as mock_glue_boto3:
-            mock_glue_boto3.client.return_value = glue_client
+        with patch(
+            "smus_cicd.helpers.operator_registry.create_client"
+        ) as mock_glue_boto3:
+            mock_glue_boto3.return_value = glue_client
             with patch("smus_cicd.helpers.destroy_executor.s3_helper") as mock_s3:
                 mock_s3.list_objects.return_value = [{"Key": "k1"}]
-                mock_s3.delete_objects.side_effect = lambda *a, **kw: call_order.append("delete_s3")
+                mock_s3.delete_objects.side_effect = lambda *a, **kw: call_order.append(
+                    "delete_s3"
+                )
                 wf_arn = "arn:aws:airflow:us-east-1:111:workflow/wf1"
                 resources = [
-                    ResourceToDelete("airflow_workflow", wf_arn, "dev", {"workflow_name": "App_proj_dag"}),
-                    ResourceToDelete("glue_job", "my-glue-job", "dev", {"operator": GLUE_OPERATOR_KEY, "task_name": "t1"}),
-                    ResourceToDelete("quicksight_dashboard", "deployed-dev-dash1", "dev", {}),
-                    ResourceToDelete("s3_prefix", "s3://bucket/prefix", "dev", {"bucket": "bucket", "prefix": "prefix"}),
+                    ResourceToDelete(
+                        "airflow_workflow",
+                        wf_arn,
+                        "dev",
+                        {"workflow_name": "App_proj_dag"},
+                    ),
+                    ResourceToDelete(
+                        "glue_job",
+                        "my-glue-job",
+                        "dev",
+                        {"operator": GLUE_OPERATOR_KEY, "task_name": "t1"},
+                    ),
+                    ResourceToDelete(
+                        "quicksight_dashboard", "deployed-dev-dash1", "dev", {}
+                    ),
+                    ResourceToDelete(
+                        "s3_prefix",
+                        "s3://bucket/prefix",
+                        "dev",
+                        {"bucket": "bucket", "prefix": "prefix"},
+                    ),
                 ]
                 vr = _make_vr(resources=resources)
-                _destroy_stage("dev", _make_stage_config(create=True), _simple_manifest(), vr, "us-east-1", "TEXT")
+                _destroy_stage(
+                    "dev",
+                    _make_stage_config(create=True),
+                    _simple_manifest(),
+                    vr,
+                    "us-east-1",
+                    "TEXT",
+                )
 
         assert call_order.index("delete_glue") < call_order.index("delete_workflow")
-        assert call_order.index("delete_workflow") < call_order.index("delete_dashboard")
+        assert call_order.index("delete_workflow") < call_order.index(
+            "delete_dashboard"
+        )
         assert call_order.index("delete_dashboard") < call_order.index("delete_s3")
         assert call_order.index("delete_s3") < call_order.index("delete_project")
 
 
 class TestProjectCreateFlag:
     @patch(PATCH_DELETE_PROJECT)
-    @patch("smus_cicd.helpers.destroy_executor.get_project_id_by_name", return_value="proj-123")
-    @patch("smus_cicd.helpers.destroy_executor.get_domain_from_target_config", return_value=("dom-123", "my-domain"))
+    @patch(
+        "smus_cicd.helpers.destroy_executor.get_project_id_by_name",
+        return_value="proj-123",
+    )
+    @patch(
+        "smus_cicd.helpers.destroy_executor.get_domain_from_target_config",
+        return_value=("dom-123", "my-domain"),
+    )
     @patch(PATCH_BOTO3)
-    def test_u41_project_create_false_no_delete(self, mock_boto3, mock_domain, mock_project_id, mock_delete_project):
+    def test_u41_project_create_false_no_delete(
+        self, mock_boto3, mock_domain, mock_project_id, mock_delete_project
+    ):
         sts = MagicMock()
         sts.get_caller_identity.return_value = {"Account": "111122223333"}
-        mock_boto3.client.return_value = sts
-        _destroy_stage("dev", _make_stage_config(create=False), _simple_manifest(), _make_vr(), "us-east-1", "TEXT")
+        mock_boto3.return_value = sts
+        _destroy_stage(
+            "dev",
+            _make_stage_config(create=False),
+            _simple_manifest(),
+            _make_vr(),
+            "us-east-1",
+            "TEXT",
+        )
         mock_delete_project.assert_not_called()
 
     @patch(PATCH_DELETE_PROJECT)
-    @patch("smus_cicd.helpers.destroy_executor.get_project_id_by_name", return_value="proj-123")
-    @patch("smus_cicd.helpers.destroy_executor.get_domain_from_target_config", return_value=("dom-123", "my-domain"))
+    @patch(
+        "smus_cicd.helpers.destroy_executor.get_project_id_by_name",
+        return_value="proj-123",
+    )
+    @patch(
+        "smus_cicd.helpers.destroy_executor.get_domain_from_target_config",
+        return_value=("dom-123", "my-domain"),
+    )
     @patch(PATCH_BOTO3)
-    def test_u42_project_create_true_delete_called(self, mock_boto3, mock_domain, mock_project_id, mock_delete_project):
+    def test_u42_project_create_true_delete_called(
+        self, mock_boto3, mock_domain, mock_project_id, mock_delete_project
+    ):
         sts = MagicMock()
         sts.get_caller_identity.return_value = {"Account": "111122223333"}
-        mock_boto3.client.return_value = sts
-        _destroy_stage("dev", _make_stage_config(create=True), _simple_manifest(), _make_vr(), "us-east-1", "TEXT")
+        mock_boto3.return_value = sts
+        _destroy_stage(
+            "dev",
+            _make_stage_config(create=True),
+            _simple_manifest(),
+            _make_vr(),
+            "us-east-1",
+            "TEXT",
+        )
         mock_delete_project.assert_called_once()
 
 
@@ -700,27 +989,43 @@ class TestNotFoundHandling:
         sts.get_caller_identity.return_value = {"Account": "111122223333"}
         qs = MagicMock()
         qs.delete_dashboard.side_effect = ClientError(
-            {"Error": {"Code": "ResourceNotFoundException", "Message": "Not found"}}, "DeleteDashboard"
+            {"Error": {"Code": "ResourceNotFoundException", "Message": "Not found"}},
+            "DeleteDashboard",
         )
-        mock_boto3.client.side_effect = lambda s, region_name=None: sts if s == "sts" else qs
-        vr = _make_vr(resources=[ResourceToDelete("quicksight_dashboard", "dash-1", "dev", {})])
-        results = _destroy_stage("dev", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT")
+        mock_boto3.side_effect = lambda s, **kw: sts if s == "sts" else qs
+        vr = _make_vr(
+            resources=[ResourceToDelete("quicksight_dashboard", "dash-1", "dev", {})]
+        )
+        results = _destroy_stage(
+            "dev", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT"
+        )
         assert any(r.status == "not_found" for r in results)
 
     @patch(PATCH_BOTO3)
     def test_u44_glue_not_found_recorded(self, mock_boto3):
         sts = MagicMock()
         sts.get_caller_identity.return_value = {"Account": "111122223333"}
-        mock_boto3.client.return_value = sts
-        with patch("smus_cicd.helpers.operator_registry.boto3") as mock_glue:
+        mock_boto3.return_value = sts
+        with patch("smus_cicd.helpers.operator_registry.create_client") as mock_glue:
             glue = MagicMock()
             glue.delete_job.side_effect = ClientError(
-                {"Error": {"Code": "EntityNotFoundException", "Message": "Not found"}}, "DeleteJob"
+                {"Error": {"Code": "EntityNotFoundException", "Message": "Not found"}},
+                "DeleteJob",
             )
-            mock_glue.client.return_value = glue
-            vr = _make_vr(resources=[ResourceToDelete("glue_job", "missing-job", "dev",
-                                                       {"operator": GLUE_OPERATOR_KEY, "task_name": "t1"})])
-            results = _destroy_stage("dev", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT")
+            mock_glue.return_value = glue
+            vr = _make_vr(
+                resources=[
+                    ResourceToDelete(
+                        "glue_job",
+                        "missing-job",
+                        "dev",
+                        {"operator": GLUE_OPERATOR_KEY, "task_name": "t1"},
+                    )
+                ]
+            )
+            results = _destroy_stage(
+                "dev", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT"
+            )
         assert any(r.status == "not_found" for r in results)
 
     @patch(PATCH_BOTO3)
@@ -731,9 +1036,17 @@ class TestNotFoundHandling:
         paginator = MagicMock()
         paginator.paginate.return_value = iter([{}])
         s3.get_paginator.return_value = paginator
-        mock_boto3.client.side_effect = lambda s, region_name=None: sts if s == "sts" else s3
-        vr = _make_vr(resources=[ResourceToDelete("s3_prefix", "s3://bkt/p", "dev", {"bucket": "bkt", "prefix": "p"})])
-        results = _destroy_stage("dev", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT")
+        mock_boto3.side_effect = lambda s, **kw: sts if s == "sts" else s3
+        vr = _make_vr(
+            resources=[
+                ResourceToDelete(
+                    "s3_prefix", "s3://bkt/p", "dev", {"bucket": "bkt", "prefix": "p"}
+                )
+            ]
+        )
+        results = _destroy_stage(
+            "dev", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT"
+        )
         assert any(r.status == "not_found" for r in results)
 
 
@@ -748,13 +1061,22 @@ class TestErrorResilience:
         def delete_dashboard(**kwargs):
             call_count[0] += 1
             if call_count[0] == 1:
-                raise ClientError({"Error": {"Code": "InternalFailure", "Message": "Error"}}, "DeleteDashboard")
+                raise ClientError(
+                    {"Error": {"Code": "InternalFailure", "Message": "Error"}},
+                    "DeleteDashboard",
+                )
 
         qs.delete_dashboard.side_effect = delete_dashboard
-        mock_boto3.client.side_effect = lambda s, region_name=None: sts if s == "sts" else qs
-        vr = _make_vr(resources=[ResourceToDelete("quicksight_dashboard", "dash-1", "dev", {}),
-                                   ResourceToDelete("quicksight_dashboard", "dash-2", "dev", {})])
-        results = _destroy_stage("dev", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT")
+        mock_boto3.side_effect = lambda s, **kw: sts if s == "sts" else qs
+        vr = _make_vr(
+            resources=[
+                ResourceToDelete("quicksight_dashboard", "dash-1", "dev", {}),
+                ResourceToDelete("quicksight_dashboard", "dash-2", "dev", {}),
+            ]
+        )
+        results = _destroy_stage(
+            "dev", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT"
+        )
         statuses = {r.resource_id: r.status for r in results}
         assert statuses["dash-1"] == "error"
         assert statuses["dash-2"] == "deleted"
@@ -765,24 +1087,33 @@ class TestErrorResilience:
         sts.get_caller_identity.return_value = {"Account": "111122223333"}
         qs = MagicMock()
         qs.delete_dashboard.side_effect = ClientError(
-            {"Error": {"Code": "ResourceNotFoundException", "Message": "Not found"}}, "DeleteDashboard"
+            {"Error": {"Code": "ResourceNotFoundException", "Message": "Not found"}},
+            "DeleteDashboard",
         )
         s3 = MagicMock()
         paginator = MagicMock()
         paginator.paginate.return_value = iter([{}])
         s3.get_paginator.return_value = paginator
 
-        def client_factory(s, region_name=None):
+        def client_factory(s, **kw):
             if s == "sts":
                 return sts
             if s == "quicksight":
                 return qs
             return s3
 
-        mock_boto3.client.side_effect = client_factory
-        vr = _make_vr(resources=[ResourceToDelete("quicksight_dashboard", "dash-1", "dev", {}),
-                                   ResourceToDelete("s3_prefix", "s3://bkt/p", "dev", {"bucket": "bkt", "prefix": "p"})])
-        results = _destroy_stage("dev", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT")
+        mock_boto3.side_effect = client_factory
+        vr = _make_vr(
+            resources=[
+                ResourceToDelete("quicksight_dashboard", "dash-1", "dev", {}),
+                ResourceToDelete(
+                    "s3_prefix", "s3://bkt/p", "dev", {"bucket": "bkt", "prefix": "p"}
+                ),
+            ]
+        )
+        results = _destroy_stage(
+            "dev", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT"
+        )
         assert not any(r.status == "error" for r in results)
         assert sum(1 for r in results if r.status == "not_found") == 2
 
@@ -792,28 +1123,51 @@ class TestErrorResilience:
         sts.get_caller_identity.return_value = {"Account": "111122223333"}
         deleted_ids = []
         qs = MagicMock()
-        qs.delete_dashboard.side_effect = lambda **kw: deleted_ids.append(kw.get("DashboardId"))
-        mock_boto3.client.side_effect = lambda s, region_name=None: sts if s == "sts" else qs
-        vr = _make_vr(resources=[ResourceToDelete("quicksight_dashboard", "deployed-dev-covid-dash1", "dev", {})])
-        _destroy_stage("dev", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT")
+        qs.delete_dashboard.side_effect = lambda **kw: deleted_ids.append(
+            kw.get("DashboardId")
+        )
+        mock_boto3.side_effect = lambda s, **kw: sts if s == "sts" else qs
+        vr = _make_vr(
+            resources=[
+                ResourceToDelete(
+                    "quicksight_dashboard", "deployed-dev-covid-dash1", "dev", {}
+                )
+            ]
+        )
+        _destroy_stage(
+            "dev", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT"
+        )
         assert deleted_ids == ["deployed-dev-covid-dash1"]
 
     @patch(PATCH_BOTO3)
     def test_u49_s3_deletion_scoped_to_prefix(self, mock_boto3):
         sts = MagicMock()
         sts.get_caller_identity.return_value = {"Account": "111122223333"}
-        mock_boto3.client.return_value = sts
+        mock_boto3.return_value = sts
         deleted_keys = []
 
         with patch("smus_cicd.helpers.destroy_executor.s3_helper") as mock_s3:
             mock_s3.list_objects.side_effect = lambda bucket, prefix, region=None: (
                 [{"Key": "base/bundle/f1.py"}, {"Key": "base/bundle/f2.py"}]
-                if prefix == "base/bundle" else []
+                if prefix == "base/bundle"
+                else []
             )
-            mock_s3.delete_objects.side_effect = lambda bucket, keys, region=None: deleted_keys.extend(keys)
-            vr = _make_vr(resources=[ResourceToDelete("s3_prefix", "s3://bkt/base/bundle", "dev",
-                                                       {"bucket": "bkt", "prefix": "base/bundle"})])
-            _destroy_stage("dev", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT")
+            mock_s3.delete_objects.side_effect = (
+                lambda bucket, keys, region=None: deleted_keys.extend(keys)
+            )
+            vr = _make_vr(
+                resources=[
+                    ResourceToDelete(
+                        "s3_prefix",
+                        "s3://bkt/base/bundle",
+                        "dev",
+                        {"bucket": "bkt", "prefix": "base/bundle"},
+                    )
+                ]
+            )
+            _destroy_stage(
+                "dev", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT"
+            )
 
         assert all(k.startswith("base/bundle") for k in deleted_keys)
         assert "base/bundle/f1.py" in deleted_keys
@@ -823,13 +1177,19 @@ class TestErrorResilience:
 # Level 6: Command entry point and CLI (U50–U73)
 # ---------------------------------------------------------------------------
 
+
 class TestInvalidStageName:
     @patch(PATCH_DESTROY_STAGE)
     @patch(PATCH_VALIDATE)
     @patch(PATCH_FROM_FILE)
-    def test_u50_invalid_stage_exits_1(self, mock_from_file, mock_validate, mock_destroy):
+    def test_u50_invalid_stage_exits_1(
+        self, mock_from_file, mock_validate, mock_destroy
+    ):
         mock_from_file.return_value = _make_manifest_mock(stages=["dev", "test"])
-        result = runner.invoke(app, ["destroy", "--manifest", "m.yaml", "--targets", "nonexistent", "--force"])
+        result = runner.invoke(
+            app,
+            ["destroy", "--manifest", "m.yaml", "--targets", "nonexistent", "--force"],
+        )
         assert result.exit_code == 1
         assert "nonexistent" in result.output or "nonexistent" in (result.stderr or "")
         mock_validate.assert_not_called()
@@ -839,7 +1199,17 @@ class TestInvalidStageName:
 class TestManifestNotFound:
     @patch(PATCH_FROM_FILE, side_effect=ValueError("Not found"))
     def test_u51_manifest_not_found_exits_1(self, _):
-        result = runner.invoke(app, ["destroy", "--manifest", "nonexistent.yaml", "--targets", "dev", "--force"])
+        result = runner.invoke(
+            app,
+            [
+                "destroy",
+                "--manifest",
+                "nonexistent.yaml",
+                "--targets",
+                "dev",
+                "--force",
+            ],
+        )
         assert result.exit_code == 1
 
 
@@ -847,20 +1217,31 @@ class TestValidationErrorsAbort:
     @patch(PATCH_DESTROY_STAGE)
     @patch(PATCH_VALIDATE)
     @patch(PATCH_FROM_FILE)
-    def test_u52_validation_errors_abort(self, mock_from_file, mock_validate, mock_destroy):
+    def test_u52_validation_errors_abort(
+        self, mock_from_file, mock_validate, mock_destroy
+    ):
         mock_from_file.return_value = _make_manifest_mock(stages=["dev"])
         mock_validate.return_value = _make_vr(errors=["QuickSight collision"])
-        result = runner.invoke(app, ["destroy", "--manifest", "m.yaml", "--targets", "dev", "--force"])
+        result = runner.invoke(
+            app, ["destroy", "--manifest", "m.yaml", "--targets", "dev", "--force"]
+        )
         assert result.exit_code == 1
         mock_destroy.assert_not_called()
 
     @patch(PATCH_DESTROY_STAGE)
     @patch(PATCH_VALIDATE)
     @patch(PATCH_FROM_FILE)
-    def test_u53_all_stage_errors_in_report(self, mock_from_file, mock_validate, mock_destroy):
+    def test_u53_all_stage_errors_in_report(
+        self, mock_from_file, mock_validate, mock_destroy
+    ):
         mock_from_file.return_value = _make_manifest_mock(stages=["dev", "test"])
-        mock_validate.side_effect = [_make_vr(errors=["dev collision"]), _make_vr(errors=["test collision"])]
-        result = runner.invoke(app, ["destroy", "--manifest", "m.yaml", "--targets", "dev,test", "--force"])
+        mock_validate.side_effect = [
+            _make_vr(errors=["dev collision"]),
+            _make_vr(errors=["test collision"]),
+        ]
+        result = runner.invoke(
+            app, ["destroy", "--manifest", "m.yaml", "--targets", "dev,test", "--force"]
+        )
         assert result.exit_code == 1
         combined = result.output + (result.stderr or "")
         assert "dev collision" in combined
@@ -872,12 +1253,18 @@ class TestDestructionPlan:
     @patch(PATCH_CONFIRM, return_value=False)
     @patch(PATCH_VALIDATE)
     @patch(PATCH_FROM_FILE)
-    def test_u54_plan_printed_before_confirmation(self, mock_from_file, mock_validate, mock_confirm):
+    def test_u54_plan_printed_before_confirmation(
+        self, mock_from_file, mock_validate, mock_confirm
+    ):
         mock_from_file.return_value = _make_manifest_mock(stages=["dev"])
-        mock_validate.return_value = _make_vr(resources=[
-            ResourceToDelete("quicksight_dashboard", "dash-1", "dev", {}),
-        ])
-        result = runner.invoke(app, ["destroy", "--manifest", "m.yaml", "--targets", "dev"])
+        mock_validate.return_value = _make_vr(
+            resources=[
+                ResourceToDelete("quicksight_dashboard", "dash-1", "dev", {}),
+            ]
+        )
+        result = runner.invoke(
+            app, ["destroy", "--manifest", "m.yaml", "--targets", "dev"]
+        )
         assert result.exit_code == 0
         assert "dash-1" in result.output
 
@@ -887,7 +1274,9 @@ class TestForceAndConfirmation:
     @patch(PATCH_CONFIRM, return_value=True)
     @patch(PATCH_VALIDATE)
     @patch(PATCH_FROM_FILE)
-    def test_u55_user_confirms_proceeds(self, mock_from_file, mock_validate, mock_confirm, mock_destroy):
+    def test_u55_user_confirms_proceeds(
+        self, mock_from_file, mock_validate, mock_confirm, mock_destroy
+    ):
         mock_from_file.return_value = _make_manifest_mock(stages=["dev"])
         mock_validate.return_value = _make_vr()
         runner.invoke(app, ["destroy", "--manifest", "m.yaml", "--targets", "dev"])
@@ -897,10 +1286,14 @@ class TestForceAndConfirmation:
     @patch(PATCH_CONFIRM, return_value=False)
     @patch(PATCH_VALIDATE)
     @patch(PATCH_FROM_FILE)
-    def test_u56_user_declines_exit_0_no_deletion(self, mock_from_file, mock_validate, mock_confirm, mock_destroy):
+    def test_u56_user_declines_exit_0_no_deletion(
+        self, mock_from_file, mock_validate, mock_confirm, mock_destroy
+    ):
         mock_from_file.return_value = _make_manifest_mock(stages=["dev"])
         mock_validate.return_value = _make_vr()
-        result = runner.invoke(app, ["destroy", "--manifest", "m.yaml", "--targets", "dev"])
+        result = runner.invoke(
+            app, ["destroy", "--manifest", "m.yaml", "--targets", "dev"]
+        )
         assert result.exit_code == 0
         mock_destroy.assert_not_called()
 
@@ -908,20 +1301,28 @@ class TestForceAndConfirmation:
     @patch(PATCH_CONFIRM)
     @patch(PATCH_VALIDATE)
     @patch(PATCH_FROM_FILE)
-    def test_u57_force_skips_prompt(self, mock_from_file, mock_validate, mock_confirm, mock_destroy):
+    def test_u57_force_skips_prompt(
+        self, mock_from_file, mock_validate, mock_confirm, mock_destroy
+    ):
         mock_from_file.return_value = _make_manifest_mock(stages=["dev"])
         mock_validate.return_value = _make_vr()
-        runner.invoke(app, ["destroy", "--manifest", "m.yaml", "--targets", "dev", "--force"])
+        runner.invoke(
+            app, ["destroy", "--manifest", "m.yaml", "--targets", "dev", "--force"]
+        )
         mock_confirm.assert_not_called()
         mock_destroy.assert_called_once()
 
     @patch(PATCH_DESTROY_STAGE)
     @patch(PATCH_VALIDATE)
     @patch(PATCH_FROM_FILE)
-    def test_u58_force_with_collision_still_aborts(self, mock_from_file, mock_validate, mock_destroy):
+    def test_u58_force_with_collision_still_aborts(
+        self, mock_from_file, mock_validate, mock_destroy
+    ):
         mock_from_file.return_value = _make_manifest_mock(stages=["dev"])
         mock_validate.return_value = _make_vr(errors=["Collision!"])
-        result = runner.invoke(app, ["destroy", "--manifest", "m.yaml", "--targets", "dev", "--force"])
+        result = runner.invoke(
+            app, ["destroy", "--manifest", "m.yaml", "--targets", "dev", "--force"]
+        )
         assert result.exit_code == 1
         mock_destroy.assert_not_called()
 
@@ -929,14 +1330,23 @@ class TestForceAndConfirmation:
     @patch(PATCH_CONFIRM)
     @patch(PATCH_VALIDATE)
     @patch(PATCH_FROM_FILE)
-    def test_u59_force_with_active_runs_no_prompt(self, mock_from_file, mock_validate, mock_confirm, mock_destroy):
+    def test_u59_force_with_active_runs_no_prompt(
+        self, mock_from_file, mock_validate, mock_confirm, mock_destroy
+    ):
         mock_from_file.return_value = _make_manifest_mock(stages=["dev"])
         mock_validate.return_value = ValidationResult(
-            errors=[], warnings=[],
-            resources=[ResourceToDelete("airflow_workflow", "arn:wf1", "dev", {"workflow_name": "my_wf"})],
+            errors=[],
+            warnings=[],
+            resources=[
+                ResourceToDelete(
+                    "airflow_workflow", "arn:wf1", "dev", {"workflow_name": "my_wf"}
+                )
+            ],
             active_workflow_runs={"my_wf": ["run-001"]},
         )
-        runner.invoke(app, ["destroy", "--manifest", "m.yaml", "--targets", "dev", "--force"])
+        runner.invoke(
+            app, ["destroy", "--manifest", "m.yaml", "--targets", "dev", "--force"]
+        )
         mock_confirm.assert_not_called()
         mock_destroy.assert_called_once()
 
@@ -945,11 +1355,17 @@ class TestExitCodes:
     @patch(PATCH_DESTROY_STAGE)
     @patch(PATCH_VALIDATE)
     @patch(PATCH_FROM_FILE)
-    def test_u60_error_result_exits_1(self, mock_from_file, mock_validate, mock_destroy):
+    def test_u60_error_result_exits_1(
+        self, mock_from_file, mock_validate, mock_destroy
+    ):
         mock_from_file.return_value = _make_manifest_mock(stages=["dev"])
         mock_validate.return_value = _make_vr()
-        mock_destroy.return_value = [ResourceResult("quicksight_dashboard", "d1", "error", "API error")]
-        result = runner.invoke(app, ["destroy", "--manifest", "m.yaml", "--targets", "dev", "--force"])
+        mock_destroy.return_value = [
+            ResourceResult("quicksight_dashboard", "d1", "error", "API error")
+        ]
+        result = runner.invoke(
+            app, ["destroy", "--manifest", "m.yaml", "--targets", "dev", "--force"]
+        )
         assert result.exit_code == 1
 
     @patch(PATCH_DESTROY_STAGE)
@@ -958,8 +1374,12 @@ class TestExitCodes:
     def test_u61_all_deleted_exits_0(self, mock_from_file, mock_validate, mock_destroy):
         mock_from_file.return_value = _make_manifest_mock(stages=["dev"])
         mock_validate.return_value = _make_vr()
-        mock_destroy.return_value = [ResourceResult("quicksight_dashboard", "d1", "deleted", "OK")]
-        result = runner.invoke(app, ["destroy", "--manifest", "m.yaml", "--targets", "dev", "--force"])
+        mock_destroy.return_value = [
+            ResourceResult("quicksight_dashboard", "d1", "deleted", "OK")
+        ]
+        result = runner.invoke(
+            app, ["destroy", "--manifest", "m.yaml", "--targets", "dev", "--force"]
+        )
         assert result.exit_code == 0
 
 
@@ -967,14 +1387,32 @@ class TestJsonOutput:
     @patch(PATCH_DESTROY_STAGE)
     @patch(PATCH_VALIDATE)
     @patch(PATCH_FROM_FILE)
-    def test_u62_json_output_valid_structure(self, mock_from_file, mock_validate, mock_destroy):
-        mock_from_file.return_value = _make_manifest_mock(stages=["dev"], app_name="MyApp")
+    def test_u62_json_output_valid_structure(
+        self, mock_from_file, mock_validate, mock_destroy
+    ):
+        mock_from_file.return_value = _make_manifest_mock(
+            stages=["dev"], app_name="MyApp"
+        )
         mock_validate.return_value = _make_vr()
-        mock_destroy.return_value = [ResourceResult("quicksight_dashboard", "dash-1", "deleted", "OK")]
-        result = runner.invoke(app, ["destroy", "--manifest", "m.yaml", "--targets", "dev", "--force", "--output", "JSON"])
+        mock_destroy.return_value = [
+            ResourceResult("quicksight_dashboard", "dash-1", "deleted", "OK")
+        ]
+        result = runner.invoke(
+            app,
+            [
+                "destroy",
+                "--manifest",
+                "m.yaml",
+                "--targets",
+                "dev",
+                "--force",
+                "--output",
+                "JSON",
+            ],
+        )
         assert result.exit_code == 0
         output = result.output
-        data = json.loads(output[output.find("{"):output.rfind("}") + 1])
+        data = json.loads(output[output.find("{") : output.rfind("}") + 1])
         assert data["application_name"] == "MyApp"
         assert "dev" in data["stages"]
         assert data["stages"]["dev"][0]["resource_id"] == "dash-1"
@@ -982,19 +1420,35 @@ class TestJsonOutput:
     @patch(PATCH_DESTROY_STAGE, return_value=[])
     @patch(PATCH_VALIDATE)
     @patch(PATCH_FROM_FILE)
-    def test_u63_json_stdout_parseable(self, mock_from_file, mock_validate, mock_destroy):
+    def test_u63_json_stdout_parseable(
+        self, mock_from_file, mock_validate, mock_destroy
+    ):
         mock_from_file.return_value = _make_manifest_mock(stages=["dev"])
         mock_validate.return_value = _make_vr()
-        result = runner.invoke(app, ["destroy", "--manifest", "m.yaml", "--targets", "dev", "--force", "--output", "JSON"])
+        result = runner.invoke(
+            app,
+            [
+                "destroy",
+                "--manifest",
+                "m.yaml",
+                "--targets",
+                "dev",
+                "--force",
+                "--output",
+                "JSON",
+            ],
+        )
         output = result.output
-        json.loads(output[output.find("{"):output.rfind("}") + 1])
+        json.loads(output[output.find("{") : output.rfind("}") + 1])
 
 
 class TestSummaryOutput:
     @patch(PATCH_DESTROY_STAGE)
     @patch(PATCH_VALIDATE)
     @patch(PATCH_FROM_FILE)
-    def test_u64_summary_shows_counts(self, mock_from_file, mock_validate, mock_destroy):
+    def test_u64_summary_shows_counts(
+        self, mock_from_file, mock_validate, mock_destroy
+    ):
         mock_from_file.return_value = _make_manifest_mock(stages=["dev"])
         mock_validate.return_value = _make_vr()
         mock_destroy.return_value = [
@@ -1002,7 +1456,9 @@ class TestSummaryOutput:
             ResourceResult("s3_prefix", "s3://b/p", "not_found", "Empty"),
             ResourceResult("glue_job", "j1", "skipped", "Template var"),
         ]
-        result = runner.invoke(app, ["destroy", "--manifest", "m.yaml", "--targets", "dev", "--force"])
+        result = runner.invoke(
+            app, ["destroy", "--manifest", "m.yaml", "--targets", "dev", "--force"]
+        )
         assert "deleted=1" in result.output
         assert "not_found=1" in result.output
         assert "skipped=1" in result.output
@@ -1022,29 +1478,37 @@ class TestEdgeCases:
     @patch(PATCH_DESTROY_STAGE, return_value=_ok_results())
     @patch(PATCH_VALIDATE)
     @patch(PATCH_FROM_FILE)
-    def test_u72_multiple_targets_each_processed(self, mock_from_file, mock_validate, mock_destroy):
+    def test_u72_multiple_targets_each_processed(
+        self, mock_from_file, mock_validate, mock_destroy
+    ):
         mock_from_file.return_value = _make_manifest_mock(stages=["dev", "test"])
         mock_validate.return_value = _make_vr()
-        runner.invoke(app, ["destroy", "--manifest", "m.yaml", "--targets", "dev,test", "--force"])
+        runner.invoke(
+            app, ["destroy", "--manifest", "m.yaml", "--targets", "dev,test", "--force"]
+        )
         assert mock_validate.call_count == 2
         assert mock_destroy.call_count == 2
 
     @patch(PATCH_DESTROY_STAGE, return_value=_ok_results())
     @patch(PATCH_VALIDATE)
     @patch(PATCH_FROM_FILE)
-    def test_u73_missing_targets_exits_1(self, mock_from_file, mock_validate, mock_destroy):
+    def test_u73_missing_targets_exits_1(
+        self, mock_from_file, mock_validate, mock_destroy
+    ):
         """Omitting --targets should exit with error, not default to all stages."""
-        mock_from_file.return_value = _make_manifest_mock(stages=["dev", "test", "prod"])
+        mock_from_file.return_value = _make_manifest_mock(
+            stages=["dev", "test", "prod"]
+        )
         mock_validate.return_value = _make_vr()
         result = runner.invoke(app, ["destroy", "--manifest", "m.yaml", "--force"])
         assert result.exit_code != 0
         mock_destroy.assert_not_called()
 
 
-
 # ---------------------------------------------------------------------------
 # Task 10: Bootstrap Connection deletion tests
 # ---------------------------------------------------------------------------
+
 
 class TestBootstrapConnectionDiscovery:
     """Validation phase: connection discovery from bootstrap actions."""
@@ -1055,28 +1519,42 @@ class TestBootstrapConnectionDiscovery:
     @patch(PATCH_CONNECTIONS)
     @patch(PATCH_PROJECT_ID, return_value="proj-123")
     @patch(PATCH_DOMAIN, return_value=("dom-123", "my-domain"))
-    def test_connection_added_to_plan_when_exists(self, mock_domain, mock_project,
-                                                   mock_conns, *_):
+    def test_connection_added_to_plan_when_exists(
+        self, mock_domain, mock_project, mock_conns, *_
+    ):
         """Connection declared in bootstrap and found in project → added to plan."""
         mock_conns.return_value = {
             "mlflow-server": {"connectionId": "conn-abc", "type": "MLFLOW"},
         }
         from smus_cicd.application.application_manifest import (
-            StageConfig, ProjectConfig, DomainConfig, DeploymentConfiguration
+            DeploymentConfiguration,
+            DomainConfig,
+            ProjectConfig,
+            StageConfig,
         )
         from smus_cicd.bootstrap.models import BootstrapAction, BootstrapConfig
+
         sc = StageConfig(
             project=ProjectConfig(name="test-project", create=False),
             domain=DomainConfig(region="us-east-1"),
             stage="TEST",
             deployment_configuration=DeploymentConfiguration(),
-            bootstrap=BootstrapConfig(actions=[
-                BootstrapAction(type="datazone.create_connection",
-                                parameters={"name": "mlflow-server", "connection_type": "MLFLOW"})
-            ]),
+            bootstrap=BootstrapConfig(
+                actions=[
+                    BootstrapAction(
+                        type="datazone.create_connection",
+                        parameters={
+                            "name": "mlflow-server",
+                            "connection_type": "MLFLOW",
+                        },
+                    )
+                ]
+            ),
         )
         result = _validate_stage("test", sc, _make_manifest(), "us-east-1")
-        conn_resources = [r for r in result.resources if r.resource_type == "datazone_connection"]
+        conn_resources = [
+            r for r in result.resources if r.resource_type == "datazone_connection"
+        ]
         assert len(conn_resources) == 1
         assert conn_resources[0].resource_id == "mlflow-server"
         assert conn_resources[0].metadata["connection_id"] == "conn-abc"
@@ -1090,21 +1568,34 @@ class TestBootstrapConnectionDiscovery:
     def test_connection_not_found_records_warning(self, *_):
         """Connection declared but not in project → warning, not in plan."""
         from smus_cicd.application.application_manifest import (
-            StageConfig, ProjectConfig, DomainConfig, DeploymentConfiguration
+            DeploymentConfiguration,
+            DomainConfig,
+            ProjectConfig,
+            StageConfig,
         )
         from smus_cicd.bootstrap.models import BootstrapAction, BootstrapConfig
+
         sc = StageConfig(
             project=ProjectConfig(name="test-project", create=False),
             domain=DomainConfig(region="us-east-1"),
             stage="TEST",
             deployment_configuration=DeploymentConfiguration(),
-            bootstrap=BootstrapConfig(actions=[
-                BootstrapAction(type="datazone.create_connection",
-                                parameters={"name": "mlflow-server", "connection_type": "MLFLOW"})
-            ]),
+            bootstrap=BootstrapConfig(
+                actions=[
+                    BootstrapAction(
+                        type="datazone.create_connection",
+                        parameters={
+                            "name": "mlflow-server",
+                            "connection_type": "MLFLOW",
+                        },
+                    )
+                ]
+            ),
         )
         result = _validate_stage("test", sc, _make_manifest(), "us-east-1")
-        conn_resources = [r for r in result.resources if r.resource_type == "datazone_connection"]
+        conn_resources = [
+            r for r in result.resources if r.resource_type == "datazone_connection"
+        ]
         assert conn_resources == []
         assert any("mlflow-server" in w for w in result.warnings)
 
@@ -1114,28 +1605,42 @@ class TestBootstrapConnectionDiscovery:
     @patch(PATCH_CONNECTIONS)
     @patch(PATCH_PROJECT_ID, return_value="proj-123")
     @patch(PATCH_DOMAIN, return_value=("dom-123", "my-domain"))
-    def test_default_connection_skipped_with_warning(self, mock_domain, mock_project,
-                                                      mock_conns, *_):
+    def test_default_connection_skipped_with_warning(
+        self, mock_domain, mock_project, mock_conns, *_
+    ):
         """default.* connections are never added to the plan."""
         mock_conns.return_value = {
             "default.s3_shared": {"connectionId": "conn-builtin"},
         }
         from smus_cicd.application.application_manifest import (
-            StageConfig, ProjectConfig, DomainConfig, DeploymentConfiguration
+            DeploymentConfiguration,
+            DomainConfig,
+            ProjectConfig,
+            StageConfig,
         )
         from smus_cicd.bootstrap.models import BootstrapAction, BootstrapConfig
+
         sc = StageConfig(
             project=ProjectConfig(name="test-project", create=False),
             domain=DomainConfig(region="us-east-1"),
             stage="TEST",
             deployment_configuration=DeploymentConfiguration(),
-            bootstrap=BootstrapConfig(actions=[
-                BootstrapAction(type="datazone.create_connection",
-                                parameters={"name": "default.s3_shared", "connection_type": "S3"})
-            ]),
+            bootstrap=BootstrapConfig(
+                actions=[
+                    BootstrapAction(
+                        type="datazone.create_connection",
+                        parameters={
+                            "name": "default.s3_shared",
+                            "connection_type": "S3",
+                        },
+                    )
+                ]
+            ),
         )
         result = _validate_stage("test", sc, _make_manifest(), "us-east-1")
-        conn_resources = [r for r in result.resources if r.resource_type == "datazone_connection"]
+        conn_resources = [
+            r for r in result.resources if r.resource_type == "datazone_connection"
+        ]
         assert conn_resources == []
         assert any("default.s3_shared" in w for w in result.warnings)
 
@@ -1145,28 +1650,42 @@ class TestBootstrapConnectionDiscovery:
     @patch(PATCH_CONNECTIONS)
     @patch(PATCH_PROJECT_ID, return_value="proj-123")
     @patch(PATCH_DOMAIN, return_value=("dom-123", "my-domain"))
-    def test_project_create_true_skips_connections(self, mock_domain, mock_project,
-                                                    mock_conns, *_):
+    def test_project_create_true_skips_connections(
+        self, mock_domain, mock_project, mock_conns, *_
+    ):
         """When project.create=true, connections are not added (project deletion cascades)."""
         mock_conns.return_value = {
             "mlflow-server": {"connectionId": "conn-abc"},
         }
         from smus_cicd.application.application_manifest import (
-            StageConfig, ProjectConfig, DomainConfig, DeploymentConfiguration
+            DeploymentConfiguration,
+            DomainConfig,
+            ProjectConfig,
+            StageConfig,
         )
         from smus_cicd.bootstrap.models import BootstrapAction, BootstrapConfig
+
         sc = StageConfig(
             project=ProjectConfig(name="test-project", create=True),
             domain=DomainConfig(region="us-east-1"),
             stage="TEST",
             deployment_configuration=DeploymentConfiguration(),
-            bootstrap=BootstrapConfig(actions=[
-                BootstrapAction(type="datazone.create_connection",
-                                parameters={"name": "mlflow-server", "connection_type": "MLFLOW"})
-            ]),
+            bootstrap=BootstrapConfig(
+                actions=[
+                    BootstrapAction(
+                        type="datazone.create_connection",
+                        parameters={
+                            "name": "mlflow-server",
+                            "connection_type": "MLFLOW",
+                        },
+                    )
+                ]
+            ),
         )
         result = _validate_stage("test", sc, _make_manifest(), "us-east-1")
-        conn_resources = [r for r in result.resources if r.resource_type == "datazone_connection"]
+        conn_resources = [
+            r for r in result.resources if r.resource_type == "datazone_connection"
+        ]
         assert conn_resources == []
 
 
@@ -1179,17 +1698,28 @@ class TestBootstrapConnectionDeletion:
         sts = MagicMock()
         sts.get_caller_identity.return_value = {"Account": "111122223333"}
         dz = MagicMock()
-        mock_boto3.client.side_effect = lambda s, region_name=None: sts if s == "sts" else dz
+        mock_boto3.side_effect = lambda s, **kw: sts if s == "sts" else dz
 
-        vr = _make_vr(resources=[
-            ResourceToDelete("datazone_connection", "mlflow-server", "test",
-                             {"connection_id": "conn-abc", "domain_id": "dom-123"})
-        ])
-        results = _destroy_stage("test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT")
+        vr = _make_vr(
+            resources=[
+                ResourceToDelete(
+                    "datazone_connection",
+                    "mlflow-server",
+                    "test",
+                    {"connection_id": "conn-abc", "domain_id": "dom-123"},
+                )
+            ]
+        )
+        results = _destroy_stage(
+            "test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT"
+        )
         dz.delete_connection.assert_called_once_with(
             domainIdentifier="dom-123", identifier="conn-abc"
         )
-        assert any(r.status == "deleted" and r.resource_type == "datazone_connection" for r in results)
+        assert any(
+            r.status == "deleted" and r.resource_type == "datazone_connection"
+            for r in results
+        )
 
     @patch(PATCH_BOTO3)
     def test_connection_not_found_recorded(self, mock_boto3):
@@ -1201,14 +1731,25 @@ class TestBootstrapConnectionDeletion:
             {"Error": {"Code": "ResourceNotFoundException", "Message": "Not found"}},
             "DeleteConnection",
         )
-        mock_boto3.client.side_effect = lambda s, region_name=None: sts if s == "sts" else dz
+        mock_boto3.side_effect = lambda s, **kw: sts if s == "sts" else dz
 
-        vr = _make_vr(resources=[
-            ResourceToDelete("datazone_connection", "mlflow-server", "test",
-                             {"connection_id": "conn-abc", "domain_id": "dom-123"})
-        ])
-        results = _destroy_stage("test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT")
-        assert any(r.status == "not_found" and r.resource_type == "datazone_connection" for r in results)
+        vr = _make_vr(
+            resources=[
+                ResourceToDelete(
+                    "datazone_connection",
+                    "mlflow-server",
+                    "test",
+                    {"connection_id": "conn-abc", "domain_id": "dom-123"},
+                )
+            ]
+        )
+        results = _destroy_stage(
+            "test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT"
+        )
+        assert any(
+            r.status == "not_found" and r.resource_type == "datazone_connection"
+            for r in results
+        )
 
     @patch(PATCH_BOTO3)
     def test_connection_api_error_recorded(self, mock_boto3):
@@ -1220,19 +1761,31 @@ class TestBootstrapConnectionDeletion:
             {"Error": {"Code": "AccessDeniedException", "Message": "Denied"}},
             "DeleteConnection",
         )
-        mock_boto3.client.side_effect = lambda s, region_name=None: sts if s == "sts" else dz
+        mock_boto3.side_effect = lambda s, **kw: sts if s == "sts" else dz
 
-        vr = _make_vr(resources=[
-            ResourceToDelete("datazone_connection", "mlflow-server", "test",
-                             {"connection_id": "conn-abc", "domain_id": "dom-123"})
-        ])
-        results = _destroy_stage("test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT")
-        assert any(r.status == "error" and r.resource_type == "datazone_connection" for r in results)
+        vr = _make_vr(
+            resources=[
+                ResourceToDelete(
+                    "datazone_connection",
+                    "mlflow-server",
+                    "test",
+                    {"connection_id": "conn-abc", "domain_id": "dom-123"},
+                )
+            ]
+        )
+        results = _destroy_stage(
+            "test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT"
+        )
+        assert any(
+            r.status == "error" and r.resource_type == "datazone_connection"
+            for r in results
+        )
 
 
 # ---------------------------------------------------------------------------
 # Task 12: Catalog resource deletion tests
 # ---------------------------------------------------------------------------
+
 
 class TestCatalogResourceDiscovery:
     """Validation phase: catalog resource discovery."""
@@ -1246,27 +1799,40 @@ class TestCatalogResourceDiscovery:
     def test_catalog_resources_added_to_plan(self, *_):
         """Catalog resources are discovered and added to the destruction plan."""
         from smus_cicd.application.application_manifest import (
-            StageConfig, ProjectConfig, DomainConfig, DeploymentConfiguration
+            DeploymentConfiguration,
+            DomainConfig,
+            ProjectConfig,
+            StageConfig,
         )
+
         sc = StageConfig(
             project=ProjectConfig(name="test-project", create=False),
             domain=DomainConfig(region="us-east-1"),
             stage="TEST",
             deployment_configuration=DeploymentConfiguration(catalog={}),
         )
-        mock_search = MagicMock(return_value=[
-            {"glossaryItem": {"id": "g-1", "name": "MyGlossary"}},
-        ])
+        mock_search = MagicMock(
+            return_value=[
+                {"glossaryItem": {"id": "g-1", "name": "MyGlossary"}},
+            ]
+        )
         mock_search_types = MagicMock(return_value=[])
-        with patch("smus_cicd.helpers.destroy_validator.boto3") as mock_boto3:
+        with patch("smus_cicd.helpers.destroy_validator.create_client") as mock_boto3:
             sts = MagicMock()
             sts.get_caller_identity.return_value = {"Account": "111122223333"}
             dz = MagicMock()
-            mock_boto3.client.side_effect = lambda s, region_name=None: sts if s == "sts" else dz
-            with patch("smus_cicd.helpers.catalog_import._search_target_resources", mock_search):
-                with patch("smus_cicd.helpers.catalog_import._search_target_type_resources", mock_search_types):
+            mock_boto3.side_effect = lambda s, **kw: sts if s == "sts" else dz
+            with patch(
+                "smus_cicd.helpers.catalog_import._search_target_resources", mock_search
+            ):
+                with patch(
+                    "smus_cicd.helpers.catalog_import._search_target_type_resources",
+                    mock_search_types,
+                ):
                     result = _validate_stage("test", sc, _make_manifest(), "us-east-1")
-        catalog_resources = [r for r in result.resources if r.resource_type.startswith("catalog_")]
+        catalog_resources = [
+            r for r in result.resources if r.resource_type.startswith("catalog_")
+        ]
         assert len(catalog_resources) == 1
         assert catalog_resources[0].resource_type == "catalog_glossary"
         assert catalog_resources[0].resource_id == "g-1"
@@ -1280,8 +1846,12 @@ class TestCatalogResourceDiscovery:
     def test_catalog_disabled_skips_discovery(self, *_):
         """When catalog.disable=true, no catalog resources are added."""
         from smus_cicd.application.application_manifest import (
-            StageConfig, ProjectConfig, DomainConfig, DeploymentConfiguration
+            DeploymentConfiguration,
+            DomainConfig,
+            ProjectConfig,
+            StageConfig,
         )
+
         sc = StageConfig(
             project=ProjectConfig(name="test-project", create=False),
             domain=DomainConfig(region="us-east-1"),
@@ -1289,9 +1859,13 @@ class TestCatalogResourceDiscovery:
             deployment_configuration=DeploymentConfiguration(catalog={"disable": True}),
         )
         result = _validate_stage("test", sc, _make_manifest(), "us-east-1")
-        catalog_resources = [r for r in result.resources if r.resource_type.startswith("catalog_")]
+        catalog_resources = [
+            r for r in result.resources if r.resource_type.startswith("catalog_")
+        ]
         assert catalog_resources == []
-        assert any("disabled" in w.lower() or "disable" in w.lower() for w in result.warnings)
+        assert any(
+            "disabled" in w.lower() or "disable" in w.lower() for w in result.warnings
+        )
 
     @patch(PATCH_GET_WF_DEF, return_value="")
     @patch(PATCH_LIST_RUNS, return_value=[])
@@ -1302,8 +1876,12 @@ class TestCatalogResourceDiscovery:
     def test_catalog_absent_skips_discovery(self, *_):
         """When deployment_configuration.catalog is absent, no catalog resources added."""
         from smus_cicd.application.application_manifest import (
-            StageConfig, ProjectConfig, DomainConfig, DeploymentConfiguration
+            DeploymentConfiguration,
+            DomainConfig,
+            ProjectConfig,
+            StageConfig,
         )
+
         sc = StageConfig(
             project=ProjectConfig(name="test-project", create=False),
             domain=DomainConfig(region="us-east-1"),
@@ -1311,7 +1889,9 @@ class TestCatalogResourceDiscovery:
             deployment_configuration=DeploymentConfiguration(catalog=None),
         )
         result = _validate_stage("test", sc, _make_manifest(), "us-east-1")
-        catalog_resources = [r for r in result.resources if r.resource_type.startswith("catalog_")]
+        catalog_resources = [
+            r for r in result.resources if r.resource_type.startswith("catalog_")
+        ]
         assert catalog_resources == []
 
     @patch(PATCH_GET_WF_DEF, return_value="")
@@ -1323,8 +1903,12 @@ class TestCatalogResourceDiscovery:
     def test_managed_form_types_filtered_out(self, *_):
         """Managed form types (amazon.datazone.*) are not added to the plan."""
         from smus_cicd.application.application_manifest import (
-            StageConfig, ProjectConfig, DomainConfig, DeploymentConfiguration
+            DeploymentConfiguration,
+            DomainConfig,
+            ProjectConfig,
+            StageConfig,
         )
+
         sc = StageConfig(
             project=ProjectConfig(name="test-project", create=False),
             domain=DomainConfig(region="us-east-1"),
@@ -1332,19 +1916,38 @@ class TestCatalogResourceDiscovery:
             deployment_configuration=DeploymentConfiguration(catalog={}),
         )
         mock_search = MagicMock(return_value=[])
-        mock_search_types = MagicMock(return_value=[
-            {"formTypeItem": {"name": "amazon.datazone.ManagedForm", "owningProjectId": "proj-123"}},
-            {"formTypeItem": {"name": "MyCustomForm", "owningProjectId": "proj-123"}},
-        ])
-        with patch("smus_cicd.helpers.destroy_validator.boto3") as mock_boto3:
+        mock_search_types = MagicMock(
+            return_value=[
+                {
+                    "formTypeItem": {
+                        "name": "amazon.datazone.ManagedForm",
+                        "owningProjectId": "proj-123",
+                    }
+                },
+                {
+                    "formTypeItem": {
+                        "name": "MyCustomForm",
+                        "owningProjectId": "proj-123",
+                    }
+                },
+            ]
+        )
+        with patch("smus_cicd.helpers.destroy_validator.create_client") as mock_boto3:
             sts = MagicMock()
             sts.get_caller_identity.return_value = {"Account": "111122223333"}
             dz = MagicMock()
-            mock_boto3.client.side_effect = lambda s, region_name=None: sts if s == "sts" else dz
-            with patch("smus_cicd.helpers.catalog_import._search_target_resources", mock_search):
-                with patch("smus_cicd.helpers.catalog_import._search_target_type_resources", mock_search_types):
+            mock_boto3.side_effect = lambda s, **kw: sts if s == "sts" else dz
+            with patch(
+                "smus_cicd.helpers.catalog_import._search_target_resources", mock_search
+            ):
+                with patch(
+                    "smus_cicd.helpers.catalog_import._search_target_type_resources",
+                    mock_search_types,
+                ):
                     result = _validate_stage("test", sc, _make_manifest(), "us-east-1")
-        form_types = [r for r in result.resources if r.resource_type == "catalog_form_type"]
+        form_types = [
+            r for r in result.resources if r.resource_type == "catalog_form_type"
+        ]
         assert len(form_types) == 1
         assert form_types[0].resource_id == "MyCustomForm"
 
@@ -1358,15 +1961,28 @@ class TestCatalogResourceDeletion:
         sts = MagicMock()
         sts.get_caller_identity.return_value = {"Account": "111122223333"}
         dz = MagicMock()
-        mock_boto3.client.side_effect = lambda s, region_name=None: sts if s == "sts" else dz
+        mock_boto3.side_effect = lambda s, **kw: sts if s == "sts" else dz
 
-        vr = _make_vr(resources=[
-            ResourceToDelete("catalog_glossary", "g-1", "test",
-                             {"name": "MyGlossary", "domain_id": "dom-123"})
-        ])
-        results = _destroy_stage("test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT")
-        dz.delete_glossary.assert_called_once_with(domainIdentifier="dom-123", identifier="g-1")
-        assert any(r.status == "deleted" and r.resource_type == "catalog_glossary" for r in results)
+        vr = _make_vr(
+            resources=[
+                ResourceToDelete(
+                    "catalog_glossary",
+                    "g-1",
+                    "test",
+                    {"name": "MyGlossary", "domain_id": "dom-123"},
+                )
+            ]
+        )
+        results = _destroy_stage(
+            "test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT"
+        )
+        dz.delete_glossary.assert_called_once_with(
+            domainIdentifier="dom-123", identifier="g-1"
+        )
+        assert any(
+            r.status == "deleted" and r.resource_type == "catalog_glossary"
+            for r in results
+        )
 
     @patch(PATCH_BOTO3)
     def test_catalog_asset_not_found_recorded(self, mock_boto3):
@@ -1378,14 +1994,25 @@ class TestCatalogResourceDeletion:
             {"Error": {"Code": "ResourceNotFoundException", "Message": "Not found"}},
             "DeleteAsset",
         )
-        mock_boto3.client.side_effect = lambda s, region_name=None: sts if s == "sts" else dz
+        mock_boto3.side_effect = lambda s, **kw: sts if s == "sts" else dz
 
-        vr = _make_vr(resources=[
-            ResourceToDelete("catalog_asset", "a-1", "test",
-                             {"name": "MyAsset", "domain_id": "dom-123"})
-        ])
-        results = _destroy_stage("test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT")
-        assert any(r.status == "not_found" and r.resource_type == "catalog_asset" for r in results)
+        vr = _make_vr(
+            resources=[
+                ResourceToDelete(
+                    "catalog_asset",
+                    "a-1",
+                    "test",
+                    {"name": "MyAsset", "domain_id": "dom-123"},
+                )
+            ]
+        )
+        results = _destroy_stage(
+            "test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT"
+        )
+        assert any(
+            r.status == "not_found" and r.resource_type == "catalog_asset"
+            for r in results
+        )
 
     @patch(PATCH_BOTO3)
     def test_catalog_deletion_order(self, mock_boto3):
@@ -1394,23 +2021,46 @@ class TestCatalogResourceDeletion:
         sts.get_caller_identity.return_value = {"Account": "111122223333"}
         dz = MagicMock()
         call_order = []
-        dz.delete_data_product.side_effect = lambda **kw: call_order.append("data_product")
+        dz.delete_data_product.side_effect = lambda **kw: call_order.append(
+            "data_product"
+        )
         dz.delete_asset.side_effect = lambda **kw: call_order.append("asset")
         dz.delete_glossary.side_effect = lambda **kw: call_order.append("glossary")
-        mock_boto3.client.side_effect = lambda s, region_name=None: sts if s == "sts" else dz
+        mock_boto3.side_effect = lambda s, **kw: sts if s == "sts" else dz
 
-        vr = _make_vr(resources=[
-            ResourceToDelete("catalog_glossary", "g-1", "test", {"name": "G", "domain_id": "dom-123"}),
-            ResourceToDelete("catalog_asset", "a-1", "test", {"name": "A", "domain_id": "dom-123"}),
-            ResourceToDelete("catalog_data_product", "dp-1", "test", {"name": "DP", "domain_id": "dom-123"}),
-        ])
-        _destroy_stage("test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT")
+        vr = _make_vr(
+            resources=[
+                ResourceToDelete(
+                    "catalog_glossary",
+                    "g-1",
+                    "test",
+                    {"name": "G", "domain_id": "dom-123"},
+                ),
+                ResourceToDelete(
+                    "catalog_asset",
+                    "a-1",
+                    "test",
+                    {"name": "A", "domain_id": "dom-123"},
+                ),
+                ResourceToDelete(
+                    "catalog_data_product",
+                    "dp-1",
+                    "test",
+                    {"name": "DP", "domain_id": "dom-123"},
+                ),
+            ]
+        )
+        _destroy_stage(
+            "test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT"
+        )
         assert call_order.index("data_product") < call_order.index("asset")
         assert call_order.index("asset") < call_order.index("glossary")
+
 
 # ---------------------------------------------------------------------------
 # Deploy/Destroy drift detection
 # ---------------------------------------------------------------------------
+
 
 class TestDeployDestroyDrift:
     """Ensure destroy supports every resource type that deploy can create.
@@ -1421,8 +2071,8 @@ class TestDeployDestroyDrift:
     """
 
     def test_destroy_covers_all_deploy_resource_types(self):
-        from smus_cicd.resource_types import DEPLOY_RESOURCE_TYPES
         from smus_cicd.helpers.destroy_models import DESTROY_SUPPORTED_RESOURCE_TYPES
+        from smus_cicd.resource_types import DEPLOY_RESOURCE_TYPES
 
         missing = DEPLOY_RESOURCE_TYPES - DESTROY_SUPPORTED_RESOURCE_TYPES
         extra = DESTROY_SUPPORTED_RESOURCE_TYPES - DEPLOY_RESOURCE_TYPES

--- a/tests/unit/helpers/test_catalog_import.py
+++ b/tests/unit/helpers/test_catalog_import.py
@@ -883,22 +883,22 @@ class TestGetDatazoneClient(unittest.TestCase):
     """Test _get_datazone_client with custom endpoint."""
 
     @patch.dict("os.environ", {"DATAZONE_ENDPOINT_URL": "https://custom.endpoint"})
-    @patch("smus_cicd.helpers.catalog_import.boto3.client")
-    def test_custom_endpoint(self, mock_boto_client):
+    @patch("smus_cicd.helpers.catalog_import.create_client")
+    def test_custom_endpoint(self, mock_create_client):
         from smus_cicd.helpers.catalog_import import _get_datazone_client
 
         _get_datazone_client("us-east-1")
-        mock_boto_client.assert_called_once_with(
-            "datazone", region_name="us-east-1", endpoint_url="https://custom.endpoint"
+        mock_create_client.assert_called_once_with(
+            "datazone", region="us-east-1", endpoint_url="https://custom.endpoint"
         )
 
     @patch.dict("os.environ", {}, clear=True)
-    @patch("smus_cicd.helpers.catalog_import.boto3.client")
-    def test_default_endpoint(self, mock_boto_client):
+    @patch("smus_cicd.helpers.catalog_import.create_client")
+    def test_default_endpoint(self, mock_create_client):
         from smus_cicd.helpers.catalog_import import _get_datazone_client
 
         _get_datazone_client("us-west-2")
-        mock_boto_client.assert_called_once_with("datazone", region_name="us-west-2")
+        mock_create_client.assert_called_once_with("datazone", region="us-west-2")
 
 
 class TestSearchTargetResources(unittest.TestCase):

--- a/tests/unit/helpers/test_datazone_properties.py
+++ b/tests/unit/helpers/test_datazone_properties.py
@@ -7,7 +7,8 @@ import os
 import unittest
 from unittest.mock import MagicMock, patch
 
-from hypothesis import given, settings, strategies as st
+from hypothesis import given, settings
+from hypothesis import strategies as st
 
 from smus_cicd.helpers import datazone
 from smus_cicd.helpers.connection_creator import ConnectionCreator
@@ -19,18 +20,26 @@ def endpoint_url_strategy(draw):
     """Generate valid endpoint URLs for testing."""
     protocols = ["http", "https"]
     protocol = draw(st.sampled_from(protocols))
-    
+
     # Generate hostname
-    hostname_parts = draw(st.lists(
-        st.text(min_size=1, max_size=10, alphabet=st.characters(whitelist_categories=("Ll", "Nd"), whitelist_characters="-")),
-        min_size=1,
-        max_size=3
-    ))
+    hostname_parts = draw(
+        st.lists(
+            st.text(
+                min_size=1,
+                max_size=10,
+                alphabet=st.characters(
+                    whitelist_categories=("Ll", "Nd"), whitelist_characters="-"
+                ),
+            ),
+            min_size=1,
+            max_size=3,
+        )
+    )
     hostname = ".".join(hostname_parts)
-    
+
     # Generate optional port
     port = draw(st.one_of(st.none(), st.integers(min_value=1024, max_value=65535)))
-    
+
     if port:
         return f"{protocol}://{hostname}:{port}"
     return f"{protocol}://{hostname}"
@@ -41,8 +50,14 @@ def endpoint_url_strategy(draw):
 def aws_region_strategy(draw):
     """Generate valid AWS region names."""
     regions = [
-        "us-east-1", "us-east-2", "us-west-1", "us-west-2",
-        "eu-west-1", "eu-central-1", "ap-southeast-1", "ap-northeast-1"
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+        "eu-west-1",
+        "eu-central-1",
+        "ap-southeast-1",
+        "ap-northeast-1",
     ]
     return draw(st.sampled_from(regions))
 
@@ -51,80 +66,72 @@ class TestDataZoneProperties(unittest.TestCase):
     """Property-based tests for DataZone helper."""
 
     @settings(max_examples=100)
-    @given(
-        endpoint_url=endpoint_url_strategy(),
-        region=aws_region_strategy()
-    )
+    @given(endpoint_url=endpoint_url_strategy(), region=aws_region_strategy())
     @patch.dict(os.environ, {}, clear=True)
-    @patch("smus_cicd.helpers.datazone.boto3")
+    @patch("smus_cicd.helpers.datazone.create_client")
     def test_property_8_endpoint_url_override_for_all_operations(
-        self, mock_boto3, region, endpoint_url
+        self, mock_create_client, region, endpoint_url
     ):
         """
         Property 8: Endpoint URL Override for All Operations
-        
+
         For any DataZone operation, when the DATAZONE_ENDPOINT_URL environment variable
         is set, the client SHALL use the specified endpoint URL instead of the default.
-        
+
         Feature: remove-datazone-internal-client, Property 8: Endpoint URL Override for All Operations
         **Validates: Requirements 13.1**
         """
-        # Set up mock boto3 client
+        # Set up mock client
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
-        
+        mock_create_client.return_value = mock_client
+
         # Set the environment variable
         os.environ["DATAZONE_ENDPOINT_URL"] = endpoint_url
-        
+
         # Call _get_datazone_client
         result_client = datazone._get_datazone_client(region)
-        
-        # Verify boto3.client was called with the endpoint URL
-        mock_boto3.client.assert_called_once_with(
-            "datazone",
-            region_name=region,
-            endpoint_url=endpoint_url
+
+        # Verify create_client was called with the endpoint URL
+        mock_create_client.assert_called_once_with(
+            "datazone", region=region, endpoint_url=endpoint_url
         )
-        
+
         # Verify the returned client is the mock client
         self.assertEqual(result_client, mock_client)
-        
+
         # Clean up
         del os.environ["DATAZONE_ENDPOINT_URL"]
 
     @settings(max_examples=100)
     @given(region=aws_region_strategy())
     @patch.dict(os.environ, {}, clear=True)
-    @patch("smus_cicd.helpers.datazone.boto3")
+    @patch("smus_cicd.helpers.datazone.create_client")
     def test_property_8_no_endpoint_override_when_not_set(
-        self, mock_boto3, region
+        self, mock_create_client, region
     ):
         """
         Property 8: Endpoint URL Override for All Operations (negative case)
-        
+
         For any DataZone operation, when the DATAZONE_ENDPOINT_URL environment variable
         is NOT set, the client SHALL use the default endpoint (no endpoint_url parameter).
-        
+
         Feature: remove-datazone-internal-client, Property 8: Endpoint URL Override for All Operations
         **Validates: Requirements 13.1**
         """
-        # Set up mock boto3 client
+        # Set up mock client
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
-        
+        mock_create_client.return_value = mock_client
+
         # Ensure DATAZONE_ENDPOINT_URL is not set
         if "DATAZONE_ENDPOINT_URL" in os.environ:
             del os.environ["DATAZONE_ENDPOINT_URL"]
-        
+
         # Call _get_datazone_client
         result_client = datazone._get_datazone_client(region)
-        
-        # Verify boto3.client was called WITHOUT endpoint_url parameter
-        mock_boto3.client.assert_called_once_with(
-            "datazone",
-            region_name=region
-        )
-        
+
+        # Verify create_client was called WITHOUT endpoint_url parameter
+        mock_create_client.assert_called_once_with("datazone", region=region)
+
         # Verify the returned client is the mock client
         self.assertEqual(result_client, mock_client)
 
@@ -132,223 +139,251 @@ class TestDataZoneProperties(unittest.TestCase):
     @given(
         endpoint_url=endpoint_url_strategy(),
         region=aws_region_strategy(),
-        domain_name=st.text(min_size=1, max_size=50, alphabet=st.characters(whitelist_categories=("Lu", "Ll", "Nd"), whitelist_characters="-_"))
+        domain_name=st.text(
+            min_size=1,
+            max_size=50,
+            alphabet=st.characters(
+                whitelist_categories=("Lu", "Ll", "Nd"), whitelist_characters="-_"
+            ),
+        ),
     )
     @patch.dict(os.environ, {}, clear=True)
-    @patch("smus_cicd.helpers.datazone.boto3")
+    @patch("smus_cicd.helpers.datazone.create_client")
     def test_property_8_endpoint_override_for_domain_operations(
-        self, mock_boto3, domain_name, region, endpoint_url
+        self, mock_create_client, domain_name, region, endpoint_url
     ):
         """
         Property 8: Endpoint URL Override for All Operations (domain operations)
-        
+
         For domain-related DataZone operations (like resolve_domain_id), when the
         DATAZONE_ENDPOINT_URL environment variable is set, the operation SHALL use
         a client configured with the specified endpoint URL.
-        
+
         Feature: remove-datazone-internal-client, Property 8: Endpoint URL Override for All Operations
         **Validates: Requirements 13.1**
         """
-        # Set up mock boto3 client
+        # Set up mock client
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
-        
+        mock_create_client.return_value = mock_client
+
         # Mock list_domains response
         mock_client.list_domains.return_value = {
             "items": [
-                {"id": "domain-123", "name": domain_name, "arn": "arn:aws:datazone:us-east-1:123456789012:domain/domain-123"}
-            ]
-        }
-        
-        # Mock list_tags_for_resource response
-        mock_client.list_tags_for_resource.return_value = {"tags": {}}
-        
-        # Set the environment variable
-        os.environ["DATAZONE_ENDPOINT_URL"] = endpoint_url
-        
-        # Call resolve_domain_id
-        domain_id, resolved_name = datazone.resolve_domain_id(
-            domain_name=domain_name,
-            region=region
-        )
-        
-        # Verify boto3.client was called with the endpoint URL
-        mock_boto3.client.assert_called_with(
-            "datazone",
-            region_name=region,
-            endpoint_url=endpoint_url
-        )
-        
-        # Verify the operation succeeded
-        self.assertEqual(domain_id, "domain-123")
-        self.assertEqual(resolved_name, domain_name)
-        
-        # Clean up
-        del os.environ["DATAZONE_ENDPOINT_URL"]
-
-    @settings(max_examples=100)
-    @given(
-        endpoint_url=endpoint_url_strategy(),
-        region=aws_region_strategy(),
-        project_name=st.text(min_size=1, max_size=50, alphabet=st.characters(whitelist_categories=("Lu", "Ll", "Nd"), whitelist_characters="-_")),
-        domain_id=st.text(min_size=1, max_size=50, alphabet=st.characters(whitelist_categories=("Ll", "Nd"), whitelist_characters="-"))
-    )
-    @patch.dict(os.environ, {}, clear=True)
-    @patch("smus_cicd.helpers.datazone.boto3")
-    def test_property_8_endpoint_override_for_project_operations(
-        self, mock_boto3, domain_id, project_name, region, endpoint_url
-    ):
-        """
-        Property 8: Endpoint URL Override for All Operations (project operations)
-        
-        For project-related DataZone operations (like get_project_by_name), when the
-        DATAZONE_ENDPOINT_URL environment variable is set, the operation SHALL use
-        a client configured with the specified endpoint URL.
-        
-        Feature: remove-datazone-internal-client, Property 8: Endpoint URL Override for All Operations
-        **Validates: Requirements 13.1**
-        """
-        # Set up mock boto3 client
-        mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
-        
-        # Mock list_projects response
-        mock_client.list_projects.return_value = {
-            "items": [
-                {"id": "project-123", "name": project_name}
-            ]
-        }
-        
-        # Set the environment variable
-        os.environ["DATAZONE_ENDPOINT_URL"] = endpoint_url
-        
-        # Call get_project_by_name
-        project = datazone.get_project_by_name(project_name, domain_id, region)
-        
-        # Verify boto3.client was called with the endpoint URL
-        mock_boto3.client.assert_called_with(
-            "datazone",
-            region_name=region,
-            endpoint_url=endpoint_url
-        )
-        
-        # Verify the operation succeeded
-        self.assertIsNotNone(project)
-        self.assertEqual(project["name"], project_name)
-        
-        # Clean up
-        del os.environ["DATAZONE_ENDPOINT_URL"]
-
-    @settings(max_examples=100)
-    @given(
-        endpoint_url=endpoint_url_strategy(),
-        region=aws_region_strategy(),
-        domain_id=st.text(min_size=1, max_size=50, alphabet=st.characters(whitelist_categories=("Ll", "Nd"), whitelist_characters="-")),
-        project_id=st.text(min_size=1, max_size=50, alphabet=st.characters(whitelist_categories=("Ll", "Nd"), whitelist_characters="-"))
-    )
-    @patch.dict(os.environ, {}, clear=True)
-    @patch("smus_cicd.helpers.datazone.boto3")
-    def test_property_8_endpoint_override_for_environment_operations(
-        self, mock_boto3, project_id, domain_id, region, endpoint_url
-    ):
-        """
-        Property 8: Endpoint URL Override for All Operations (environment operations)
-        
-        For environment-related DataZone operations (like get_project_environments), when the
-        DATAZONE_ENDPOINT_URL environment variable is set, the operation SHALL use
-        a client configured with the specified endpoint URL.
-        
-        Feature: remove-datazone-internal-client, Property 8: Endpoint URL Override for All Operations
-        **Validates: Requirements 13.1**
-        """
-        # Set up mock boto3 client
-        mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
-        
-        # Mock list_environments response
-        mock_client.list_environments.return_value = {
-            "items": [
-                {"id": "env-123", "name": "test-env", "status": "ACTIVE"}
-            ]
-        }
-        
-        # Set the environment variable
-        os.environ["DATAZONE_ENDPOINT_URL"] = endpoint_url
-        
-        # Call get_project_environments
-        environments = datazone.get_project_environments(project_id, domain_id, region)
-        
-        # Verify boto3.client was called with the endpoint URL
-        mock_boto3.client.assert_called_with(
-            "datazone",
-            region_name=region,
-            endpoint_url=endpoint_url
-        )
-        
-        # Verify the operation succeeded
-        self.assertIsInstance(environments, list)
-        self.assertEqual(len(environments), 1)
-        
-        # Clean up
-        del os.environ["DATAZONE_ENDPOINT_URL"]
-
-    @settings(max_examples=100)
-    @given(
-        endpoint_url=endpoint_url_strategy(),
-        region=aws_region_strategy(),
-        domain_id=st.text(min_size=1, max_size=50, alphabet=st.characters(whitelist_categories=("Ll", "Nd"), whitelist_characters="-")),
-        identifier=st.text(min_size=1, max_size=50, alphabet=st.characters(whitelist_categories=("Lu", "Ll", "Nd"), whitelist_characters="-_"))
-    )
-    @patch.dict(os.environ, {}, clear=True)
-    @patch("smus_cicd.helpers.datazone.boto3")
-    def test_property_8_endpoint_override_for_catalog_operations(
-        self, mock_boto3, identifier, domain_id, region, endpoint_url
-    ):
-        """
-        Property 8: Endpoint URL Override for All Operations (catalog operations)
-        
-        For catalog-related DataZone operations (like search_asset_listing), when the
-        DATAZONE_ENDPOINT_URL environment variable is set, the operation SHALL use
-        a client configured with the specified endpoint URL.
-        
-        Feature: remove-datazone-internal-client, Property 8: Endpoint URL Override for All Operations
-        **Validates: Requirements 13.1**
-        """
-        # Set up mock boto3 client
-        mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
-        
-        # Mock search_listings response
-        mock_client.search_listings.return_value = {
-            "items": [
                 {
-                    "assetListing": {
-                        "entityId": "asset-123",
-                        "listingId": "listing-123"
-                    }
+                    "id": "domain-123",
+                    "name": domain_name,
+                    "arn": "arn:aws:datazone:us-east-1:123456789012:domain/domain-123",
                 }
             ]
         }
-        
+
+        # Mock list_tags_for_resource response
+        mock_client.list_tags_for_resource.return_value = {"tags": {}}
+
         # Set the environment variable
         os.environ["DATAZONE_ENDPOINT_URL"] = endpoint_url
-        
+
+        # Call resolve_domain_id
+        domain_id, resolved_name = datazone.resolve_domain_id(
+            domain_name=domain_name, region=region
+        )
+
+        # Verify create_client was called with the endpoint URL
+        mock_create_client.assert_called_with(
+            "datazone", region=region, endpoint_url=endpoint_url
+        )
+
+        # Verify the operation succeeded
+        self.assertEqual(domain_id, "domain-123")
+        self.assertEqual(resolved_name, domain_name)
+
+        # Clean up
+        del os.environ["DATAZONE_ENDPOINT_URL"]
+
+    @settings(max_examples=100)
+    @given(
+        endpoint_url=endpoint_url_strategy(),
+        region=aws_region_strategy(),
+        project_name=st.text(
+            min_size=1,
+            max_size=50,
+            alphabet=st.characters(
+                whitelist_categories=("Lu", "Ll", "Nd"), whitelist_characters="-_"
+            ),
+        ),
+        domain_id=st.text(
+            min_size=1,
+            max_size=50,
+            alphabet=st.characters(
+                whitelist_categories=("Ll", "Nd"), whitelist_characters="-"
+            ),
+        ),
+    )
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("smus_cicd.helpers.datazone.create_client")
+    def test_property_8_endpoint_override_for_project_operations(
+        self, mock_create_client, domain_id, project_name, region, endpoint_url
+    ):
+        """
+        Property 8: Endpoint URL Override for All Operations (project operations)
+
+        For project-related DataZone operations (like get_project_by_name), when the
+        DATAZONE_ENDPOINT_URL environment variable is set, the operation SHALL use
+        a client configured with the specified endpoint URL.
+
+        Feature: remove-datazone-internal-client, Property 8: Endpoint URL Override for All Operations
+        **Validates: Requirements 13.1**
+        """
+        # Set up mock client
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+
+        # Mock list_projects response
+        mock_client.list_projects.return_value = {
+            "items": [{"id": "project-123", "name": project_name}]
+        }
+
+        # Set the environment variable
+        os.environ["DATAZONE_ENDPOINT_URL"] = endpoint_url
+
+        # Call get_project_by_name
+        project = datazone.get_project_by_name(project_name, domain_id, region)
+
+        # Verify create_client was called with the endpoint URL
+        mock_create_client.assert_called_with(
+            "datazone", region=region, endpoint_url=endpoint_url
+        )
+
+        # Verify the operation succeeded
+        self.assertIsNotNone(project)
+        self.assertEqual(project["name"], project_name)
+
+        # Clean up
+        del os.environ["DATAZONE_ENDPOINT_URL"]
+
+    @settings(max_examples=100)
+    @given(
+        endpoint_url=endpoint_url_strategy(),
+        region=aws_region_strategy(),
+        domain_id=st.text(
+            min_size=1,
+            max_size=50,
+            alphabet=st.characters(
+                whitelist_categories=("Ll", "Nd"), whitelist_characters="-"
+            ),
+        ),
+        project_id=st.text(
+            min_size=1,
+            max_size=50,
+            alphabet=st.characters(
+                whitelist_categories=("Ll", "Nd"), whitelist_characters="-"
+            ),
+        ),
+    )
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("smus_cicd.helpers.datazone.create_client")
+    def test_property_8_endpoint_override_for_environment_operations(
+        self, mock_create_client, project_id, domain_id, region, endpoint_url
+    ):
+        """
+        Property 8: Endpoint URL Override for All Operations (environment operations)
+
+        For environment-related DataZone operations (like get_project_environments), when the
+        DATAZONE_ENDPOINT_URL environment variable is set, the operation SHALL use
+        a client configured with the specified endpoint URL.
+
+        Feature: remove-datazone-internal-client, Property 8: Endpoint URL Override for All Operations
+        **Validates: Requirements 13.1**
+        """
+        # Set up mock client
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+
+        # Mock list_environments response
+        mock_client.list_environments.return_value = {
+            "items": [{"id": "env-123", "name": "test-env", "status": "ACTIVE"}]
+        }
+
+        # Set the environment variable
+        os.environ["DATAZONE_ENDPOINT_URL"] = endpoint_url
+
+        # Call get_project_environments
+        environments = datazone.get_project_environments(project_id, domain_id, region)
+
+        # Verify create_client was called with the endpoint URL
+        mock_create_client.assert_called_with(
+            "datazone", region=region, endpoint_url=endpoint_url
+        )
+
+        # Verify the operation succeeded
+        self.assertIsInstance(environments, list)
+        self.assertEqual(len(environments), 1)
+
+        # Clean up
+        del os.environ["DATAZONE_ENDPOINT_URL"]
+
+    @settings(max_examples=100)
+    @given(
+        endpoint_url=endpoint_url_strategy(),
+        region=aws_region_strategy(),
+        domain_id=st.text(
+            min_size=1,
+            max_size=50,
+            alphabet=st.characters(
+                whitelist_categories=("Ll", "Nd"), whitelist_characters="-"
+            ),
+        ),
+        identifier=st.text(
+            min_size=1,
+            max_size=50,
+            alphabet=st.characters(
+                whitelist_categories=("Lu", "Ll", "Nd"), whitelist_characters="-_"
+            ),
+        ),
+    )
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("smus_cicd.helpers.datazone.create_client")
+    def test_property_8_endpoint_override_for_catalog_operations(
+        self, mock_create_client, identifier, domain_id, region, endpoint_url
+    ):
+        """
+        Property 8: Endpoint URL Override for All Operations (catalog operations)
+
+        For catalog-related DataZone operations (like search_asset_listing), when the
+        DATAZONE_ENDPOINT_URL environment variable is set, the operation SHALL use
+        a client configured with the specified endpoint URL.
+
+        Feature: remove-datazone-internal-client, Property 8: Endpoint URL Override for All Operations
+        **Validates: Requirements 13.1**
+        """
+        # Set up mock client
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+
+        # Mock search_listings response
+        mock_client.search_listings.return_value = {
+            "items": [
+                {"assetListing": {"entityId": "asset-123", "listingId": "listing-123"}}
+            ]
+        }
+
+        # Set the environment variable
+        os.environ["DATAZONE_ENDPOINT_URL"] = endpoint_url
+
         # Call search_asset_listing
         result = datazone.search_asset_listing(domain_id, identifier, region)
-        
-        # Verify boto3.client was called with the endpoint URL
-        mock_boto3.client.assert_called_with(
-            "datazone",
-            region_name=region,
-            endpoint_url=endpoint_url
+
+        # Verify create_client was called with the endpoint URL
+        mock_create_client.assert_called_with(
+            "datazone", region=region, endpoint_url=endpoint_url
         )
-        
+
         # Verify the operation succeeded
         self.assertIsNotNone(result)
         asset_id, listing_id = result
         self.assertEqual(asset_id, "asset-123")
         self.assertEqual(listing_id, "listing-123")
-        
+
         # Clean up
         del os.environ["DATAZONE_ENDPOINT_URL"]
 
@@ -362,190 +397,263 @@ class TestConnectionCreatorProperties(unittest.TestCase):
 
     @settings(max_examples=100)
     @given(
-        domain_id=st.text(min_size=1, max_size=50, alphabet=st.characters(whitelist_categories=("Ll", "Nd"), whitelist_characters="-")),
-        environment_id=st.text(min_size=1, max_size=50, alphabet=st.characters(whitelist_categories=("Ll", "Nd"), whitelist_characters="-")),
-        connection_name=st.text(min_size=1, max_size=50, alphabet=st.characters(whitelist_categories=("Lu", "Ll", "Nd"), whitelist_characters="-_")),
-        mwaa_env_name=st.text(min_size=1, max_size=50, alphabet=st.characters(whitelist_categories=("Lu", "Ll", "Nd"), whitelist_characters="-_")),
-        region=aws_region_strategy()
+        domain_id=st.text(
+            min_size=1,
+            max_size=50,
+            alphabet=st.characters(
+                whitelist_categories=("Ll", "Nd"), whitelist_characters="-"
+            ),
+        ),
+        environment_id=st.text(
+            min_size=1,
+            max_size=50,
+            alphabet=st.characters(
+                whitelist_categories=("Ll", "Nd"), whitelist_characters="-"
+            ),
+        ),
+        connection_name=st.text(
+            min_size=1,
+            max_size=50,
+            alphabet=st.characters(
+                whitelist_categories=("Lu", "Ll", "Nd"), whitelist_characters="-_"
+            ),
+        ),
+        mwaa_env_name=st.text(
+            min_size=1,
+            max_size=50,
+            alphabet=st.characters(
+                whitelist_categories=("Lu", "Ll", "Nd"), whitelist_characters="-_"
+            ),
+        ),
+        region=aws_region_strategy(),
     )
-    @patch("smus_cicd.helpers.connection_creator.boto3")
+    @patch("smus_cicd.helpers.connection_creator.create_client")
     def test_property_2_workflows_mwaa_connection_creation(
-        self, mock_boto3, region, mwaa_env_name, connection_name, environment_id, domain_id
+        self,
+        mock_create_client,
+        region,
+        mwaa_env_name,
+        connection_name,
+        environment_id,
+        domain_id,
     ):
         """
         Property 2: WORKFLOWS_MWAA Connection Creation
-        
+
         For any valid MWAA environment name, creating a WORKFLOWS_MWAA connection
         SHALL succeed and use public API-compatible property names.
-        
+
         Feature: remove-datazone-internal-client, Property 2: WORKFLOWS_MWAA Connection Creation
         **Validates: Requirements 3.3**
         """
-        # Set up mock boto3 client
+        # Set up mock client
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
-        
+        mock_create_client.return_value = mock_client
+
         # Mock create_connection response
         connection_id = "conn-123"
-        mock_client.create_connection.return_value = {
-            "connectionId": connection_id
-        }
-        
+        mock_client.create_connection.return_value = {"connectionId": connection_id}
+
         # Mock get_connection response for status check
         mock_client.get_connection.return_value = {
             "connectionId": connection_id,
-            "status": "AVAILABLE"
+            "status": "AVAILABLE",
         }
-        
+
         # Create ConnectionCreator instance
         creator = ConnectionCreator(domain_id=domain_id, region=region)
-        
+
         # Create WORKFLOWS_MWAA connection
         result_connection_id = creator.create_connection(
             environment_id=environment_id,
             name=connection_name,
             connection_type="WORKFLOWS_MWAA",
-            mwaa_environment_name=mwaa_env_name
+            mwaa_environment_name=mwaa_env_name,
         )
-        
+
         # Verify the connection was created successfully
         self.assertEqual(result_connection_id, connection_id)
-        
+
         # Verify create_connection was called with correct parameters
         mock_client.create_connection.assert_called_once()
         call_args = mock_client.create_connection.call_args
-        
+
         # Verify domain and environment identifiers
         self.assertEqual(call_args.kwargs["domainIdentifier"], domain_id)
         self.assertEqual(call_args.kwargs["environmentIdentifier"], environment_id)
         self.assertEqual(call_args.kwargs["name"], connection_name)
-        
+
         # Verify public API-compatible property names are used
         props = call_args.kwargs["props"]
         self.assertIn("workflowsMwaaProperties", props)
         self.assertIn("mwaaEnvironmentName", props["workflowsMwaaProperties"])
         self.assertEqual(
-            props["workflowsMwaaProperties"]["mwaaEnvironmentName"],
-            mwaa_env_name
+            props["workflowsMwaaProperties"]["mwaaEnvironmentName"], mwaa_env_name
         )
-        
+
         # Verify standard client is used (not internal client)
-        mock_boto3.client.assert_called_with("datazone", region_name=region)
+        mock_create_client.assert_called_with("datazone", region=region)
 
     @settings(max_examples=100)
     @given(
-        domain_id=st.text(min_size=1, max_size=50, alphabet=st.characters(whitelist_categories=("Ll", "Nd"), whitelist_characters="-")),
-        environment_id=st.text(min_size=1, max_size=50, alphabet=st.characters(whitelist_categories=("Ll", "Nd"), whitelist_characters="-")),
-        connection_name=st.text(min_size=1, max_size=50, alphabet=st.characters(whitelist_categories=("Lu", "Ll", "Nd"), whitelist_characters="-_")),
-        region=aws_region_strategy()
+        domain_id=st.text(
+            min_size=1,
+            max_size=50,
+            alphabet=st.characters(
+                whitelist_categories=("Ll", "Nd"), whitelist_characters="-"
+            ),
+        ),
+        environment_id=st.text(
+            min_size=1,
+            max_size=50,
+            alphabet=st.characters(
+                whitelist_categories=("Ll", "Nd"), whitelist_characters="-"
+            ),
+        ),
+        connection_name=st.text(
+            min_size=1,
+            max_size=50,
+            alphabet=st.characters(
+                whitelist_categories=("Lu", "Ll", "Nd"), whitelist_characters="-_"
+            ),
+        ),
+        region=aws_region_strategy(),
     )
-    @patch("smus_cicd.helpers.connection_creator.boto3")
+    @patch("smus_cicd.helpers.connection_creator.create_client")
     def test_property_3_workflows_serverless_connection_creation(
-        self, mock_boto3, region, connection_name, environment_id, domain_id
+        self, mock_create_client, region, connection_name, environment_id, domain_id
     ):
         """
         Property 3: WORKFLOWS_SERVERLESS Connection Creation
-        
+
         For any valid environment, creating a WORKFLOWS_SERVERLESS connection
         SHALL succeed and use public API-compatible property names.
-        
+
         Feature: remove-datazone-internal-client, Property 3: WORKFLOWS_SERVERLESS Connection Creation
         **Validates: Requirements 3.4**
         """
-        # Set up mock boto3 client
+        # Set up mock client
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
-        
+        mock_create_client.return_value = mock_client
+
         # Mock create_connection response
         connection_id = "conn-456"
-        mock_client.create_connection.return_value = {
-            "connectionId": connection_id
-        }
-        
+        mock_client.create_connection.return_value = {"connectionId": connection_id}
+
         # Mock get_connection response for status check
         mock_client.get_connection.return_value = {
             "connectionId": connection_id,
-            "status": "AVAILABLE"
+            "status": "AVAILABLE",
         }
-        
+
         # Create ConnectionCreator instance
         creator = ConnectionCreator(domain_id=domain_id, region=region)
-        
+
         # Create WORKFLOWS_SERVERLESS connection
         result_connection_id = creator.create_connection(
             environment_id=environment_id,
             name=connection_name,
-            connection_type="WORKFLOWS_SERVERLESS"
+            connection_type="WORKFLOWS_SERVERLESS",
         )
-        
+
         # Verify the connection was created successfully
         self.assertEqual(result_connection_id, connection_id)
-        
+
         # Verify create_connection was called with correct parameters
         mock_client.create_connection.assert_called_once()
         call_args = mock_client.create_connection.call_args
-        
+
         # Verify domain and environment identifiers
         self.assertEqual(call_args.kwargs["domainIdentifier"], domain_id)
         self.assertEqual(call_args.kwargs["environmentIdentifier"], environment_id)
         self.assertEqual(call_args.kwargs["name"], connection_name)
-        
+
         # Verify public API-compatible property names are used
         props = call_args.kwargs["props"]
         self.assertIn("workflowsServerlessProperties", props)
-        
+
         # Verify the properties structure is correct (empty dict for serverless)
         self.assertIsInstance(props["workflowsServerlessProperties"], dict)
-        
+
         # Verify standard client is used (not internal client)
-        mock_boto3.client.assert_called_with("datazone", region_name=region)
+        mock_create_client.assert_called_with("datazone", region=region)
 
     @settings(max_examples=100)
     @given(
-        domain_id=st.text(min_size=1, max_size=50, alphabet=st.characters(whitelist_categories=("Ll", "Nd"), whitelist_characters="-")),
-        environment_id=st.text(min_size=1, max_size=50, alphabet=st.characters(whitelist_categories=("Ll", "Nd"), whitelist_characters="-")),
-        connection_name=st.text(min_size=1, max_size=50, alphabet=st.characters(whitelist_categories=("Lu", "Ll", "Nd"), whitelist_characters="-_")),
-        connection_type=st.sampled_from([
-            "S3", "IAM", "SPARK_GLUE", "SPARK_EMR", "REDSHIFT", 
-            "ATHENA", "WORKFLOWS_MWAA", "WORKFLOWS_SERVERLESS"
-        ]),
-        region=aws_region_strategy()
+        domain_id=st.text(
+            min_size=1,
+            max_size=50,
+            alphabet=st.characters(
+                whitelist_categories=("Ll", "Nd"), whitelist_characters="-"
+            ),
+        ),
+        environment_id=st.text(
+            min_size=1,
+            max_size=50,
+            alphabet=st.characters(
+                whitelist_categories=("Ll", "Nd"), whitelist_characters="-"
+            ),
+        ),
+        connection_name=st.text(
+            min_size=1,
+            max_size=50,
+            alphabet=st.characters(
+                whitelist_categories=("Lu", "Ll", "Nd"), whitelist_characters="-_"
+            ),
+        ),
+        connection_type=st.sampled_from(
+            [
+                "S3",
+                "IAM",
+                "SPARK_GLUE",
+                "SPARK_EMR",
+                "REDSHIFT",
+                "ATHENA",
+                "WORKFLOWS_MWAA",
+                "WORKFLOWS_SERVERLESS",
+            ]
+        ),
+        region=aws_region_strategy(),
     )
-    @patch("smus_cicd.helpers.connection_creator.boto3")
+    @patch("smus_cicd.helpers.connection_creator.create_client")
     def test_property_7_all_connection_types_remain_functional(
-        self, mock_boto3, region, connection_type, connection_name, environment_id, domain_id
+        self,
+        mock_create_client,
+        region,
+        connection_type,
+        connection_name,
+        environment_id,
+        domain_id,
     ):
         """
         Property 7: All Connection Types Remain Functional
-        
+
         For any connection type that worked before the migration, the connection
         SHALL continue to work after migrating to the public client.
-        
+
         Note: MLFLOW is excluded from this test as it uses a custom client with
         a custom service model, which is tested separately.
-        
+
         Feature: remove-datazone-internal-client, Property 7: All Connection Types Remain Functional
         **Validates: Requirements 9.5**
         """
-        # Set up mock boto3 client
+        # Set up mock client
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
-        
+        mock_create_client.return_value = mock_client
+
         # Mock create_connection response
         connection_id = f"conn-{connection_type.lower()}-123"
-        mock_client.create_connection.return_value = {
-            "connectionId": connection_id
-        }
-        
+        mock_client.create_connection.return_value = {"connectionId": connection_id}
+
         # Mock get_connection response for status check
         mock_client.get_connection.return_value = {
             "connectionId": connection_id,
-            "status": "AVAILABLE"
+            "status": "AVAILABLE",
         }
-        
+
         # Create ConnectionCreator instance
         creator = ConnectionCreator(domain_id=domain_id, region=region)
-        
+
         # Prepare connection-specific kwargs
         kwargs = {}
         if connection_type == "S3":
@@ -555,7 +663,9 @@ class TestConnectionCreatorProperties(unittest.TestCase):
             kwargs["worker_type"] = "G.1X"
             kwargs["num_workers"] = 3
         elif connection_type == "SPARK_EMR":
-            kwargs["compute_arn"] = "arn:aws:emr:us-east-1:123456789012:cluster/j-ABC123"
+            kwargs["compute_arn"] = (
+                "arn:aws:emr:us-east-1:123456789012:cluster/j-ABC123"
+            )
             kwargs["runtime_role"] = "arn:aws:iam::123456789012:role/EMRRole"
         elif connection_type == "REDSHIFT":
             kwargs["cluster_name"] = "test-cluster"
@@ -567,31 +677,31 @@ class TestConnectionCreatorProperties(unittest.TestCase):
         elif connection_type == "WORKFLOWS_MWAA":
             kwargs["mwaa_environment_name"] = "test-mwaa-env"
         # WORKFLOWS_SERVERLESS and IAM need no additional kwargs
-        
+
         # Create connection
         result_connection_id = creator.create_connection(
             environment_id=environment_id,
             name=connection_name,
             connection_type=connection_type,
-            **kwargs
+            **kwargs,
         )
-        
+
         # Verify the connection was created successfully
         self.assertEqual(result_connection_id, connection_id)
-        
+
         # Verify create_connection was called
         mock_client.create_connection.assert_called_once()
         call_args = mock_client.create_connection.call_args
-        
+
         # Verify domain and environment identifiers
         self.assertEqual(call_args.kwargs["domainIdentifier"], domain_id)
         self.assertEqual(call_args.kwargs["environmentIdentifier"], environment_id)
         self.assertEqual(call_args.kwargs["name"], connection_name)
-        
+
         # Verify connection properties are present
         self.assertIn("props", call_args.kwargs)
         props = call_args.kwargs["props"]
-        
+
         # Verify connection-type-specific properties
         if connection_type == "S3":
             self.assertIn("s3Properties", props)
@@ -609,58 +719,89 @@ class TestConnectionCreatorProperties(unittest.TestCase):
             self.assertIn("workflowsMwaaProperties", props)
         elif connection_type == "WORKFLOWS_SERVERLESS":
             self.assertIn("workflowsServerlessProperties", props)
-        
+
         # Verify that the connection uses the public client (not internal client)
-        mock_boto3.client.assert_any_call("datazone", region_name=region)
+        mock_create_client.assert_any_call("datazone", region=region)
 
     @settings(max_examples=100)
     @given(
         endpoint_url=endpoint_url_strategy(),
         region=aws_region_strategy(),
-        domain_id=st.text(min_size=1, max_size=50, alphabet=st.characters(whitelist_categories=("Ll", "Nd"), whitelist_characters="-")),
-        environment_id=st.text(min_size=1, max_size=50, alphabet=st.characters(whitelist_categories=("Ll", "Nd"), whitelist_characters="-")),
-        connection_name=st.text(min_size=1, max_size=50, alphabet=st.characters(whitelist_categories=("Lu", "Ll", "Nd"), whitelist_characters="-_")),
-        connection_type=st.sampled_from([
-            "S3", "IAM", "SPARK_GLUE", "REDSHIFT", "ATHENA", "WORKFLOWS_MWAA", "WORKFLOWS_SERVERLESS"
-        ])
+        domain_id=st.text(
+            min_size=1,
+            max_size=50,
+            alphabet=st.characters(
+                whitelist_categories=("Ll", "Nd"), whitelist_characters="-"
+            ),
+        ),
+        environment_id=st.text(
+            min_size=1,
+            max_size=50,
+            alphabet=st.characters(
+                whitelist_categories=("Ll", "Nd"), whitelist_characters="-"
+            ),
+        ),
+        connection_name=st.text(
+            min_size=1,
+            max_size=50,
+            alphabet=st.characters(
+                whitelist_categories=("Lu", "Ll", "Nd"), whitelist_characters="-_"
+            ),
+        ),
+        connection_type=st.sampled_from(
+            [
+                "S3",
+                "IAM",
+                "SPARK_GLUE",
+                "REDSHIFT",
+                "ATHENA",
+                "WORKFLOWS_MWAA",
+                "WORKFLOWS_SERVERLESS",
+            ]
+        ),
     )
     @patch.dict(os.environ, {}, clear=True)
-    @patch("smus_cicd.helpers.connection_creator.boto3")
+    @patch("smus_cicd.helpers.connection_creator.create_client")
     def test_property_9_endpoint_url_override_consistency(
-        self, mock_boto3, connection_type, connection_name, environment_id, domain_id, region, endpoint_url
+        self,
+        mock_create_client,
+        connection_type,
+        connection_name,
+        environment_id,
+        domain_id,
+        region,
+        endpoint_url,
     ):
         """
         Property 9: Endpoint URL Override Consistency
-        
+
         For any DataZone operation that previously supported endpoint URL override
         with the internal client, the same override mechanism SHALL work with the
         public client.
-        
+
         Feature: remove-datazone-internal-client, Property 9: Endpoint URL Override Consistency
         **Validates: Requirements 13.2, 13.3**
         """
-        # Set up mock boto3 client
+        # Set up mock client
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
-        
+        mock_create_client.return_value = mock_client
+
         # Mock create_connection response
         connection_id = f"conn-{connection_type.lower()}-override-123"
-        mock_client.create_connection.return_value = {
-            "connectionId": connection_id
-        }
-        
+        mock_client.create_connection.return_value = {"connectionId": connection_id}
+
         # Mock get_connection response for status check
         mock_client.get_connection.return_value = {
             "connectionId": connection_id,
-            "status": "AVAILABLE"
+            "status": "AVAILABLE",
         }
-        
+
         # Set the DATAZONE_ENDPOINT_URL environment variable
         os.environ["DATAZONE_ENDPOINT_URL"] = endpoint_url
-        
+
         # Create ConnectionCreator instance
         creator = ConnectionCreator(domain_id=domain_id, region=region)
-        
+
         # Prepare connection-specific kwargs
         kwargs = {}
         if connection_type == "S3":
@@ -679,28 +820,28 @@ class TestConnectionCreatorProperties(unittest.TestCase):
         elif connection_type == "WORKFLOWS_MWAA":
             kwargs["mwaa_environment_name"] = "test-mwaa-env"
         # WORKFLOWS_SERVERLESS and IAM need no additional kwargs
-        
+
         # Create connection
         result_connection_id = creator.create_connection(
             environment_id=environment_id,
             name=connection_name,
             connection_type=connection_type,
-            **kwargs
+            **kwargs,
         )
-        
+
         # Verify the connection was created successfully
         self.assertEqual(result_connection_id, connection_id)
-        
-        # Verify that boto3.client was called with the endpoint URL
+
+        # Verify that create_client was called with the endpoint URL
         # The ConnectionCreator creates the client in __init__, so check that call
-        mock_boto3.client.assert_any_call("datazone", region_name=region)
-        
+        mock_create_client.assert_any_call("datazone", region=region)
+
         # Verify create_connection was called
         mock_client.create_connection.assert_called_once()
-        
+
         # Verify the endpoint override mechanism works consistently
         # The key property is that the client is created with the endpoint URL
         # when DATAZONE_ENDPOINT_URL is set, just like it worked with internal client
-        
+
         # Clean up
         del os.environ["DATAZONE_ENDPOINT_URL"]

--- a/tests/unit/helpers/test_event_emitter.py
+++ b/tests/unit/helpers/test_event_emitter.py
@@ -3,8 +3,6 @@
 import json
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from smus_cicd.helpers.event_emitter import EventEmitter
 
 
@@ -13,7 +11,9 @@ class TestEventEmitter:
 
     def test_init_enabled(self):
         """Test EventEmitter initialization when enabled."""
-        emitter = EventEmitter(enabled=True, event_bus_name="test-bus", region="us-east-1")
+        emitter = EventEmitter(
+            enabled=True, event_bus_name="test-bus", region="us-east-1"
+        )
         assert emitter.enabled is True
         assert emitter.event_bus_name == "test-bus"
         assert emitter.region == "us-east-1"
@@ -23,22 +23,22 @@ class TestEventEmitter:
         emitter = EventEmitter(enabled=False)
         assert emitter.enabled is False
 
-    @patch("smus_cicd.helpers.eventbridge_client.boto3.client")
-    def test_lazy_client_loading(self, mock_boto_client):
+    @patch("smus_cicd.helpers.eventbridge_client.create_client")
+    def test_lazy_client_loading(self, mock_create_client):
         """Test that boto3 client is lazy-loaded."""
         emitter = EventEmitter(enabled=True, region="us-east-1")
         assert emitter._client is None
-        
+
         # Access client property
         _ = emitter.client
-        mock_boto_client.assert_called_once_with("events", region_name="us-east-1")
+        mock_create_client.assert_called_once_with("events", region="us-east-1")
 
-    @patch("smus_cicd.helpers.eventbridge_client.boto3.client")
-    def test_emit_success(self, mock_boto_client):
+    @patch("smus_cicd.helpers.eventbridge_client.create_client")
+    def test_emit_success(self, mock_create_client):
         """Test successful event emission."""
         mock_client = MagicMock()
         mock_client.put_events.return_value = {"FailedEntryCount": 0}
-        mock_boto_client.return_value = mock_client
+        mock_create_client.return_value = mock_client
 
         emitter = EventEmitter(enabled=True, region="us-east-1")
         result = emitter.emit("TestEvent", {"key": "value"})
@@ -49,12 +49,12 @@ class TestEventEmitter:
         assert call_args["Entries"][0]["Source"] == "com.amazon.smus.cicd"
         assert call_args["Entries"][0]["DetailType"] == "TestEvent"
 
-    @patch("smus_cicd.helpers.eventbridge_client.boto3.client")
-    def test_emit_failure(self, mock_boto_client):
+    @patch("smus_cicd.helpers.eventbridge_client.create_client")
+    def test_emit_failure(self, mock_create_client):
         """Test failed event emission."""
         mock_client = MagicMock()
         mock_client.put_events.return_value = {"FailedEntryCount": 1}
-        mock_boto_client.return_value = mock_client
+        mock_create_client.return_value = mock_client
 
         emitter = EventEmitter(enabled=True, region="us-east-1")
         result = emitter.emit("TestEvent", {"key": "value"})
@@ -67,19 +67,19 @@ class TestEventEmitter:
         result = emitter.emit("TestEvent", {"key": "value"})
         assert result is True
 
-    @patch("smus_cicd.helpers.eventbridge_client.boto3.client")
-    def test_deploy_started(self, mock_boto_client):
+    @patch("smus_cicd.helpers.eventbridge_client.create_client")
+    def test_deploy_started(self, mock_create_client):
         """Test deploy started event."""
         mock_client = MagicMock()
         mock_client.put_events.return_value = {"FailedEntryCount": 0}
-        mock_boto_client.return_value = mock_client
+        mock_create_client.return_value = mock_client
 
         emitter = EventEmitter(enabled=True, region="us-east-1")
         target = {"name": "test", "stage": "TEST"}
         bundle_info = {"path": "/tmp/bundle.zip"}
-        
+
         result = emitter.deploy_started("TestPipeline", target, bundle_info)
-        
+
         assert result is True
         call_args = mock_client.put_events.call_args[1]
         detail = json.loads(call_args["Entries"][0]["Detail"])
@@ -87,38 +87,38 @@ class TestEventEmitter:
         assert detail["stage"] == "deploy"
         assert detail["status"] == "started"
 
-    @patch("smus_cicd.helpers.eventbridge_client.boto3.client")
-    def test_deploy_failed(self, mock_boto_client):
+    @patch("smus_cicd.helpers.eventbridge_client.create_client")
+    def test_deploy_failed(self, mock_create_client):
         """Test deploy failed event."""
         mock_client = MagicMock()
         mock_client.put_events.return_value = {"FailedEntryCount": 0}
-        mock_boto_client.return_value = mock_client
+        mock_create_client.return_value = mock_client
 
         emitter = EventEmitter(enabled=True, region="us-east-1")
         target = {"name": "test", "stage": "TEST"}
         error = {"code": "TEST_ERROR", "message": "Test error"}
-        
+
         result = emitter.deploy_failed("TestPipeline", target, error)
-        
+
         assert result is True
         call_args = mock_client.put_events.call_args[1]
         detail = json.loads(call_args["Entries"][0]["Detail"])
         assert detail["status"] == "failed"
         assert detail["error"]["code"] == "TEST_ERROR"
 
-    @patch("smus_cicd.helpers.eventbridge_client.boto3.client")
-    def test_workflow_creation_completed(self, mock_boto_client):
+    @patch("smus_cicd.helpers.eventbridge_client.create_client")
+    def test_workflow_creation_completed(self, mock_create_client):
         """Test workflow creation completed event."""
         mock_client = MagicMock()
         mock_client.put_events.return_value = {"FailedEntryCount": 0}
-        mock_boto_client.return_value = mock_client
+        mock_create_client.return_value = mock_client
 
         emitter = EventEmitter(enabled=True, region="us-east-1")
         target = {"name": "test", "stage": "TEST"}
         workflows = [{"workflowName": "test_wf", "status": "created"}]
-        
+
         result = emitter.workflow_creation_completed("TestPipeline", target, workflows)
-        
+
         assert result is True
         call_args = mock_client.put_events.call_args[1]
         detail = json.loads(call_args["Entries"][0]["Detail"])

--- a/tests/unit/test_create.py
+++ b/tests/unit/test_create.py
@@ -1,11 +1,12 @@
 """Unit tests for create command."""
 
 import os
-import tempfile
-import pytest
 import re
-from unittest.mock import patch, MagicMock
+import tempfile
+from unittest.mock import MagicMock, patch
+
 from typer.testing import CliRunner
+
 from smus_cicd.cli import app
 
 
@@ -71,7 +72,8 @@ class TestCreateCommand:
             output_file = "custom-stages.yaml"
 
             result = runner.invoke(
-                app, ["create", "--output", output_file, "--targets", "dev,staging,prod"]
+                app,
+                ["create", "--output", output_file, "--targets", "dev,staging,prod"],
             )
 
             assert result.exit_code == 0
@@ -105,12 +107,12 @@ class TestCreateCommand:
                 content = f.read()
                 assert "region: ${DEV_DOMAIN_REGION:us-west-2}" in content
 
-    @patch("smus_cicd.commands.create.boto3.client")
-    def test_create_with_aws_resources(self, mock_boto3_client):
+    @patch("smus_cicd.commands.create.create_client")
+    def test_create_with_aws_resources(self, mock_create_client):
         """Test creating manifest with AWS domain and project validation."""
         # Mock DataZone client responses
         mock_client = MagicMock()
-        mock_boto3_client.return_value = mock_client
+        mock_create_client.return_value = mock_client
 
         mock_client.get_domain.return_value = {"name": "test-domain"}
         mock_client.get_project.return_value = {"name": "dev-test-project"}
@@ -154,12 +156,12 @@ class TestCreateCommand:
                     "name: dev-test-project-prod" in content
                 )  # synthesized prod project
 
-    @patch("smus_cicd.commands.create.boto3.client")
-    def test_create_with_domain_and_project_no_warnings(self, mock_boto3_client):
+    @patch("smus_cicd.commands.create.create_client")
+    def test_create_with_domain_and_project_no_warnings(self, mock_create_client):
         """Test creating manifest with domain and project IDs produces no warnings."""
         # Mock DataZone client
         mock_client = MagicMock()
-        mock_boto3_client.return_value = mock_client
+        mock_create_client.return_value = mock_client
 
         # Mock domain response
         mock_client.get_domain.return_value = {
@@ -212,21 +214,25 @@ class TestCreateCommand:
                     stripped = line.strip()
                     if stripped == "stages:":
                         in_targets = True
-                    elif not line.startswith(" ") and stripped and stripped != "---":  # New top-level key
+                    elif (
+                        not line.startswith(" ") and stripped and stripped != "---"
+                    ):  # New top-level key
                         in_targets = False
-                    if not in_targets and stripped == "domain:":  # Only check outside targets section
+                    if (
+                        not in_targets and stripped == "domain:"
+                    ):  # Only check outside targets section
                         assert False, "Found top-level domain configuration"
                 # Check domain configuration exists under each target
                 for stage in ["dev", "test", "prod"]:
                     assert f"{stage}:" in content
                     assert f"  {stage}:\n    domain:" in content  # Domain under target
 
-    @patch("smus_cicd.commands.create.boto3.client")
-    def test_create_with_aws_domain_error(self, mock_boto3_client):
+    @patch("smus_cicd.commands.create.create_client")
+    def test_create_with_aws_domain_error(self, mock_create_client):
         """Test creating manifest with invalid AWS domain."""
         # Mock DataZone client to raise error
         mock_client = MagicMock()
-        mock_boto3_client.return_value = mock_client
+        mock_create_client.return_value = mock_client
 
         from botocore.exceptions import ClientError
 
@@ -264,12 +270,12 @@ class TestCreateCommand:
             assert "AWS Error:" in error_output or "Domain not found" in error_output
             assert os.path.exists(output_file)  # File is still created
 
-    @patch("smus_cicd.commands.create.boto3.client")
-    def test_create_with_aws_project_error(self, mock_boto3_client):
+    @patch("smus_cicd.commands.create.create_client")
+    def test_create_with_aws_project_error(self, mock_create_client):
         """Test creating manifest with invalid AWS project."""
         # Mock DataZone client responses
         mock_client = MagicMock()
-        mock_boto3_client.return_value = mock_client
+        mock_create_client.return_value = mock_client
 
         mock_client.get_domain.return_value = {"name": "test-domain"}
 

--- a/tests/unit/test_eventbridge_client.py
+++ b/tests/unit/test_eventbridge_client.py
@@ -16,25 +16,25 @@ class TestEventBridgeEmitter(unittest.TestCase):
             enabled=True, event_bus_name="test-bus", region="us-east-1"
         )
 
-    @patch("smus_cicd.helpers.eventbridge_client.boto3.client")
-    def test_client_lazy_load(self, mock_boto_client):
+    @patch("smus_cicd.helpers.eventbridge_client.create_client")
+    def test_client_lazy_load(self, mock_create_client):
         """Test EventBridge client is lazy-loaded."""
         emitter = EventBridgeEmitter(enabled=True)
         self.assertIsNone(emitter._client)
         _ = emitter.client
-        mock_boto_client.assert_called_once_with("events", region_name=None)
+        mock_create_client.assert_called_once_with("events", region=None)
 
     def test_client_not_created_when_disabled(self):
         """Test client is not created when disabled."""
         emitter = EventBridgeEmitter(enabled=False)
         self.assertIsNone(emitter.client)
 
-    @patch("smus_cicd.helpers.eventbridge_client.boto3.client")
-    def test_emit_event_success(self, mock_boto_client):
+    @patch("smus_cicd.helpers.eventbridge_client.create_client")
+    def test_emit_event_success(self, mock_create_client):
         """Test successful event emission."""
         mock_events = MagicMock()
         mock_events.put_events.return_value = {"FailedEntryCount": 0}
-        mock_boto_client.return_value = mock_events
+        mock_create_client.return_value = mock_events
 
         result = self.emitter.emit_event(
             source="test.source",
@@ -51,12 +51,12 @@ class TestEventBridgeEmitter(unittest.TestCase):
         self.assertEqual(json.loads(entry["Detail"]), {"key": "value"})
         self.assertEqual(entry["EventBusName"], "test-bus")
 
-    @patch("smus_cicd.helpers.eventbridge_client.boto3.client")
-    def test_emit_event_with_resources(self, mock_boto_client):
+    @patch("smus_cicd.helpers.eventbridge_client.create_client")
+    def test_emit_event_with_resources(self, mock_create_client):
         """Test event emission with resources."""
         mock_events = MagicMock()
         mock_events.put_events.return_value = {"FailedEntryCount": 0}
-        mock_boto_client.return_value = mock_events
+        mock_create_client.return_value = mock_events
 
         resources = ["arn:aws:s3:::bucket"]
         result = self.emitter.emit_event(
@@ -71,12 +71,12 @@ class TestEventBridgeEmitter(unittest.TestCase):
         entry = call_args["Entries"][0]
         self.assertEqual(entry["Resources"], resources)
 
-    @patch("smus_cicd.helpers.eventbridge_client.boto3.client")
-    def test_emit_event_failure(self, mock_boto_client):
+    @patch("smus_cicd.helpers.eventbridge_client.create_client")
+    def test_emit_event_failure(self, mock_create_client):
         """Test event emission failure."""
         mock_events = MagicMock()
         mock_events.put_events.return_value = {"FailedEntryCount": 1}
-        mock_boto_client.return_value = mock_events
+        mock_create_client.return_value = mock_events
 
         result = self.emitter.emit_event(
             source="test.source",
@@ -86,12 +86,12 @@ class TestEventBridgeEmitter(unittest.TestCase):
 
         self.assertFalse(result)
 
-    @patch("smus_cicd.helpers.eventbridge_client.boto3.client")
-    def test_emit_event_exception(self, mock_boto_client):
+    @patch("smus_cicd.helpers.eventbridge_client.create_client")
+    def test_emit_event_exception(self, mock_create_client):
         """Test event emission with exception."""
         mock_events = MagicMock()
         mock_events.put_events.side_effect = Exception("API error")
-        mock_boto_client.return_value = mock_events
+        mock_create_client.return_value = mock_events
 
         result = self.emitter.emit_event(
             source="test.source",

--- a/tests/unit/test_quicksight_helper.py
+++ b/tests/unit/test_quicksight_helper.py
@@ -16,69 +16,69 @@ from smus_cicd.helpers.quicksight import (
 class TestQuickSightHelper(unittest.TestCase):
     """Test QuickSight helper functions."""
 
-    @patch("smus_cicd.helpers.quicksight.boto3.client")
-    def test_export_dashboard_success(self, mock_boto_client):
+    @patch("smus_cicd.helpers.quicksight.create_client")
+    def test_export_dashboard_success(self, mock_create_client):
         """Test successful dashboard export."""
         mock_qs = MagicMock()
         mock_qs.start_asset_bundle_export_job.return_value = {
             "AssetBundleExportJobId": "export-123"
         }
-        mock_boto_client.return_value = mock_qs
+        mock_create_client.return_value = mock_qs
 
         job_id = export_dashboard("dash-1", "123456789012", "us-east-1")
 
         self.assertEqual(job_id, "export-123")
         mock_qs.start_asset_bundle_export_job.assert_called_once()
 
-    @patch("smus_cicd.helpers.quicksight.boto3.client")
-    def test_export_dashboard_failure(self, mock_boto_client):
+    @patch("smus_cicd.helpers.quicksight.create_client")
+    def test_export_dashboard_failure(self, mock_create_client):
         """Test dashboard export failure."""
         mock_qs = MagicMock()
         mock_qs.start_asset_bundle_export_job.side_effect = Exception("API error")
-        mock_boto_client.return_value = mock_qs
+        mock_create_client.return_value = mock_qs
 
         with self.assertRaises(QuickSightDeploymentError):
             export_dashboard("dash-1", "123456789012", "us-east-1")
 
-    @patch("smus_cicd.helpers.quicksight.boto3.client")
+    @patch("smus_cicd.helpers.quicksight.create_client")
     @patch("smus_cicd.helpers.quicksight.time.sleep")
-    def test_poll_export_job_success(self, mock_sleep, mock_boto_client):
+    def test_poll_export_job_success(self, mock_sleep, mock_create_client):
         """Test successful export job polling."""
         mock_qs = MagicMock()
         mock_qs.describe_asset_bundle_export_job.return_value = {
             "JobStatus": "SUCCESSFUL",
             "DownloadUrl": "https://example.com/bundle.zip",
         }
-        mock_boto_client.return_value = mock_qs
+        mock_create_client.return_value = mock_qs
 
         url = poll_export_job("export-123", "123456789012", "us-east-1")
 
         self.assertEqual(url, "https://example.com/bundle.zip")
 
-    @patch("smus_cicd.helpers.quicksight.boto3.client")
+    @patch("smus_cicd.helpers.quicksight.create_client")
     @patch("smus_cicd.helpers.quicksight.time.sleep")
-    def test_poll_export_job_failure(self, mock_sleep, mock_boto_client):
+    def test_poll_export_job_failure(self, mock_sleep, mock_create_client):
         """Test export job polling with failure."""
         mock_qs = MagicMock()
         mock_qs.describe_asset_bundle_export_job.return_value = {
             "JobStatus": "FAILED",
             "Errors": ["Export error"],
         }
-        mock_boto_client.return_value = mock_qs
+        mock_create_client.return_value = mock_qs
 
         with self.assertRaises(QuickSightDeploymentError):
             poll_export_job("export-123", "123456789012", "us-east-1")
 
-    @patch("smus_cicd.helpers.quicksight.boto3.client")
+    @patch("smus_cicd.helpers.quicksight.create_client")
     @patch("smus_cicd.helpers.quicksight._download_bundle")
-    def test_import_dashboard_success(self, mock_download, mock_boto_client):
+    def test_import_dashboard_success(self, mock_download, mock_create_client):
         """Test successful dashboard import."""
         mock_download.return_value = b"bundle-content"
         mock_qs = MagicMock()
         mock_qs.start_asset_bundle_import_job.return_value = {
             "AssetBundleImportJobId": "import-456"
         }
-        mock_boto_client.return_value = mock_qs
+        mock_create_client.return_value = mock_qs
 
         job_id = import_dashboard(
             "https://example.com/bundle.zip", "123456789012", "us-east-1"
@@ -87,26 +87,26 @@ class TestQuickSightHelper(unittest.TestCase):
         self.assertEqual(job_id, "import-456")
         mock_qs.start_asset_bundle_import_job.assert_called_once()
 
-    @patch("smus_cicd.helpers.quicksight.boto3.client")
+    @patch("smus_cicd.helpers.quicksight.create_client")
     @patch("smus_cicd.helpers.quicksight.time.sleep")
-    def test_poll_import_job_success(self, mock_sleep, mock_boto_client):
+    def test_poll_import_job_success(self, mock_sleep, mock_create_client):
         """Test successful import job polling."""
         mock_qs = MagicMock()
         mock_qs.describe_asset_bundle_import_job.return_value = {
             "JobStatus": "SUCCESSFUL",
             "AssetBundleImportJobId": "import-456",
         }
-        mock_boto_client.return_value = mock_qs
+        mock_create_client.return_value = mock_qs
 
         result = poll_import_job("import-456", "123456789012", "us-east-1")
 
         self.assertEqual(result["JobStatus"], "SUCCESSFUL")
 
-    @patch("smus_cicd.helpers.quicksight.boto3.client")
-    def test_grant_permissions_success(self, mock_boto_client):
+    @patch("smus_cicd.helpers.quicksight.create_client")
+    def test_grant_permissions_success(self, mock_create_client):
         """Test successful permission grant."""
         mock_qs = MagicMock()
-        mock_boto_client.return_value = mock_qs
+        mock_create_client.return_value = mock_qs
 
         permissions = [{"principal": "user1", "actions": ["READ"]}]
         result = grant_dashboard_permissions(
@@ -116,12 +116,10 @@ class TestQuickSightHelper(unittest.TestCase):
         self.assertTrue(result)
         mock_qs.update_dashboard_permissions.assert_called_once()
 
-    @patch("smus_cicd.helpers.quicksight.boto3.client")
-    def test_grant_permissions_empty(self, mock_boto_client):
+    @patch("smus_cicd.helpers.quicksight.create_client")
+    def test_grant_permissions_empty(self, mock_create_client):
         """Test permission grant with empty list."""
-        result = grant_dashboard_permissions(
-            "dash-1", "123456789012", "us-east-1", []
-        )
+        result = grant_dashboard_permissions("dash-1", "123456789012", "us-east-1", [])
 
         self.assertTrue(result)
 
@@ -136,9 +134,13 @@ class TestResolveResourcePrefix(unittest.TestCase):
     def test_replaces_stage_name(self):
         from smus_cicd.helpers.quicksight import resolve_resource_prefix
 
-        qs = {"overrideParameters": {"ResourceIdOverrideConfiguration": {
-            "PrefixForAllResources": "deployed-{stage.name}-covid-"
-        }}}
+        qs = {
+            "overrideParameters": {
+                "ResourceIdOverrideConfiguration": {
+                    "PrefixForAllResources": "deployed-{stage.name}-covid-"
+                }
+            }
+        }
         assert resolve_resource_prefix("dev", qs) == "deployed-dev-covid-"
 
     def test_empty_config(self):
@@ -149,9 +151,11 @@ class TestResolveResourcePrefix(unittest.TestCase):
     def test_no_variable(self):
         from smus_cicd.helpers.quicksight import resolve_resource_prefix
 
-        qs = {"overrideParameters": {"ResourceIdOverrideConfiguration": {
-            "PrefixForAllResources": "static-"
-        }}}
+        qs = {
+            "overrideParameters": {
+                "ResourceIdOverrideConfiguration": {"PrefixForAllResources": "static-"}
+            }
+        }
         assert resolve_resource_prefix("dev", qs) == "static-"
 
 
@@ -161,10 +165,12 @@ class TestResolveResourceIdsFromOverrides(unittest.TestCase):
     def test_dashboards_only(self):
         from smus_cicd.helpers.quicksight import resolve_resource_ids_from_overrides
 
-        qs = {"overrideParameters": {
-            "ResourceIdOverrideConfiguration": {"PrefixForAllResources": "pfx-"},
-            "Dashboards": [{"DashboardId": "d1", "Name": "Dash1"}],
-        }}
+        qs = {
+            "overrideParameters": {
+                "ResourceIdOverrideConfiguration": {"PrefixForAllResources": "pfx-"},
+                "Dashboards": [{"DashboardId": "d1", "Name": "Dash1"}],
+            }
+        }
         result = resolve_resource_ids_from_overrides("dev", qs)
         assert "dashboards" in result
         assert result["dashboards"][0]["id"] == "pfx-d1"
@@ -175,12 +181,14 @@ class TestResolveResourceIdsFromOverrides(unittest.TestCase):
     def test_all_three_types(self):
         from smus_cicd.helpers.quicksight import resolve_resource_ids_from_overrides
 
-        qs = {"overrideParameters": {
-            "ResourceIdOverrideConfiguration": {"PrefixForAllResources": "p-"},
-            "Dashboards": [{"DashboardId": "d1", "Name": "D"}],
-            "DataSets": [{"DataSetId": "ds1", "Name": "DS"}],
-            "DataSources": [{"DataSourceId": "src1", "Name": "S"}],
-        }}
+        qs = {
+            "overrideParameters": {
+                "ResourceIdOverrideConfiguration": {"PrefixForAllResources": "p-"},
+                "Dashboards": [{"DashboardId": "d1", "Name": "D"}],
+                "DataSets": [{"DataSetId": "ds1", "Name": "DS"}],
+                "DataSources": [{"DataSourceId": "src1", "Name": "S"}],
+            }
+        }
         result = resolve_resource_ids_from_overrides("test", qs)
         assert result["dashboards"][0]["id"] == "p-d1"
         assert result["datasets"][0]["id"] == "p-ds1"
@@ -189,29 +197,37 @@ class TestResolveResourceIdsFromOverrides(unittest.TestCase):
     def test_stage_name_resolved_in_ids(self):
         from smus_cicd.helpers.quicksight import resolve_resource_ids_from_overrides
 
-        qs = {"overrideParameters": {
-            "ResourceIdOverrideConfiguration": {"PrefixForAllResources": "pfx-{stage.name}-"},
-            "Dashboards": [{"DashboardId": "dash-{stage.name}", "Name": "D"}],
-        }}
+        qs = {
+            "overrideParameters": {
+                "ResourceIdOverrideConfiguration": {
+                    "PrefixForAllResources": "pfx-{stage.name}-"
+                },
+                "Dashboards": [{"DashboardId": "dash-{stage.name}", "Name": "D"}],
+            }
+        }
         result = resolve_resource_ids_from_overrides("prod", qs)
         assert result["dashboards"][0]["id"] == "pfx-prod-dash-prod"
 
     def test_no_overrides_returns_empty(self):
         from smus_cicd.helpers.quicksight import resolve_resource_ids_from_overrides
 
-        qs = {"overrideParameters": {
-            "ResourceIdOverrideConfiguration": {"PrefixForAllResources": "pfx-"},
-        }}
+        qs = {
+            "overrideParameters": {
+                "ResourceIdOverrideConfiguration": {"PrefixForAllResources": "pfx-"},
+            }
+        }
         result = resolve_resource_ids_from_overrides("dev", qs)
         assert result == {}
 
     def test_empty_id_skipped(self):
         from smus_cicd.helpers.quicksight import resolve_resource_ids_from_overrides
 
-        qs = {"overrideParameters": {
-            "ResourceIdOverrideConfiguration": {"PrefixForAllResources": "pfx-"},
-            "Dashboards": [{"DashboardId": "", "Name": "Empty"}],
-        }}
+        qs = {
+            "overrideParameters": {
+                "ResourceIdOverrideConfiguration": {"PrefixForAllResources": "pfx-"},
+                "Dashboards": [{"DashboardId": "", "Name": "Empty"}],
+            }
+        }
         result = resolve_resource_ids_from_overrides("dev", qs)
         assert result["dashboards"] == []
 

--- a/tests/unit/test_quicksight_permissions.py
+++ b/tests/unit/test_quicksight_permissions.py
@@ -1,7 +1,7 @@
 """Unit tests for QuickSight permissions handling during import."""
 
 import unittest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 from smus_cicd.helpers.quicksight import import_dashboard
 
@@ -9,15 +9,15 @@ from smus_cicd.helpers.quicksight import import_dashboard
 class TestQuickSightPermissionsImport(unittest.TestCase):
     """Test QuickSight permissions are correctly passed during import."""
 
-    @patch("smus_cicd.helpers.quicksight.boto3.client")
+    @patch("smus_cicd.helpers.quicksight.create_client")
     @patch("smus_cicd.helpers.quicksight._download_bundle")
-    def test_import_with_no_permissions(self, mock_download, mock_boto_client):
+    def test_import_with_no_permissions(self, mock_download, mock_create_client):
         """Test import with no permissions uses empty dict."""
         mock_qs = MagicMock()
         mock_qs.start_asset_bundle_import_job.return_value = {
             "AssetBundleImportJobId": "test-job-123"
         }
-        mock_boto_client.return_value = mock_qs
+        mock_create_client.return_value = mock_qs
         mock_download.return_value = b"bundle_data"
 
         job_id = import_dashboard(
@@ -28,22 +28,22 @@ class TestQuickSightPermissionsImport(unittest.TestCase):
         )
 
         self.assertEqual(job_id, "test-job-123")
-        
+
         # Verify OverridePermissions.Dashboards has empty Permissions
         call_args = mock_qs.start_asset_bundle_import_job.call_args
         override_perms = call_args[1]["OverridePermissions"]
         dashboard_perms = override_perms["Dashboards"][0]["Permissions"]
         self.assertEqual(dashboard_perms, {})
 
-    @patch("smus_cicd.helpers.quicksight.boto3.client")
+    @patch("smus_cicd.helpers.quicksight.create_client")
     @patch("smus_cicd.helpers.quicksight._download_bundle")
-    def test_import_with_single_owner(self, mock_download, mock_boto_client):
+    def test_import_with_single_owner(self, mock_download, mock_create_client):
         """Test import with single owner permission."""
         mock_qs = MagicMock()
         mock_qs.start_asset_bundle_import_job.return_value = {
             "AssetBundleImportJobId": "test-job-123"
         }
-        mock_boto_client.return_value = mock_qs
+        mock_create_client.return_value = mock_qs
         mock_download.return_value = b"bundle_data"
 
         permissions = [
@@ -64,12 +64,12 @@ class TestQuickSightPermissionsImport(unittest.TestCase):
         )
 
         self.assertEqual(job_id, "test-job-123")
-        
+
         # Verify OverridePermissions.Dashboards has correct structure
         call_args = mock_qs.start_asset_bundle_import_job.call_args
         override_perms = call_args[1]["OverridePermissions"]
         dashboard_perms = override_perms["Dashboards"][0]["Permissions"]
-        
+
         self.assertIn("Principals", dashboard_perms)
         self.assertIn("Actions", dashboard_perms)
         self.assertEqual(len(dashboard_perms["Principals"]), 1)
@@ -81,15 +81,15 @@ class TestQuickSightPermissionsImport(unittest.TestCase):
         self.assertIn("quicksight:DescribeDashboard", dashboard_perms["Actions"])
         self.assertIn("quicksight:UpdateDashboard", dashboard_perms["Actions"])
 
-    @patch("smus_cicd.helpers.quicksight.boto3.client")
+    @patch("smus_cicd.helpers.quicksight.create_client")
     @patch("smus_cicd.helpers.quicksight._download_bundle")
-    def test_import_with_multiple_principals(self, mock_download, mock_boto_client):
+    def test_import_with_multiple_principals(self, mock_download, mock_create_client):
         """Test import with multiple principals (owners and viewers)."""
         mock_qs = MagicMock()
         mock_qs.start_asset_bundle_import_job.return_value = {
             "AssetBundleImportJobId": "test-job-123"
         }
-        mock_boto_client.return_value = mock_qs
+        mock_create_client.return_value = mock_qs
         mock_download.return_value = b"bundle_data"
 
         permissions = [
@@ -118,12 +118,12 @@ class TestQuickSightPermissionsImport(unittest.TestCase):
         )
 
         self.assertEqual(job_id, "test-job-123")
-        
+
         # Verify OverridePermissions.Dashboards has correct structure
         call_args = mock_qs.start_asset_bundle_import_job.call_args
         override_perms = call_args[1]["OverridePermissions"]
         dashboard_perms = override_perms["Dashboards"][0]["Permissions"]
-        
+
         self.assertIn("Principals", dashboard_perms)
         self.assertIn("Actions", dashboard_perms)
         self.assertEqual(len(dashboard_perms["Principals"]), 2)
@@ -135,32 +135,38 @@ class TestQuickSightPermissionsImport(unittest.TestCase):
             "arn:aws:quicksight:us-east-1:123:user/default/Viewer/*",
             dashboard_perms["Principals"],
         )
-        
+
         # Actions should be deduplicated
         self.assertIn("quicksight:DescribeDashboard", dashboard_perms["Actions"])
         self.assertIn("quicksight:UpdateDashboard", dashboard_perms["Actions"])
         self.assertIn("quicksight:DeleteDashboard", dashboard_perms["Actions"])
         self.assertIn("quicksight:QueryDashboard", dashboard_perms["Actions"])
 
-    @patch("smus_cicd.helpers.quicksight.boto3.client")
+    @patch("smus_cicd.helpers.quicksight.create_client")
     @patch("smus_cicd.helpers.quicksight._download_bundle")
-    def test_import_with_duplicate_actions(self, mock_download, mock_boto_client):
+    def test_import_with_duplicate_actions(self, mock_download, mock_create_client):
         """Test that duplicate actions are removed."""
         mock_qs = MagicMock()
         mock_qs.start_asset_bundle_import_job.return_value = {
             "AssetBundleImportJobId": "test-job-123"
         }
-        mock_boto_client.return_value = mock_qs
+        mock_create_client.return_value = mock_qs
         mock_download.return_value = b"bundle_data"
 
         permissions = [
             {
                 "principal": "arn:aws:quicksight:us-east-1:123:user/default/User1/*",
-                "actions": ["quicksight:DescribeDashboard", "quicksight:QueryDashboard"],
+                "actions": [
+                    "quicksight:DescribeDashboard",
+                    "quicksight:QueryDashboard",
+                ],
             },
             {
                 "principal": "arn:aws:quicksight:us-east-1:123:user/default/User2/*",
-                "actions": ["quicksight:DescribeDashboard", "quicksight:UpdateDashboard"],
+                "actions": [
+                    "quicksight:DescribeDashboard",
+                    "quicksight:UpdateDashboard",
+                ],
             },
         ]
 
@@ -176,22 +182,24 @@ class TestQuickSightPermissionsImport(unittest.TestCase):
         override_perms = call_args[1]["OverridePermissions"]
         dashboard_perms = override_perms["Dashboards"][0]["Permissions"]
         actions = dashboard_perms["Actions"]
-        
+
         # Should have 3 unique actions
         self.assertEqual(len(actions), 3)
         self.assertIn("quicksight:DescribeDashboard", actions)
         self.assertIn("quicksight:QueryDashboard", actions)
         self.assertIn("quicksight:UpdateDashboard", actions)
 
-    @patch("smus_cicd.helpers.quicksight.boto3.client")
+    @patch("smus_cicd.helpers.quicksight.create_client")
     @patch("smus_cicd.helpers.quicksight._download_bundle")
-    def test_import_with_empty_permissions_list(self, mock_download, mock_boto_client):
+    def test_import_with_empty_permissions_list(
+        self, mock_download, mock_create_client
+    ):
         """Test import with empty permissions list."""
         mock_qs = MagicMock()
         mock_qs.start_asset_bundle_import_job.return_value = {
             "AssetBundleImportJobId": "test-job-123"
         }
-        mock_boto_client.return_value = mock_qs
+        mock_create_client.return_value = mock_qs
         mock_download.return_value = b"bundle_data"
 
         job_id = import_dashboard(
@@ -202,7 +210,7 @@ class TestQuickSightPermissionsImport(unittest.TestCase):
         )
 
         self.assertEqual(job_id, "test-job-123")
-        
+
         # Empty list should result in empty dict
         call_args = mock_qs.start_asset_bundle_import_job.call_args
         override_perms = call_args[1]["OverridePermissions"]

--- a/tests/unit/test_region_config_regression.py
+++ b/tests/unit/test_region_config_regression.py
@@ -1,12 +1,13 @@
 """Regression tests for the specific region configuration bug."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 
 from smus_cicd.helpers.utils import (
     _get_region_from_config,
-    load_config,
     get_datazone_project_info,
+    load_config,
 )
 
 
@@ -69,12 +70,16 @@ class TestRegionConfigurationRegression:
         assert config["region"] == "us-east-1"
         assert config["domain_name"] == "cicd-test-domain"
 
-    @patch("smus_cicd.helpers.utils.boto3")
-    def test_boto3_client_uses_correct_region_not_credentials_region(self, mock_boto3):
+    @patch("smus_cicd.helpers.datazone.create_client")
+    @patch("smus_cicd.helpers.utils.create_client")
+    def test_boto3_client_uses_correct_region_not_credentials_region(
+        self, mock_utils_create_client, mock_dz_create_client
+    ):
         """Test that boto3 clients are created with domain region, not AWS credentials region."""
-        # Mock boto3 client
+        # Mock clients
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
+        mock_utils_create_client.return_value = mock_client
+        mock_dz_create_client.return_value = mock_client
 
         # Simulate GitHub Actions scenario:
         # - AWS credentials configured for us-east-2 (this would be in AWS_DEFAULT_REGION env var)
@@ -103,14 +108,14 @@ class TestRegionConfigurationRegression:
         # Call the function that should create DataZone client
         result = get_datazone_project_info("integration-test-test", config)
 
-        # Verify boto3.client was called with the DOMAIN region (first call is CloudFormation for domain resolution)
-        calls = mock_boto3.client.call_args_list
-        assert len(calls) > 0, "Expected at least one boto3.client call"
+        # Verify create_client was called with the DOMAIN region (first call is CloudFormation for domain resolution)
+        calls = mock_utils_create_client.call_args_list
+        assert len(calls) > 0, "Expected at least one create_client call"
 
         # First call should be CloudFormation with correct region
         first_call_args, first_call_kwargs = calls[0]
         assert first_call_args[0] == "cloudformation"
-        assert first_call_kwargs["region_name"] == datazone_domain_region
+        assert first_call_kwargs["region"] == datazone_domain_region
 
         # Should succeed without region configuration errors
         assert "error" not in result or "Region must be specified" not in str(
@@ -118,12 +123,16 @@ class TestRegionConfigurationRegression:
         )
 
     @patch.dict("os.environ", {"AWS_DEFAULT_REGION": "us-east-2"})
-    @patch("smus_cicd.helpers.utils.boto3")
-    def test_domain_region_overrides_aws_env_region(self, mock_boto3):
+    @patch("smus_cicd.helpers.datazone.create_client")
+    @patch("smus_cicd.helpers.utils.create_client")
+    def test_domain_region_overrides_aws_env_region(
+        self, mock_utils_create_client, mock_dz_create_client
+    ):
         """Test that domain.region takes precedence over AWS_DEFAULT_REGION environment variable."""
-        # Mock boto3 client
+        # Mock clients
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
+        mock_utils_create_client.return_value = mock_client
+        mock_dz_create_client.return_value = mock_client
 
         # Environment has AWS_DEFAULT_REGION=us-east-2 (simulating GitHub Actions)
         # But pipeline manifest domain.region=us-east-1
@@ -143,13 +152,13 @@ class TestRegionConfigurationRegression:
         # Call function
         get_datazone_project_info("test-project", config)
 
-        # Verify ALL boto3 clients use domain region (us-east-1), not env region (us-east-2)
-        calls = mock_boto3.client.call_args_list
+        # Verify ALL create_client calls use domain region (us-east-1), not env region (us-east-2)
+        calls = mock_utils_create_client.call_args_list
         for call in calls:
             args, kwargs = call
             assert (
-                kwargs["region_name"] == "us-east-1"
-            ), f"Service {args[0]} used wrong region: {kwargs['region_name']}"
+                kwargs["region"] == "us-east-1"
+            ), f"Service {args[0]} used wrong region: {kwargs['region']}"
 
     def test_all_commands_config_consistency(self):
         """Test that all commands set up config consistently."""


### PR DESCRIPTION
…and add user agent for tracking

- Replace direct boto3.client() calls with create_client() helper across all dry-run checkers
- Update catalog_checker, connectivity_checker, dependency_checker, and permission_checker to use centralized client creation
- Standardize region parameter naming from region_name to region across all client instantiations
- Add create_client helper function to boto3_client module with user-agent configuration
- Update all related unit tests to mock create_client instead of boto3.client
- Create helpers test package structure with __init__.py
- Consolidates boto3 client configuration and enables consistent user-agent tracking across the codebase

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
