### PR TITLE
Fix license metadata inconsistency across repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1225,7 +1225,7 @@ pip install -e .
 
 ## License
 
-This project is licensed under the MIT-0 License. See [LICENSE](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/LICENSE) for details.
+This project is licensed under the MIT License. See [LICENSE](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/LICENSE) for details.
 
 ---
 

--- a/docs/langs/fr/README.md
+++ b/docs/langs/fr/README.md
@@ -1229,7 +1229,7 @@ pip install -e .
 
 ## Licence
 
-Ce projet est sous licence MIT-0. Voir [LICENSE](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/LICENSE) pour plus de détails.
+Ce projet est sous licence MIT. Voir [LICENSE](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/LICENSE) pour plus de détails.
 
 ---
 

--- a/docs/langs/he/README.md
+++ b/docs/langs/he/README.md
@@ -1429,7 +1429,7 @@ pip install -e .
 
 ## רישיון
 
-פרויקט זה מורשה תחת רישיון MIT-0. ראה [LICENSE](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/LICENSE) לפרטים נוספים.
+פרויקט זה מורשה תחת רישיון MIT. ראה [LICENSE](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/LICENSE) לפרטים נוספים.
 
 ---
 

--- a/docs/langs/it/README.md
+++ b/docs/langs/it/README.md
@@ -1228,7 +1228,7 @@ pip install -e .
 
 ## Licenza
 
-Questo progetto è concesso in licenza secondo la licenza MIT-0. Consulta [LICENSE](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/LICENSE) per i dettagli.
+Questo progetto è concesso in licenza secondo la licenza MIT. Consulta [LICENSE](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/LICENSE) per i dettagli.
 
 ---
 

--- a/docs/langs/ja/README.md
+++ b/docs/langs/ja/README.md
@@ -1229,7 +1229,7 @@ pip install -e .
 
 ## ライセンス
 
-このプロジェクトは MIT-0 ライセンスの下でライセンスされています。詳細は [LICENSE](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/LICENSE) を参照してください。
+このプロジェクトは MIT ライセンスの下でライセンスされています。詳細は [LICENSE](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/LICENSE) を参照してください。
 
 ---
 

--- a/docs/langs/pt/README.md
+++ b/docs/langs/pt/README.md
@@ -1228,7 +1228,7 @@ pip install -e .
 
 ## Licença
 
-Este projeto está licenciado sob a Licença MIT-0. Consulte [LICENSE](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/LICENSE) para mais detalhes.
+Este projeto está licenciado sob a Licença MIT. Consulte [LICENSE](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/LICENSE) para mais detalhes.
 
 ---
 

--- a/docs/langs/zh/README.md
+++ b/docs/langs/zh/README.md
@@ -1229,7 +1229,7 @@ pip install -e .
 
 ## 许可证
 
-本项目采用 MIT-0 许可证。详情请参阅 [LICENSE](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/LICENSE)。
+本项目采用 MIT 许可证。详情请参阅 [LICENSE](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/LICENSE)。
 
 ---
 

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Build Tools",
-        "License :: OSI Approved :: Apache Software License",
+        "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
## Summary

The LICENSE file is MIT, but license references elsewhere were inconsistent:

- **setup.py**: Classifier said `Apache Software License` → changed to `MIT License`
- **README.md**: Said "MIT-0 License" → corrected to "MIT License"
- **Translated READMEs** (fr, he, it, ja, pt, zh): Said "MIT-0" → corrected to "MIT"

## Why

Preparing for conda-forge publishing, which requires consistent license metadata. This also fixes the PyPI metadata (currently shows Apache-2.0) on the next release.

## Changes

8 files updated, all single-line license string corrections. No functional changes.