### PR TITLE
Fix license metadata in pyproject.toml (Apache-2.0 → MIT)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,13 @@ authors = [
 ]
 description = "A CLI tool for managing CI/CD pipelines in SageMaker Unified Studio (SMUS)"
 readme = "README.md"
-license = {text = "Apache-2.0"}
+license = {text = "MIT"}
 requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Build Tools",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
## Summary

Follow-up to #182. The previous PR fixed `setup.py` and READMEs, but `pyproject.toml` was missed — and that's the file the build system actually uses for PyPI metadata.

This is why PyPI 1.0.3 still shows `Apache-2.0` as the license despite the `setup.py` fix.

## Changes

`pyproject.toml`:
- `license` field: `Apache-2.0` → `MIT`
- classifier: `Apache Software License` → `MIT License`

## Context

Preparing for conda-forge publishing, which requires consistent license metadata across the repo, PyPI, and the recipe.