### PR TITLE
chore: remove Preview notices and fix duplicate language badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 [![zh](https://img.shields.io/badge/lang-zh-gray.svg)](docs/langs/zh/README.md)
 [![he](https://img.shields.io/badge/lang-he-gray.svg)](docs/langs/he/README.md)
 
-> **[Preview]** Amazon SageMaker Unified Studio CI/CD CLI is currently in preview and is subject to change. Commands, configuration formats, and APIs may evolve based on customer feedback. We recommend evaluating this tool in non-production environments during preview. For feedback and bug reports, please open an issue https://github.com/aws/CICD-for-SageMakerUnifiedStudio/issues
-
 > **[IAM + IdC Domains]** This CLI supports both IAM-based and IAM Identity Center (IdC)-based SMUS domains. For IdC domains, additional setup (VPC networking, Lake Formation permissions, inline IAM policies) may be required — see the setup scripts in each example directory.
 
 **Automate deployment of data applications across SageMaker Unified Studio environments**

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -2,8 +2,6 @@
 
 ← [Back to Main README](../../README.md)
 
-> **[Preview]** Amazon SageMaker Unified Studio CI/CD CLI is currently in preview and is subject to change. Commands, configuration formats, and APIs may evolve based on customer feedback. We recommend evaluating this tool in non-production environments during preview. For feedback and bug reports, please open an issue https://github.com/aws/CICD-for-SageMakerUnifiedStudio/issues
-
 Choose the guide that matches your role:
 
 ## 👨‍💻 For Data Teams (Data Scientists, Data Engineers, GenAI App Developers)

--- a/docs/langs/fr/README.md
+++ b/docs/langs/fr/README.md
@@ -18,8 +18,6 @@
 [![zh](https://img.shields.io/badge/lang-zh-gray.svg)](docs/langs/zh/README.md)
 [![he](https://img.shields.io/badge/lang-he-gray.svg)](docs/langs/he/README.md)
 
-> **[Aperçu]** Le CLI CI/CD d'Amazon SageMaker Unified Studio est actuellement en aperçu et sujet à modifications. Les commandes, formats de configuration et API peuvent évoluer en fonction des retours clients. Nous recommandons d'évaluer cet outil dans des environnements hors production pendant la période d'aperçu. Pour vos commentaires et rapports de bugs, veuillez ouvrir une issue https://github.com/aws/CICD-for-SageMakerUnifiedStudio/issues
-
 > **[Domaines IAM + IdC]** Ce CLI prend en charge les domaines SMUS basés sur IAM et sur IAM Identity Center (IdC). Pour les domaines IdC, une configuration supplémentaire (réseau VPC, permissions Lake Formation, politiques IAM en ligne) peut être nécessaire — consultez les scripts de configuration dans chaque répertoire d'exemple.
 
 **Automatisez le déploiement d'applications de données à travers les environnements SageMaker Unified Studio**

--- a/docs/langs/he/README.md
+++ b/docs/langs/he/README.md
@@ -22,8 +22,6 @@
 [![zh](https://img.shields.io/badge/lang-zh-gray.svg)](docs/langs/zh/README.md)
 [![he](https://img.shields.io/badge/lang-he-gray.svg)](docs/langs/he/README.md)
 
-> **[תצוגה מקדימה]** Amazon SageMaker Unified Studio CI/CD CLI נמצא כעת בתצוגה מקדימה וכפוף לשינויים. פקודות, פורמטים של תצורה ו-APIs עשויים להשתנות על בסיס משוב מלקוחות. אנו ממליצים להעריך כלי זה בסביבות שאינן ייצור במהלך התצוגה המקדימה. למשוב ודיווחי באגים, אנא פתחו issue בכתובת https://github.com/aws/CICD-for-SageMakerUnifiedStudio/issues
-
 > **[דומיינים של IAM + IdC]** CLI זה תומך בדומיינים של SMUS מבוססי IAM ומבוססי IAM Identity Center (IdC). עבור דומיינים של IdC, ייתכן שתידרש הגדרה נוספת (רשת VPC, הרשאות Lake Formation, מדיניות IAM מוטמעת) - ראו את סקריפטי ההתקנה בכל תיקיית דוגמה.
 
 **אוטומציה של פריסת אפליקציות נתונים על פני סביבות SageMaker Unified Studio**

--- a/docs/langs/it/README.md
+++ b/docs/langs/it/README.md
@@ -18,8 +18,6 @@
 [![zh](https://img.shields.io/badge/lang-zh-gray.svg)](docs/langs/zh/README.md)
 [![he](https://img.shields.io/badge/lang-he-gray.svg)](docs/langs/he/README.md)
 
-> **[Anteprima]** La CLI CI/CD di Amazon SageMaker Unified Studio è attualmente in anteprima ed è soggetta a modifiche. Comandi, formati di configurazione e API potrebbero evolversi in base al feedback dei clienti. Si consiglia di valutare questo strumento in ambienti non di produzione durante l'anteprima. Per feedback e segnalazioni di bug, si prega di aprire una issue su https://github.com/aws/CICD-for-SageMakerUnifiedStudio/issues
-
 > **[Domini IAM + IdC]** Questa CLI supporta sia domini basati su IAM che domini basati su IAM Identity Center (IdC). Per i domini IdC, potrebbe essere necessaria una configurazione aggiuntiva (networking VPC, permessi Lake Formation, policy IAM inline) — vedere gli script di configurazione in ciascuna directory di esempio.
 
 **Automatizza il deployment di applicazioni dati attraverso gli ambienti di SageMaker Unified Studio**

--- a/docs/langs/ja/README.md
+++ b/docs/langs/ja/README.md
@@ -18,8 +18,6 @@
 [![zh](https://img.shields.io/badge/lang-zh-gray.svg)](docs/langs/zh/README.md)
 [![he](https://img.shields.io/badge/lang-he-gray.svg)](docs/langs/he/README.md)
 
-> **[プレビュー]** Amazon SageMaker Unified Studio CI/CD CLI は現在プレビュー中であり、変更される可能性があります。コマンド、設定フォーマット、API は顧客フィードバックに基づいて進化する可能性があります。プレビュー期間中は、本番環境以外での評価を推奨します。フィードバックやバグ報告については、https://github.com/aws/CICD-for-SageMakerUnifiedStudio/issues に issue を開いてください。
-
 > **[IAM + IdC ドメイン]** この CLI は IAM ベースと IAM Identity Center (IdC) ベースの両方の SMUS ドメインをサポートしています。IdC ドメインの場合、追加のセットアップ（VPC ネットワーキング、Lake Formation パーミッション、インライン IAM ポリシー）が必要になる場合があります。各サンプルディレクトリのセットアップスクリプトを参照してください。
 
 **SageMaker Unified Studio 環境全体でデータアプリケーションのデプロイを自動化**

--- a/docs/langs/pt/README.md
+++ b/docs/langs/pt/README.md
@@ -18,8 +18,6 @@
 [![zh](https://img.shields.io/badge/lang-zh-gray.svg)](docs/langs/zh/README.md)
 [![he](https://img.shields.io/badge/lang-he-gray.svg)](docs/langs/he/README.md)
 
-> **[Pré-visualização]** O CLI de CI/CD do Amazon SageMaker Unified Studio está atualmente em pré-visualização e sujeito a alterações. Comandos, formatos de configuração e APIs podem evoluir com base no feedback dos clientes. Recomendamos avaliar esta ferramenta em ambientes de não produção durante a pré-visualização. Para feedback e relatórios de bugs, por favor abra uma issue em https://github.com/aws/CICD-for-SageMakerUnifiedStudio/issues
-
 > **[Domínios IAM + IdC]** Este CLI suporta domínios SMUS baseados em IAM e IAM Identity Center (IdC). Para domínios IdC, configuração adicional (rede VPC, permissões Lake Formation, políticas IAM inline) pode ser necessária — consulte os scripts de configuração em cada diretório de exemplo.
 
 **Automatize a implantação de aplicações de dados em ambientes do SageMaker Unified Studio**

--- a/docs/langs/zh/README.md
+++ b/docs/langs/zh/README.md
@@ -18,8 +18,6 @@
 [![zh](https://img.shields.io/badge/lang-zh-gray.svg)](docs/langs/zh/README.md)
 [![he](https://img.shields.io/badge/lang-he-gray.svg)](docs/langs/he/README.md)
 
-> **[预览版]** Amazon SageMaker Unified Studio CI/CD CLI 目前处于预览阶段，可能会发生变化。命令、配置格式和 API 可能会根据客户反馈进行调整。我们建议在预览期间在非生产环境中评估此工具。如需反馈和错误报告，请在 https://github.com/aws/CICD-for-SageMakerUnifiedStudio/issues 提交问题
-
 > **[IAM + IdC 域]** 此 CLI 支持基于 IAM 和基于 IAM Identity Center (IdC) 的 SMUS 域。对于 IdC 域,可能需要额外的设置(VPC 网络、Lake Formation 权限、内联 IAM 策略)——请参阅每个示例目录中的设置脚本。
 
 **自动化跨 SageMaker Unified Studio 环境部署数据应用程序**

--- a/docs/scripts/translate-readme-chunked.py
+++ b/docs/scripts/translate-readme-chunked.py
@@ -90,7 +90,16 @@ def main():
     print(f"Reading {readme_path}...")
     with open(readme_path, 'r', encoding='utf-8') as f:
         source_content = f.read()
-    
+
+    # Strip the language badge panel from source — the translation script
+    # adds its own badge panel with correct relative paths and highlighting
+    source_lines = source_content.split('\n')
+    source_lines = [
+        line for line in source_lines
+        if not re.match(r'\[!\[(?:en|pt|fr|it|ja|zh|he)\]', line)
+    ]
+    source_content = '\n'.join(source_lines)
+
     print(f"Source: {len(source_content)} chars, {len(source_content.splitlines())} lines\n")
     
     # Split into sections

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,5 @@
 # SMUS CI/CD Pipeline Examples
 
-> **[Preview]** Amazon SageMaker Unified Studio CI/CD CLI is currently in preview and is subject to change. Commands, configuration formats, and APIs may evolve based on customer feedback. We recommend evaluating this tool in non-production environments during preview. For feedback and bug reports, please open an issue https://github.com/aws/CICD-for-SageMakerUnifiedStudio/issues
-
 This directory contains example pipelines and configurations demonstrating SMUS CI/CD capabilities.
 
 ## 📋 Table of Contents

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,7 +1,5 @@
 # SMUS CI/CD Tests
 
-> **[Preview]** Amazon SageMaker Unified Studio CI/CD CLI is currently in preview and is subject to change. Commands, configuration formats, and APIs may evolve based on customer feedback. We recommend evaluating this tool in non-production environments during preview. For feedback and bug reports, please open an issue https://github.com/aws/CICD-for-SageMakerUnifiedStudio/issues
-
 See [developer-guide.md](../developer-guide.md) for comprehensive testing documentation.
 
 ## Quick Start


### PR DESCRIPTION
- Remove Preview blockquote notices from all READMEs (main, getting-started, examples, tests, and all 6 translations)
- Fix translation script to strip source language badges before translating, preventing duplicate badge panels in translated output

The translation workflow will re-run after merge and produce clean translations without the duplicate badges.