### PR TITLE
Fix Windows emoji encoding error in CLI output

### DIFF
--- a/src/smus_cicd/__init__.py
+++ b/src/smus_cicd/__init__.py
@@ -1,6 +1,17 @@
 """SMUS CI/CD CLI package."""
 
+import sys
 from importlib.metadata import PackageNotFoundError, version
+
+# Ensure stdout/stderr use UTF-8 encoding on all platforms (including Windows)
+# This prevents UnicodeEncodeError when printing emoji on Windows consoles
+# that default to cp1252 encoding
+for _stream in (sys.stdout, sys.stderr):
+    if _stream and hasattr(_stream, "reconfigure"):
+        try:
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+        except Exception:
+            pass
 
 try:
     __version__ = version("aws-smus-cicd-cli")


### PR DESCRIPTION
## Problem

The conda-forge Windows build fails with:
```
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f4a1' in position 0: character maps to <undefined>
```

Windows consoles default to `cp1252` encoding, which can't handle emoji characters (💡, 🔧, 📖, etc.) used in CLI output.

## Fix

Reconfigure `sys.stdout` and `sys.stderr` to use UTF-8 with `errors='replace'` on package import in `__init__.py`. This runs once, covers all modules in the package, and gracefully handles any unencodable characters.

## Testing

Simulated the Windows `cp1252` environment locally and verified:
- Without fix: `UnicodeEncodeError` crash on emoji output
- With fix: All emoji print correctly, `aws-smus-cicd-cli --help` exits cleanly

## Context

Needed for the conda-forge Windows build: https://github.com/conda-forge/staged-recipes/pull/33066