### PR TITLE
fix: revert vars.AWS_REGION rename to vars.DOMAIN_REGION in workflows

### DIFF
--- a/.github/workflows/e2e-mlops-deploy.yml
+++ b/.github/workflows/e2e-mlops-deploy.yml
@@ -102,7 +102,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-e2e-mlops-deploy
 
       - name: Assume project role
@@ -131,7 +131,7 @@ jobs:
         if: ${{ inputs.setup_infra }}
         shell: bash
         run: |
-          REGION="${{ vars.AWS_REGION || 'us-east-1' }}"
+          REGION="${{ vars.DOMAIN_REGION || 'us-east-1' }}"
           SECRET_ID="bank-mktg/github-token"
           if ! aws secretsmanager describe-secret --secret-id "$SECRET_ID" --region "$REGION" >/dev/null 2>&1; then
             echo "::error::Secret '$SECRET_ID' not found in region $REGION."
@@ -150,7 +150,7 @@ jobs:
           GITHUB_REPO: ${{ inputs.github_repo || github.repository }}
         run: |
           PROJECT_NAME="${{ vars.PROJECT_NAME || format('bank-mktg-{0}', matrix.stage) }}"
-          REGION="${{ vars.AWS_REGION || 'us-east-1' }}"
+          REGION="${{ vars.DOMAIN_REGION || 'us-east-1' }}"
 
           echo "::group::🚧 Provisioning MLOps infra for ${{ matrix.stage }}"
           bash examples/end-to-end-data-ml-pipeline/scripts/setup-mlops-infra.sh \
@@ -174,10 +174,10 @@ jobs:
 
       - name: Deploy approved model to ${{ matrix.stage }}
         env:
-          DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          PROD_DOMAIN_REGION: ${{ vars.AWS_REGION }}
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         shell: bash
         run: |
           MANIFEST="examples/end-to-end-data-ml-pipeline/examples/mlops-pipeline/manifest.yaml"

--- a/.github/workflows/e2e-mlops-promote.yml
+++ b/.github/workflows/e2e-mlops-promote.yml
@@ -128,9 +128,9 @@ jobs:
       DEV_PROJECT_NAME: ${{ vars.DEV_PROJECT_NAME }}
       TEST_PROJECT_NAME: ${{ vars.TEST_PROJECT_NAME }}
       PROD_PROJECT_NAME: ${{ vars.PROD_PROJECT_NAME }}
-      DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-      TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-      PROD_DOMAIN_REGION: ${{ vars.AWS_REGION }}
+      DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+      TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+      PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
       AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
       MLFLOW_TRACKING_SERVER_NAME: ${{ vars.MLFLOW_TRACKING_SERVER_NAME }}
       MLFLOW_TRACKING_SERVER_ARN: ${{ vars.MLFLOW_TRACKING_SERVER_ARN }}
@@ -176,7 +176,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
-          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
+          aws-region: ${{ vars.DOMAIN_REGION || 'us-east-1' }}
 
       - name: Install dependencies
         run: pip install boto3 pyyaml -q
@@ -206,7 +206,7 @@ jobs:
         shell: bash
         env:
           PROVIDED_ARN: ${{ steps.params.outputs.model_package_arn_override }}
-          REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+          REGION: ${{ vars.DOMAIN_REGION || 'us-east-1' }}
         run: |
           if [ -n "$PROVIDED_ARN" ]; then
             echo "Using user-supplied ARN: $PROVIDED_ARN"
@@ -228,7 +228,7 @@ jobs:
             --model-package-arn "${{ steps.pick.outputs.arn }}" \
             --domain-name "$DEV_DOMAIN_NAME" \
             --target-project-name "$TEST_PROJECT_NAME" \
-            --region "${{ vars.AWS_REGION || 'us-east-1' }}"
+            --region "${{ vars.DOMAIN_REGION || 'us-east-1' }}"
 
       - name: Stage artifact into PROD bucket
         id: stage-prod
@@ -239,7 +239,7 @@ jobs:
             --model-package-arn "${{ steps.pick.outputs.arn }}" \
             --domain-name "$DEV_DOMAIN_NAME" \
             --target-project-name "$PROD_PROJECT_NAME" \
-            --region "${{ vars.AWS_REGION || 'us-east-1' }}"
+            --region "${{ vars.DOMAIN_REGION || 'us-east-1' }}"
 
       - name: Summary
         run: |
@@ -268,9 +268,9 @@ jobs:
       DEV_PROJECT_NAME: ${{ vars.DEV_PROJECT_NAME }}
       TEST_PROJECT_NAME: ${{ vars.TEST_PROJECT_NAME }}
       PROD_PROJECT_NAME: ${{ vars.PROD_PROJECT_NAME }}
-      DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-      TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-      PROD_DOMAIN_REGION: ${{ vars.AWS_REGION }}
+      DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+      TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+      PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
       AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
       MLFLOW_TRACKING_SERVER_NAME: ${{ vars.MLFLOW_TRACKING_SERVER_NAME }}
       MLFLOW_TRACKING_SERVER_ARN: ${{ vars.MLFLOW_TRACKING_SERVER_ARN }}
@@ -287,7 +287,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
-          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
+          aws-region: ${{ vars.DOMAIN_REGION || 'us-east-1' }}
 
       - name: Install CLI
         run: pip install aws-smus-cicd-cli pyyaml boto3 -q
@@ -340,7 +340,7 @@ jobs:
         # the DAG's processing task failed. Check SageMaker directly.
         run: |
           python3 ${{ env.MLOPS_HELPER }} check-deploy-status \
-            --region "${{ vars.AWS_REGION || 'us-east-1' }}" \
+            --region "${{ vars.DOMAIN_REGION || 'us-east-1' }}" \
             --max-age-minutes 60
 
       - name: Smoke test endpoint
@@ -348,7 +348,7 @@ jobs:
         run: |
           python3 ${{ env.MLOPS_HELPER }} smoke-test \
             --endpoint-name "$ENDPOINT_NAME" \
-            --region "${{ vars.AWS_REGION || 'us-east-1' }}"
+            --region "${{ vars.DOMAIN_REGION || 'us-east-1' }}"
 
       - name: Record deploy on model package metadata
         if: ${{ needs.prepare.outputs.run_smoke_test == 'true' }}
@@ -374,7 +374,7 @@ jobs:
         continue-on-error: true
         run: |
           python3 ${{ env.MLOPS_HELPER }} capture-deploy-logs \
-            --region "${{ vars.AWS_REGION || 'us-east-1' }}" \
+            --region "${{ vars.DOMAIN_REGION || 'us-east-1' }}" \
             --output-dir "$RUNNER_TEMP/deploy-logs-dev"
 
       - name: Upload deploy logs artifact
@@ -443,9 +443,9 @@ jobs:
       DEV_PROJECT_NAME: ${{ vars.DEV_PROJECT_NAME }}
       TEST_PROJECT_NAME: ${{ vars.TEST_PROJECT_NAME }}
       PROD_PROJECT_NAME: ${{ vars.PROD_PROJECT_NAME }}
-      DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-      TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-      PROD_DOMAIN_REGION: ${{ vars.AWS_REGION }}
+      DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+      TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+      PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
       AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
       MLFLOW_TRACKING_SERVER_NAME: ${{ vars.MLFLOW_TRACKING_SERVER_NAME }}
       MLFLOW_TRACKING_SERVER_ARN: ${{ vars.MLFLOW_TRACKING_SERVER_ARN }}
@@ -462,7 +462,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
-          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
+          aws-region: ${{ vars.DOMAIN_REGION || 'us-east-1' }}
 
       - name: Install CLI
         run: pip install aws-smus-cicd-cli pyyaml boto3 -q
@@ -516,7 +516,7 @@ jobs:
       - name: Verify deploy processing job succeeded
         run: |
           python3 ${{ env.MLOPS_HELPER }} check-deploy-status \
-            --region "${{ vars.AWS_REGION || 'us-east-1' }}" \
+            --region "${{ vars.DOMAIN_REGION || 'us-east-1' }}" \
             --max-age-minutes 60
 
       - name: Smoke test endpoint
@@ -524,7 +524,7 @@ jobs:
         run: |
           python3 ${{ env.MLOPS_HELPER }} smoke-test \
             --endpoint-name "$ENDPOINT_NAME" \
-            --region "${{ vars.AWS_REGION || 'us-east-1' }}"
+            --region "${{ vars.DOMAIN_REGION || 'us-east-1' }}"
 
       - name: Record deploy on model package metadata
         if: ${{ needs.prepare.outputs.run_smoke_test == 'true' }}
@@ -546,7 +546,7 @@ jobs:
         continue-on-error: true
         run: |
           python3 ${{ env.MLOPS_HELPER }} capture-deploy-logs \
-            --region "${{ vars.AWS_REGION || 'us-east-1' }}" \
+            --region "${{ vars.DOMAIN_REGION || 'us-east-1' }}" \
             --output-dir "$RUNNER_TEMP/deploy-logs-test"
 
       - name: Upload deploy logs artifact
@@ -612,9 +612,9 @@ jobs:
       DEV_PROJECT_NAME: ${{ vars.DEV_PROJECT_NAME }}
       TEST_PROJECT_NAME: ${{ vars.TEST_PROJECT_NAME }}
       PROD_PROJECT_NAME: ${{ vars.PROD_PROJECT_NAME }}
-      DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-      TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-      PROD_DOMAIN_REGION: ${{ vars.AWS_REGION }}
+      DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+      TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+      PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
       AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
       MLFLOW_TRACKING_SERVER_NAME: ${{ vars.MLFLOW_TRACKING_SERVER_NAME }}
       MLFLOW_TRACKING_SERVER_ARN: ${{ vars.MLFLOW_TRACKING_SERVER_ARN }}
@@ -631,7 +631,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
-          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
+          aws-region: ${{ vars.DOMAIN_REGION || 'us-east-1' }}
 
       - name: Install CLI
         run: pip install aws-smus-cicd-cli pyyaml boto3 -q
@@ -685,7 +685,7 @@ jobs:
       - name: Verify deploy processing job succeeded
         run: |
           python3 ${{ env.MLOPS_HELPER }} check-deploy-status \
-            --region "${{ vars.AWS_REGION || 'us-east-1' }}" \
+            --region "${{ vars.DOMAIN_REGION || 'us-east-1' }}" \
             --max-age-minutes 60
 
       - name: Smoke test endpoint
@@ -693,7 +693,7 @@ jobs:
         run: |
           python3 ${{ env.MLOPS_HELPER }} smoke-test \
             --endpoint-name "$ENDPOINT_NAME" \
-            --region "${{ vars.AWS_REGION || 'us-east-1' }}"
+            --region "${{ vars.DOMAIN_REGION || 'us-east-1' }}"
 
       - name: Record deploy on model package metadata
         if: ${{ needs.prepare.outputs.run_smoke_test == 'true' }}
@@ -715,7 +715,7 @@ jobs:
         continue-on-error: true
         run: |
           python3 ${{ env.MLOPS_HELPER }} capture-deploy-logs \
-            --region "${{ vars.AWS_REGION || 'us-east-1' }}" \
+            --region "${{ vars.DOMAIN_REGION || 'us-east-1' }}" \
             --output-dir "$RUNNER_TEMP/deploy-logs-prod"
 
       - name: Upload deploy logs artifact

--- a/.github/workflows/mwaa-pipeline-lifecycle.yml
+++ b/.github/workflows/mwaa-pipeline-lifecycle.yml
@@ -33,7 +33,7 @@ jobs:
     
     - name: Validate environment variables
       env:
-        DOMAIN_REGION: ${{ vars.AWS_REGION }}
+        DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
       run: |
         echo "Validating required environment variables..."
         echo "DOMAIN_REGION: ${DOMAIN_REGION:-NOT_SET}"
@@ -47,7 +47,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-region: ${{ vars.AWS_REGION }}
+        aws-region: ${{ vars.DOMAIN_REGION }}
         role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEV }}
         role-session-name: smus-mwaa-lifecycle-setup
         role-duration-seconds: 43200
@@ -109,7 +109,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-region: ${{ vars.AWS_REGION }}
+        aws-region: ${{ vars.DOMAIN_REGION }}
         role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEV }}
         role-session-name: smus-mwaa-lifecycle-validate
         role-duration-seconds: 43200
@@ -127,7 +127,7 @@ jobs:
     
     - name: Validate pipeline configuration
       env:
-        DOMAIN_REGION: ${{ vars.AWS_REGION }}
+        DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         SMUS_LOG_LEVEL: WARNING
       run: |
         /examples/mwaa-example
@@ -149,7 +149,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-region: ${{ vars.AWS_REGION }}
+        aws-region: ${{ vars.DOMAIN_REGION }}
         role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEV }}
         role-session-name: smus-mwaa-lifecycle-bundle
         role-duration-seconds: 43200
@@ -167,7 +167,7 @@ jobs:
     
     - name: Create deployment bundle
       env:
-        DOMAIN_REGION: ${{ vars.AWS_REGION }}
+        DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         SMUS_LOG_LEVEL: WARNING
       run: |
         /examples/mwaa-example
@@ -194,7 +194,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-region: ${{ vars.AWS_REGION }}
+        aws-region: ${{ vars.DOMAIN_REGION }}
         role-to-assume: ${{ secrets.AWS_ROLE_ARN_TEST }}
         role-session-name: smus-mwaa-lifecycle-deploy
         role-duration-seconds: 43200
@@ -218,7 +218,7 @@ jobs:
     
     - name: Deploy to test environment
       env:
-        DOMAIN_REGION: ${{ vars.AWS_REGION }}
+        DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         SMUS_LOG_LEVEL: WARNING
       run: |
         /examples/mwaa-example
@@ -240,7 +240,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-region: ${{ vars.AWS_REGION }}
+        aws-region: ${{ vars.DOMAIN_REGION }}
         role-to-assume: ${{ secrets.AWS_ROLE_ARN_TEST }}
         role-session-name: smus-mwaa-lifecycle-monitor
         role-duration-seconds: 43200
@@ -258,7 +258,7 @@ jobs:
     
     - name: Monitor pipeline status
       env:
-        DOMAIN_REGION: ${{ vars.AWS_REGION }}
+        DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         SMUS_LOG_LEVEL: WARNING
       run: |
         /examples/mwaa-example
@@ -279,7 +279,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-region: ${{ vars.AWS_REGION }}
+        aws-region: ${{ vars.DOMAIN_REGION }}
         role-to-assume: ${{ secrets.AWS_ROLE_ARN_PROD }}
         role-session-name: smus-mwaa-lifecycle-deploy-prod
         role-duration-seconds: 43200
@@ -303,7 +303,7 @@ jobs:
     
     - name: Deploy to production environment
       env:
-        DOMAIN_REGION: ${{ vars.AWS_REGION }}
+        DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         SMUS_LOG_LEVEL: WARNING
       run: |
         /examples/mwaa-example
@@ -325,7 +325,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-region: ${{ vars.AWS_REGION }}
+        aws-region: ${{ vars.DOMAIN_REGION }}
         role-to-assume: ${{ secrets.AWS_ROLE_ARN_PROD }}
         role-session-name: smus-mwaa-lifecycle-final
         role-duration-seconds: 43200
@@ -343,7 +343,7 @@ jobs:
     
     - name: Final pipeline monitoring
       env:
-        DOMAIN_REGION: ${{ vars.AWS_REGION }}
+        DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         SMUS_LOG_LEVEL: WARNING
       run: |
         /examples/mwaa-example

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -111,7 +111,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-        aws-region: ${{ vars.AWS_REGION }}
+        aws-region: ${{ vars.DOMAIN_REGION }}
         role-session-name: test-${{ steps.test-name.outputs.name }}
         role-duration-seconds: 43200
     
@@ -124,18 +124,18 @@ jobs:
     
     - name: Verify DataZone domain exists
       run: |
-        echo "🔍 Checking DataZone domains in ${{ vars.AWS_REGION }}"
+        echo "🔍 Checking DataZone domains in ${{ vars.DOMAIN_REGION }}"
         ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
         echo "Account: $ACCOUNT_ID"
-        echo "Region: ${{ vars.AWS_REGION }}"
+        echo "Region: ${{ vars.DOMAIN_REGION }}"
         echo ""
         echo "Available domains:"
-        aws datazone list-domains --region ${{ vars.AWS_REGION }} --query 'items[].{id:id,name:name}' --output table
+        aws datazone list-domains --region ${{ vars.DOMAIN_REGION }} --query 'items[].{id:id,name:name}' --output table
     
     - name: Test describe --connect with basic_app manifest
       env:
-        DOMAIN_REGION: ${{ vars.AWS_REGION }}
-        DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
+        DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+        DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         AWS_ACCOUNT_ID: ${{ steps.aws-account.outputs.account-id }}
       run: |
         echo "Testing describe --connect with basic_app manifest"
@@ -143,10 +143,10 @@ jobs:
     
     - name: Run test
       env:
-        DOMAIN_REGION: ${{ vars.AWS_REGION }}
-        TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-        DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-        STS_REGION: ${{ vars.AWS_REGION }}
+        DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+        TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+        DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+        STS_REGION: ${{ vars.DOMAIN_REGION }}
         STS_ACCOUNT_ID: ${{ steps.aws-account.outputs.account-id }}
         AWS_ACCOUNT_ID: ${{ steps.aws-account.outputs.account-id }}
       run: |

--- a/.github/workflows/serverless-pipeline-lifecycle.yml
+++ b/.github/workflows/serverless-pipeline-lifecycle.yml
@@ -33,7 +33,7 @@ jobs:
     
     - name: Validate environment variables
       env:
-        DOMAIN_REGION: ${{ vars.AWS_REGION }}
+        DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
       run: |
         echo "Validating required environment variables..."
         echo "DOMAIN_REGION: ${DOMAIN_REGION:-NOT_SET}"
@@ -47,7 +47,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-region: ${{ vars.AWS_REGION }}
+        aws-region: ${{ vars.DOMAIN_REGION }}
         role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEV }}
         role-session-name: smus-serverless-lifecycle-setup
         role-duration-seconds: 43200
@@ -109,7 +109,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-region: ${{ vars.AWS_REGION }}
+        aws-region: ${{ vars.DOMAIN_REGION }}
         role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEV }}
         role-session-name: smus-serverless-lifecycle-validate
         role-duration-seconds: 43200
@@ -127,7 +127,7 @@ jobs:
     
     - name: Validate pipeline configuration
       env:
-        DOMAIN_REGION: ${{ vars.AWS_REGION }}
+        DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         SMUS_LOG_LEVEL: WARNING
       run: |
         /examples/serverless-example
@@ -149,14 +149,14 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-region: ${{ vars.AWS_REGION }}
+        aws-region: ${{ vars.DOMAIN_REGION }}
         role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEV }}
         role-session-name: smus-serverless-lifecycle-upload
         role-duration-seconds: 43200
     
     - name: Upload DAG files to S3
       env:
-        DOMAIN_REGION: ${{ vars.AWS_REGION }}
+        DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
       run: |
         /examples/serverless-example
         
@@ -180,7 +180,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-region: ${{ vars.AWS_REGION }}
+        aws-region: ${{ vars.DOMAIN_REGION }}
         role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEV }}
         role-session-name: smus-serverless-lifecycle-bundle
         role-duration-seconds: 43200
@@ -198,7 +198,7 @@ jobs:
     
     - name: Create deployment bundle
       env:
-        DOMAIN_REGION: ${{ vars.AWS_REGION }}
+        DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         SMUS_LOG_LEVEL: WARNING
       run: |
         /examples/serverless-example
@@ -225,7 +225,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-region: ${{ vars.AWS_REGION }}
+        aws-region: ${{ vars.DOMAIN_REGION }}
         role-to-assume: ${{ secrets.AWS_ROLE_ARN_TEST }}
         role-session-name: smus-serverless-lifecycle-deploy
         role-duration-seconds: 43200
@@ -249,7 +249,7 @@ jobs:
     
     - name: Deploy to test environment
       env:
-        DOMAIN_REGION: ${{ vars.AWS_REGION }}
+        DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         SMUS_LOG_LEVEL: WARNING
       run: |
         /examples/serverless-example
@@ -271,7 +271,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-region: ${{ vars.AWS_REGION }}
+        aws-region: ${{ vars.DOMAIN_REGION }}
         role-to-assume: ${{ secrets.AWS_ROLE_ARN_PROD }}
         role-session-name: smus-serverless-lifecycle-deploy-prod
         role-duration-seconds: 43200
@@ -295,7 +295,7 @@ jobs:
     
     - name: Deploy to production environment
       env:
-        DOMAIN_REGION: ${{ vars.AWS_REGION }}
+        DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         SMUS_LOG_LEVEL: WARNING
       run: |
         /examples/serverless-example
@@ -317,7 +317,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-region: ${{ vars.AWS_REGION }}
+        aws-region: ${{ vars.DOMAIN_REGION }}
         role-to-assume: ${{ secrets.AWS_ROLE_ARN_PROD }}
         role-session-name: smus-serverless-lifecycle-monitor
         role-duration-seconds: 43200
@@ -335,7 +335,7 @@ jobs:
     
     - name: Monitor pipeline status
       env:
-        DOMAIN_REGION: ${{ vars.AWS_REGION }}
+        DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         SMUS_LOG_LEVEL: WARNING
       run: |
         /examples/serverless-example

--- a/.github/workflows/smus-bundle-deploy.yml
+++ b/.github/workflows/smus-bundle-deploy.yml
@@ -128,23 +128,23 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ steps.bundle-role.outputs.role-arn }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-bundle-session
       
       - name: Setup QuickSight dashboard (optional)
         if: ${{ inputs.quicksight_setup_script != '' }}
         env:
-          DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
+          DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         run: |
           echo "📊 Setting up QuickSight dashboard..."
           python ${{ inputs.quicksight_setup_script }}
       
       - name: aws-smus-cicd-cli describe (validate bundle source target)
         env:
-          DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          PROD_DOMAIN_REGION: ${{ vars.AWS_REGION }}
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         run: |
           echo "🔍 Validating bundle source target: ${{ inputs.bundle_from_target }}"
           
@@ -152,10 +152,10 @@ jobs:
       
       - name: aws-smus-cicd-cli bundle from ${{ inputs.bundle_from_target }}
         env:
-          DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          PROD_DOMAIN_REGION: ${{ vars.AWS_REGION }}
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         run: |
           echo "🔍 DOMAIN_REGION: $DOMAIN_REGION"
           echo "🔍 DEV_DOMAIN_REGION: $DEV_DOMAIN_REGION"
@@ -203,15 +203,15 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_TEST }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-validate-session
       
       - name: aws-smus-cicd-cli describe (validate test target)
         env:
-          DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          PROD_DOMAIN_REGION: ${{ vars.AWS_REGION }}
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         run: |
           echo "🔍 DOMAIN_REGION: $DOMAIN_REGION"
           echo "🔍 TEST_DOMAIN_REGION: $TEST_DOMAIN_REGION"
@@ -250,7 +250,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_TEST }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-deploy-test-session
       
       - name: Get AWS Account ID
@@ -264,7 +264,7 @@ jobs:
         id: mlflow-setup-test
         if: ${{ inputs.setup_mlflow }}
         run: |
-          REGION="${{ vars.AWS_REGION }}"
+          REGION="${{ vars.DOMAIN_REGION }}"
           ACCOUNT_ID="${{ steps.aws-account-test.outputs.account-id }}"
           STACK_NAME="smus-shared-resources"
           TRACKING_SERVER_NAME="smus-integration-mlflow-${REGION}"
@@ -309,10 +309,10 @@ jobs:
       
       - name: aws-smus-cicd-cli describe (validate test target)
         env:
-          DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          PROD_DOMAIN_REGION: ${{ vars.AWS_REGION }}
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         run: |
           echo "🔍 Validating test target: ${{ inputs.test_target }}"
           
@@ -320,11 +320,11 @@ jobs:
       
       - name: aws-smus-cicd-cli deploy --dry-run (pre-deploy validation)
         env:
-          DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          PROD_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          STS_REGION: ${{ vars.AWS_REGION }}
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          STS_REGION: ${{ vars.DOMAIN_REGION }}
           STS_ACCOUNT_ID: ${{ steps.aws-account-test.outputs.account-id }}
           AWS_ACCOUNT_ID: ${{ steps.aws-account-test.outputs.account-id }}
         run: |
@@ -339,12 +339,12 @@ jobs:
 
       - name: aws-smus-cicd-cli deploy to test
         env:
-          DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          PROD_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          MLFLOW_TRACKING_SERVER_NAME: ${{ inputs.setup_mlflow && format('smus-integration-mlflow-{0}', vars.AWS_REGION) || '' }}
-          STS_REGION: ${{ vars.AWS_REGION }}
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          MLFLOW_TRACKING_SERVER_NAME: ${{ inputs.setup_mlflow && format('smus-integration-mlflow-{0}', vars.DOMAIN_REGION) || '' }}
+          STS_REGION: ${{ vars.DOMAIN_REGION }}
           STS_ACCOUNT_ID: ${{ steps.aws-account-test.outputs.account-id }}
           AWS_ACCOUNT_ID: ${{ steps.aws-account-test.outputs.account-id }}
         run: |
@@ -373,7 +373,7 @@ jobs:
           
           manifest_path = "${{ inputs.manifest_path }}"
           test_target = "${{ inputs.test_target }}"
-          region = "${{ vars.AWS_REGION }}"
+          region = "${{ vars.DOMAIN_REGION }}"
           
           try:
               with open(manifest_path, 'r') as f:
@@ -436,15 +436,15 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_TEST }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-test-session
       
       - name: aws-smus-cicd-cli test
         env:
-          DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          PROD_DOMAIN_REGION: ${{ vars.AWS_REGION }}
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         run: |
           echo "🔍 DOMAIN_REGION: $DOMAIN_REGION"
           echo "🔍 TEST_DOMAIN_REGION: $TEST_DOMAIN_REGION"
@@ -485,7 +485,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_PROD }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-deploy-prod-session
       
       - name: Get AWS Account ID
@@ -499,7 +499,7 @@ jobs:
         id: mlflow-setup-prod
         if: ${{ inputs.setup_mlflow }}
         run: |
-          REGION="${{ vars.AWS_REGION }}"
+          REGION="${{ vars.DOMAIN_REGION }}"
           ACCOUNT_ID="${{ steps.aws-account-prod.outputs.account-id }}"
           STACK_NAME="smus-shared-resources"
           TRACKING_SERVER_NAME="smus-integration-mlflow-${REGION}"
@@ -544,10 +544,10 @@ jobs:
       
       - name: aws-smus-cicd-cli describe (validate prod target)
         env:
-          DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          PROD_DOMAIN_REGION: ${{ vars.AWS_REGION }}
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         run: |
           echo "🔍 Validating prod target: ${{ inputs.prod_target }}"
           
@@ -555,12 +555,12 @@ jobs:
       
       - name: aws-smus-cicd-cli deploy to production
         env:
-          DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          PROD_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          MLFLOW_TRACKING_SERVER_NAME: ${{ inputs.setup_mlflow && format('smus-integration-mlflow-{0}', vars.AWS_REGION) || '' }}
-          STS_REGION: ${{ vars.AWS_REGION }}
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          MLFLOW_TRACKING_SERVER_NAME: ${{ inputs.setup_mlflow && format('smus-integration-mlflow-{0}', vars.DOMAIN_REGION) || '' }}
+          STS_REGION: ${{ vars.DOMAIN_REGION }}
           STS_ACCOUNT_ID: ${{ steps.aws-account-prod.outputs.account-id }}
           AWS_ACCOUNT_ID: ${{ steps.aws-account-prod.outputs.account-id }}
         run: |
@@ -598,7 +598,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_TEST }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-destroy-test-session
 
       - name: Get AWS Account ID
@@ -609,10 +609,10 @@ jobs:
 
       - name: Destroy test resources
         env:
-          TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          PROD_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          DOMAIN_REGION: ${{ vars.AWS_REGION }}
+          TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
           AWS_ACCOUNT_ID: ${{ steps.aws-account.outputs.account-id }}
         run: |
           aws-smus-cicd-cli destroy \
@@ -654,10 +654,10 @@ jobs:
 
       - name: Idempotency check (second destroy)
         env:
-          TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          PROD_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          DOMAIN_REGION: ${{ vars.AWS_REGION }}
+          TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
           AWS_ACCOUNT_ID: ${{ steps.aws-account.outputs.account-id }}
         run: |
           aws-smus-cicd-cli destroy \

--- a/.github/workflows/smus-direct-deploy.yml
+++ b/.github/workflows/smus-direct-deploy.yml
@@ -66,7 +66,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_TEST }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-deploy-test-session
       
       - name: Get AWS Account ID
@@ -80,7 +80,7 @@ jobs:
         id: mlflow-setup
         if: ${{ inputs.setup_mlflow }}
         run: |
-          REGION="${{ vars.AWS_REGION }}"
+          REGION="${{ vars.DOMAIN_REGION }}"
           ACCOUNT_ID="${{ steps.aws-account.outputs.account-id }}"
           STACK_NAME="smus-shared-resources"
           TRACKING_SERVER_NAME="smus-integration-mlflow-${REGION}"
@@ -125,12 +125,12 @@ jobs:
       
       - name: aws-smus-cicd-cli deploy to test (direct from branch)
         env:
-          DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          MLFLOW_TRACKING_SERVER_NAME: ${{ inputs.setup_mlflow && format('smus-integration-mlflow-{0}', vars.AWS_REGION) || '' }}
-          MLFLOW_ARTIFACT_LOCATION: s3://amazon-sagemaker-${{ steps.aws-account.outputs.account-id }}-${{ vars.AWS_REGION }}-${{ vars.PROJECT_ID }}/shared/ml/mlflow-artifacts
-          STS_REGION: ${{ vars.AWS_REGION }}
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          MLFLOW_TRACKING_SERVER_NAME: ${{ inputs.setup_mlflow && format('smus-integration-mlflow-{0}', vars.DOMAIN_REGION) || '' }}
+          MLFLOW_ARTIFACT_LOCATION: s3://amazon-sagemaker-${{ steps.aws-account.outputs.account-id }}-${{ vars.DOMAIN_REGION }}-${{ vars.PROJECT_ID }}/shared/ml/mlflow-artifacts
+          STS_REGION: ${{ vars.DOMAIN_REGION }}
           STS_ACCOUNT_ID: ${{ steps.aws-account.outputs.account-id }}
           AWS_ACCOUNT_ID: ${{ steps.aws-account.outputs.account-id }}
         run: |
@@ -156,7 +156,7 @@ jobs:
           
           manifest_path = "${{ inputs.manifest_path }}"
           test_target = "${{ inputs.test_target }}"
-          region = "${{ vars.AWS_REGION }}"
+          region = "${{ vars.DOMAIN_REGION }}"
           
           try:
               # Resolve env vars in manifest
@@ -228,7 +228,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_TEST }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-test-session
           
       - name: Get AWS Account ID
@@ -240,12 +240,12 @@ jobs:
       
       - name: aws-smus-cicd-cli test
         env:
-          DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          MLFLOW_TRACKING_SERVER_NAME: ${{ inputs.setup_mlflow && format('smus-integration-mlflow-{0}', vars.AWS_REGION) || '' }}
-          MLFLOW_ARTIFACT_LOCATION: s3://amazon-sagemaker-${{ steps.aws-account-test.outputs.account-id }}-${{ vars.AWS_REGION }}-${{ vars.PROJECT_ID }}/shared/ml/mlflow-artifacts
-          STS_REGION: ${{ vars.AWS_REGION }}
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          MLFLOW_TRACKING_SERVER_NAME: ${{ inputs.setup_mlflow && format('smus-integration-mlflow-{0}', vars.DOMAIN_REGION) || '' }}
+          MLFLOW_ARTIFACT_LOCATION: s3://amazon-sagemaker-${{ steps.aws-account-test.outputs.account-id }}-${{ vars.DOMAIN_REGION }}-${{ vars.PROJECT_ID }}/shared/ml/mlflow-artifacts
+          STS_REGION: ${{ vars.DOMAIN_REGION }}
           STS_ACCOUNT_ID: ${{ steps.aws-account-test.outputs.account-id }}
           AWS_ACCOUNT_ID: ${{ steps.aws-account-test.outputs.account-id }}
         run: |

--- a/.github/workflows/smus-e2e-direct-deploy.yml
+++ b/.github/workflows/smus-e2e-direct-deploy.yml
@@ -80,7 +80,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-e2e-deploy-session
 
       - name: Get AWS Account ID
@@ -116,7 +116,7 @@ jobs:
         env:
           GITHUB_REPO: ${{ inputs.github_repo || github.repository }}
         run: |
-          REGION="${{ vars.AWS_REGION || 'us-east-1' }}"
+          REGION="${{ vars.DOMAIN_REGION || 'us-east-1' }}"
           PROJECT_NAME="${{ vars.PROJECT_NAME || format('bank-mktg-{0}', inputs.test_target) }}"
           SECRET_ID="bank-mktg/github-token"
 
@@ -138,7 +138,7 @@ jobs:
         id: mlflow-setup
         if: ${{ inputs.setup_mlflow }}
         run: |
-          REGION="${{ vars.AWS_REGION }}"
+          REGION="${{ vars.DOMAIN_REGION }}"
           ACCOUNT_ID="${{ steps.aws-account.outputs.account-id }}"
           STACK_NAME="smus-shared-resources"
           TRACKING_SERVER_NAME="smus-integration-mlflow-${REGION}"
@@ -190,10 +190,10 @@ jobs:
 
       - name: aws-smus-cicd-cli deploy
         env:
-          DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          PROD_DOMAIN_REGION: ${{ vars.AWS_REGION }}
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
           DEV_DOMAIN_NAME: ${{ vars.DEV_DOMAIN_NAME }}
           TEST_DOMAIN_NAME: ${{ vars.TEST_DOMAIN_NAME }}
           PROD_DOMAIN_NAME: ${{ vars.PROD_DOMAIN_NAME }}
@@ -201,7 +201,7 @@ jobs:
           TEST_PROJECT_NAME: ${{ vars.TEST_PROJECT_NAME }}
           PROD_PROJECT_NAME: ${{ vars.PROD_PROJECT_NAME }}
           AWS_ACCOUNT_ID: ${{ steps.aws-account.outputs.account-id }}
-          STS_REGION: ${{ vars.AWS_REGION }}
+          STS_REGION: ${{ vars.DOMAIN_REGION }}
           STS_ACCOUNT_ID: ${{ steps.aws-account.outputs.account-id }}
           MLFLOW_TRACKING_SERVER_NAME: ${{ vars.MLFLOW_TRACKING_SERVER_NAME }}
           MLFLOW_TRACKING_SERVER_ARN: ${{ vars.MLFLOW_TRACKING_SERVER_ARN }}
@@ -236,7 +236,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-e2e-test-session
 
       - name: Get AWS Account ID
@@ -263,10 +263,10 @@ jobs:
 
       - name: aws-smus-cicd-cli test
         env:
-          DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          PROD_DOMAIN_REGION: ${{ vars.AWS_REGION }}
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
           DEV_DOMAIN_NAME: ${{ vars.DEV_DOMAIN_NAME }}
           TEST_DOMAIN_NAME: ${{ vars.TEST_DOMAIN_NAME }}
           PROD_DOMAIN_NAME: ${{ vars.PROD_DOMAIN_NAME }}
@@ -274,7 +274,7 @@ jobs:
           TEST_PROJECT_NAME: ${{ vars.TEST_PROJECT_NAME }}
           PROD_PROJECT_NAME: ${{ vars.PROD_PROJECT_NAME }}
           AWS_ACCOUNT_ID: ${{ steps.aws-account-test.outputs.account-id }}
-          STS_REGION: ${{ vars.AWS_REGION }}
+          STS_REGION: ${{ vars.DOMAIN_REGION }}
           STS_ACCOUNT_ID: ${{ steps.aws-account-test.outputs.account-id }}
           MLFLOW_TRACKING_SERVER_NAME: ${{ vars.MLFLOW_TRACKING_SERVER_NAME }}
           MLFLOW_TRACKING_SERVER_ARN: ${{ vars.MLFLOW_TRACKING_SERVER_ARN }}

--- a/.github/workflows/smus-multi-env-reusable.yml
+++ b/.github/workflows/smus-multi-env-reusable.yml
@@ -91,13 +91,13 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEV }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-bundle-session
       
       - name: aws-smus-cicd-cli describe (validate dev target)
         env:
-          DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         run: |
           echo "🔍 Validating dev target"
           
@@ -105,8 +105,8 @@ jobs:
       
       - name: aws-smus-cicd-cli bundle from dev
         env:
-          DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          DEV_DOMAIN_REGION: ${{ vars.AWS_REGION }}
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          DEV_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         run: |
           echo "🔍 DOMAIN_REGION: $DOMAIN_REGION"
           echo "🔍 DEV_DOMAIN_REGION: $DEV_DOMAIN_REGION"
@@ -151,13 +151,13 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_TEST }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-validate-session
       
       - name: aws-smus-cicd-cli describe (validate all targets)
         env:
-          DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         run: |
           echo "🔍 DOMAIN_REGION: $DOMAIN_REGION"
           echo "🔍 TEST_DOMAIN_REGION: $TEST_DOMAIN_REGION"
@@ -196,13 +196,13 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_TEST }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-deploy-test-session
        
       - name: aws-smus-cicd-cli describe (validate test target)
         env:
-          DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         run: |
           echo "🔍 Validating test target: ${{ inputs.test_target }}"
           
@@ -210,8 +210,8 @@ jobs:
       
       - name: aws-smus-cicd-cli deploy to test
         env:
-          DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         run: |
           echo "🔍 DOMAIN_REGION: $DOMAIN_REGION"
           echo "🔍 TEST_DOMAIN_REGION: $TEST_DOMAIN_REGION"
@@ -254,13 +254,13 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_TEST }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-test-session
       
       - name: aws-smus-cicd-cli test
         env:
-          DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          TEST_DOMAIN_REGION: ${{ vars.AWS_REGION }}
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          TEST_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         run: |
           echo "🔍 DOMAIN_REGION: $DOMAIN_REGION"
           echo "🔍 TEST_DOMAIN_REGION: $TEST_DOMAIN_REGION"
@@ -301,13 +301,13 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_PROD }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-deploy-prod-session
       
       - name: aws-smus-cicd-cli describe (validate prod target)
         env:
-          DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          PROD_DOMAIN_REGION: ${{ vars.AWS_REGION }}
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         run: |
           echo "🔍 Validating prod target: ${{ inputs.prod_target }}"
           
@@ -315,8 +315,8 @@ jobs:
       
       - name: aws-smus-cicd-cli deploy to production
         env:
-          DOMAIN_REGION: ${{ vars.AWS_REGION }}
-          PROD_DOMAIN_REGION: ${{ vars.AWS_REGION }}
+          DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+          PROD_DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         run: |
           echo "🔍 DOMAIN_REGION: $DOMAIN_REGION"
           echo "🔍 PROD_DOMAIN_REGION: $PROD_DOMAIN_REGION"

--- a/.github/workflows/smus-workflow-housekeeping.yml
+++ b/.github/workflows/smus-workflow-housekeeping.yml
@@ -20,10 +20,10 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEV }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-housekeeping-dev-session
       - name: Delete all MWAA workflows
-        run: python3 tests/scripts/delete_all_workflows.py --region ${{ vars.AWS_REGION }}
+        run: python3 tests/scripts/delete_all_workflows.py --region ${{ vars.DOMAIN_REGION }}
 
   cleanup-test-workflows:
     name: Delete All MWAA Workflows (Test)
@@ -35,10 +35,10 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_TEST }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-housekeeping-test-session
       - name: Delete all MWAA workflows
-        run: python3 tests/scripts/delete_all_workflows.py --region ${{ vars.AWS_REGION }}
+        run: python3 tests/scripts/delete_all_workflows.py --region ${{ vars.DOMAIN_REGION }}
 
   cleanup-prod-workflows:
     name: Delete All MWAA Workflows (Prod)
@@ -50,7 +50,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_PROD }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-housekeeping-prod-session
       - name: Delete all MWAA workflows
-        run: python3 tests/scripts/delete_all_workflows.py --region ${{ vars.AWS_REGION }}
+        run: python3 tests/scripts/delete_all_workflows.py --region ${{ vars.DOMAIN_REGION }}

--- a/.github/workflows/test-aws-credentials.yml
+++ b/.github/workflows/test-aws-credentials.yml
@@ -18,7 +18,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEV }}
-        aws-region: ${{ vars.AWS_REGION }}
+        aws-region: ${{ vars.DOMAIN_REGION }}
         role-session-name: test-dev-credentials
     
     - name: Verify credentials
@@ -27,7 +27,7 @@ jobs:
         aws sts get-caller-identity
         echo ""
         echo "=== Environment Variables ==="
-        echo "DOMAIN_REGION: ${{ vars.AWS_REGION }}"
+        echo "DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}"
         echo "AWS_REGION: $AWS_REGION"
         echo "AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION"
 
@@ -41,7 +41,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ secrets.AWS_ROLE_ARN_TEST }}
-        aws-region: ${{ vars.AWS_REGION }}
+        aws-region: ${{ vars.DOMAIN_REGION }}
         role-session-name: test-test-credentials
     
     - name: Verify credentials
@@ -50,7 +50,7 @@ jobs:
         aws sts get-caller-identity
         echo ""
         echo "=== Environment Variables ==="
-        echo "DOMAIN_REGION: ${{ vars.AWS_REGION }}"
+        echo "DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}"
         echo "AWS_REGION: $AWS_REGION"
         echo "AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION"
 
@@ -64,7 +64,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ secrets.AWS_ROLE_ARN_PROD }}
-        aws-region: ${{ vars.AWS_REGION }}
+        aws-region: ${{ vars.DOMAIN_REGION }}
         role-session-name: test-prod-credentials
     
     - name: Verify credentials
@@ -73,6 +73,6 @@ jobs:
         aws sts get-caller-identity
         echo ""
         echo "=== Environment Variables ==="
-        echo "DOMAIN_REGION: ${{ vars.AWS_REGION }}"
+        echo "DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}"
         echo "AWS_REGION: $AWS_REGION"
         echo "AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION"


### PR DESCRIPTION
## Summary

- Reverts the `vars.AWS_REGION` rename introduced in PR #221 back to `vars.DOMAIN_REGION` across all GitHub Actions workflow files
- PR #221 renamed the variable reference but the repository only has `DOMAIN_REGION` configured as a repository variable, causing all workflows to fail with: `Input required and not supplied: aws-region`

## Test plan

- [ ] Verify `smus-direct-deploy.yml` workflow passes (previously failing with `aws-region` not supplied)
- [ ] Verify `smus-bundle-deploy.yml` workflow passes
- [ ] Verify `pr-tests.yml` workflow passes
- [ ] Verify new `e2e-mlops-deploy.yml` and `smus-e2e-direct-deploy.yml` workflows pass