### PR TITLE
fix: use correct environment names and role secrets in e2e workflows

### DIFF
--- a/.github/workflows/e2e-mlops-deploy.yml
+++ b/.github/workflows/e2e-mlops-deploy.yml
@@ -83,7 +83,7 @@ jobs:
       max-parallel: 1
       matrix:
         stage: ${{ fromJSON(needs.resolve.outputs.stages) }}
-    environment: ${{ matrix.stage }}
+    environment: ${{ fromJSON('{"dev":"dev-aws-account","test":"test-aws-account","prod":"prod-aws-account"}')[matrix.stage] || 'dev-aws-account' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -98,10 +98,28 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
+      - name: Determine AWS Role ARN
+        id: resolve-role
+        run: |
+          case "${{ matrix.stage }}" in
+            dev)
+              echo "role-arn=${{ secrets.AWS_ROLE_ARN_DEV }}" >> $GITHUB_OUTPUT
+              ;;
+            test)
+              echo "role-arn=${{ secrets.AWS_ROLE_ARN_TEST }}" >> $GITHUB_OUTPUT
+              ;;
+            prod)
+              echo "role-arn=${{ secrets.AWS_ROLE_ARN_PROD }}" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "role-arn=${{ secrets.AWS_ROLE_ARN_DEV }}" >> $GITHUB_OUTPUT
+              ;;
+          esac
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          role-to-assume: ${{ steps.resolve-role.outputs.role-arn }}
           aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-e2e-mlops-deploy
 

--- a/.github/workflows/e2e-mlops-promote.yml
+++ b/.github/workflows/e2e-mlops-promote.yml
@@ -113,7 +113,7 @@ jobs:
     # Run this in the dev environment because that's where the registry lives
     # in our single-account topology. In multi-account, this would target a
     # dedicated registry account.
-    environment: dev
+    environment: dev-aws-account
     outputs:
       model_package_arn: ${{ steps.pick.outputs.arn }}
       model_package_version: ${{ steps.pick.outputs.version }}
@@ -175,7 +175,7 @@ jobs:
       - name: Authenticate via OIDC
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEV }}
           aws-region: ${{ vars.DOMAIN_REGION || 'us-east-1' }}
 
       - name: Install dependencies
@@ -258,7 +258,7 @@ jobs:
     needs: [prepare]
     if: ${{ needs.prepare.outputs.start_at == 'dev' && needs.prepare.result == 'success' }}
     runs-on: ubuntu-latest
-    environment: dev
+    environment: dev-aws-account
     env:
       STAGE: dev
       ENDPOINT_NAME: bank-mktg-prediction-dev
@@ -286,7 +286,7 @@ jobs:
       - name: Authenticate via OIDC
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEV }}
           aws-region: ${{ vars.DOMAIN_REGION || 'us-east-1' }}
 
       - name: Install CLI
@@ -433,7 +433,7 @@ jobs:
         needs.prepare.outputs.start_at == 'test'
       )
     runs-on: ubuntu-latest
-    environment: test
+    environment: test-aws-account
     env:
       STAGE: test
       ENDPOINT_NAME: bank-mktg-prediction-test
@@ -461,7 +461,7 @@ jobs:
       - name: Authenticate via OIDC
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_TEST }}
           aws-region: ${{ vars.DOMAIN_REGION || 'us-east-1' }}
 
       - name: Install CLI
@@ -602,7 +602,7 @@ jobs:
         needs.prepare.outputs.start_at == 'prod'
       )
     runs-on: ubuntu-latest
-    environment: prod
+    environment: prod-aws-account
     env:
       STAGE: prod
       ENDPOINT_NAME: bank-mktg-prediction-prod
@@ -630,7 +630,7 @@ jobs:
       - name: Authenticate via OIDC
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_PROD }}
           aws-region: ${{ vars.DOMAIN_REGION || 'us-east-1' }}
 
       - name: Install CLI

--- a/.github/workflows/smus-e2e-direct-deploy.yml
+++ b/.github/workflows/smus-e2e-direct-deploy.yml
@@ -59,9 +59,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    # Run inside the per-stage GitHub Environment so OIDC role + vars resolve
-    # from `dev`, `test`, or `prod` based on the caller's `test_target` input.
-    environment: ${{ inputs.test_target }}
+    environment: ${{ fromJSON('{"dev":"dev-aws-account","test":"test-aws-account","prod":"prod-aws-account","dev-idc":"dev-aws-account","test-idc":"test-aws-account","prod-idc":"prod-aws-account"}')[inputs.test_target] || 'dev-aws-account' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -76,10 +74,28 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
+      - name: Determine AWS Role ARN
+        id: resolve-role
+        run: |
+          case "${{ inputs.test_target }}" in
+            dev|dev-idc)
+              echo "role-arn=${{ secrets.AWS_ROLE_ARN_DEV }}" >> $GITHUB_OUTPUT
+              ;;
+            test|test-idc)
+              echo "role-arn=${{ secrets.AWS_ROLE_ARN_TEST }}" >> $GITHUB_OUTPUT
+              ;;
+            prod|prod-idc)
+              echo "role-arn=${{ secrets.AWS_ROLE_ARN_PROD }}" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "role-arn=${{ secrets.AWS_ROLE_ARN_DEV }}" >> $GITHUB_OUTPUT
+              ;;
+          esac
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          role-to-assume: ${{ steps.resolve-role.outputs.role-arn }}
           aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-e2e-deploy-session
 
@@ -217,7 +233,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy
     if: ${{ !inputs.skip_tests }}
-    environment: ${{ inputs.test_target }}
+    environment: ${{ fromJSON('{"dev":"dev-aws-account","test":"test-aws-account","prod":"prod-aws-account","dev-idc":"dev-aws-account","test-idc":"test-aws-account","prod-idc":"prod-aws-account"}')[inputs.test_target] || 'dev-aws-account' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -232,10 +248,28 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
+      - name: Determine AWS Role ARN
+        id: resolve-role-test
+        run: |
+          case "${{ inputs.test_target }}" in
+            dev|dev-idc)
+              echo "role-arn=${{ secrets.AWS_ROLE_ARN_DEV }}" >> $GITHUB_OUTPUT
+              ;;
+            test|test-idc)
+              echo "role-arn=${{ secrets.AWS_ROLE_ARN_TEST }}" >> $GITHUB_OUTPUT
+              ;;
+            prod|prod-idc)
+              echo "role-arn=${{ secrets.AWS_ROLE_ARN_PROD }}" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "role-arn=${{ secrets.AWS_ROLE_ARN_DEV }}" >> $GITHUB_OUTPUT
+              ;;
+          esac
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          role-to-assume: ${{ steps.resolve-role-test.outputs.role-arn }}
           aws-region: ${{ vars.DOMAIN_REGION }}
           role-session-name: smus-e2e-test-session
 


### PR DESCRIPTION
## Summary

- Maps environment names in e2e workflows (`dev` → `dev-aws-account`, etc.) using the same `fromJSON(...)` pattern already used in `smus-bundle-deploy.yml`
- Replaces `vars.AWS_ROLE_ARN` (which doesn't exist) with the correct environment-level secrets (`secrets.AWS_ROLE_ARN_DEV`, `secrets.AWS_ROLE_ARN_TEST`, `secrets.AWS_ROLE_ARN_PROD`)
- Adds role resolution steps in `smus-e2e-direct-deploy.yml` and `e2e-mlops-deploy.yml` to dynamically select the correct secret based on target stage

Fixes the `Input required and not supplied: aws-region` failure in https://github.com/aws/CICD-for-SageMakerUnifiedStudio/actions/runs/28001721338

**Note:** The e2e-mlops workflows still reference other missing environment variables (`vars.AWS_ACCOUNT_ID`, `vars.DEPLOYMENT_ROLE_NAME`, `vars.PROJECT_NAME`, etc.) that need to be configured in the GitHub environments separately.

## Test plan

- [ ] Verify `E2E Deploy DataOps Pipeline` workflow passes the credential step
- [ ] Verify `E2E Deploy MLOps Pipeline` workflow passes the credential step
- [ ] Verify `E2E MLOps Promote` workflow passes the credential step