### PR TITLE
feat(notebooks): Add spec for native Data Notebooks support

### DIFF
--- a/.github/workflows/e2e-notebook-sync.yml
+++ b/.github/workflows/e2e-notebook-sync.yml
@@ -1,0 +1,53 @@
+name: E2E Notebook Sync
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'examples/e2e-notebook-sync/**'
+      - 'src/**'
+      - '.github/workflows/smus-bundle-deploy.yml'
+      - '.github/workflows/e2e-notebook-sync.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-notebook-sync-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  # -------------------------------------------------------------------
+  # IAM domain: bundle from dev → deploy to test → deploy to prod
+  # -------------------------------------------------------------------
+  deploy-iam:
+    uses: ./.github/workflows/smus-bundle-deploy.yml
+    secrets:
+      AWS_ROLE_ARN_DEV: ${{ secrets.AWS_ROLE_ARN_DEV }}
+      AWS_ROLE_ARN_TEST: ${{ secrets.AWS_ROLE_ARN_TEST }}
+      AWS_ROLE_ARN_PROD: ${{ secrets.AWS_ROLE_ARN_PROD }}
+    with:
+      manifest_path: 'examples/e2e-notebook-sync/manifest.yaml'
+      test_target: 'test'
+      prod_target: 'prod'
+      deploy_to_prod: ${{ github.ref == 'refs/heads/main' }}
+      destroy_test_after_deploy: true
+
+  # -------------------------------------------------------------------
+  # IdC domain: bundle from dev-idc → deploy to test-idc → deploy to prod-idc
+  # -------------------------------------------------------------------
+  deploy-idc:
+    uses: ./.github/workflows/smus-bundle-deploy.yml
+    secrets:
+      AWS_ROLE_ARN_DEV: ${{ secrets.AWS_ROLE_ARN_DEV }}
+      AWS_ROLE_ARN_TEST: ${{ secrets.AWS_ROLE_ARN_TEST }}
+      AWS_ROLE_ARN_PROD: ${{ secrets.AWS_ROLE_ARN_PROD }}
+    with:
+      manifest_path: 'examples/e2e-notebook-sync/manifest-idc.yaml'
+      test_target: 'test-idc'
+      prod_target: 'prod-idc'
+      deploy_to_prod: ${{ github.ref == 'refs/heads/main' }}
+      destroy_test_after_deploy: true

--- a/.github/workflows/slack-action-state-notification.yml
+++ b/.github/workflows/slack-action-state-notification.yml
@@ -10,6 +10,7 @@ on:
       - "Deploy ML Training"
       - "Translate Documentation"
       - "Deploy Catalog Import Export"
+      - "E2E Notebook Sync"
     types: [completed]
 
 permissions:

--- a/.github/workflows/slack-weekly-summary.yml
+++ b/.github/workflows/slack-weekly-summary.yml
@@ -39,6 +39,7 @@ jobs:
             "Deploy ML Training"
             "Translate Documentation"
             "Deploy Catalog Import Export"
+            "E2E Notebook Sync"
           )
 
           WORKFLOW_SUMMARY=""

--- a/.kiro/specs/data-notebooks-support/design.md
+++ b/.kiro/specs/data-notebooks-support/design.md
@@ -2,25 +2,31 @@
 
 ## Overview
 
-This feature adds native Data Notebooks support to the SMUS CI/CD CLI, enabling promotion of SageMaker Unified Studio notebooks across environments (dev → test → prod) using the DataZone Notebook Import/Export APIs. The implementation follows the existing CLI architecture patterns — specifically mirroring the catalog import/export approach — with two new helper modules (`notebook_export.py` and `notebook_import.py`) and integration into the existing `bundle`, `deploy`, `destroy`, and `dry-run` commands.
+This feature adds native Data Notebooks support to the SMUS CI/CD CLI, enabling promotion of SageMaker Unified Studio notebooks across environments (dev → test → prod) using the DataZone Notebook APIs. The implementation follows the existing CLI architecture patterns — specifically mirroring the catalog import/export approach — with two new helper modules (`notebook_export.py` and `notebook_import.py`) and integration into the existing `bundle`, `deploy`, `destroy`, and `dry-run` commands.
 
 ### Design Goals
 
 - **Consistency**: Follow the same module structure, error handling, and reporting patterns established by the catalog import/export feature
 - **Resilience**: Individual notebook failures do not block the entire export/import operation; failures are collected and reported
-- **Upsert Safety**: Import uses a create-or-replace strategy — old versions are only deleted after the new version is confirmed ACTIVE and updated
+- **In-Place Updates**: `StartNotebookSync` handles both create and update — no delete-old-version flow. Run history is preserved across deployments
+- **Metadata Tracking**: Target notebooks are tagged with `smus-cicd-source-notebook-id` to maintain source-to-target mapping via `UpdateNotebook`
 - **Idempotency**: Import operations use client tokens to prevent duplicate notebook creation on retries
+- **Fail-Fast Validation**: When `notebook_ids` is specified, all IDs are validated upfront via `GetNotebook` before any exports begin
 - **Extensibility**: The `content.notebooks` manifest section and `deployment_configuration.notebooks` section follow the same convention as `content.catalog` and `deployment_configuration.catalog`
 
 ### Key Design Decisions
 
-1. **Separate helper modules** rather than embedding logic in command files — follows `catalog_export.py` / `catalog_import.py` pattern
-2. **JSON manifest inside the bundle** (`notebooks/notebook_export_manifest.json`) — mirrors `catalog/catalog_export.json` approach
-3. **Async polling with exponential backoff** for both export (GetNotebookExport) and post-import status (GetNotebook) — avoids hammering APIs
-4. **Notebook ID used directly for file paths** — the notebook ID (pattern: `[a-zA-Z0-9_-]{1,36}`) is inherently safe for both filesystem and S3 key usage, eliminating the need for name sanitization
-5. **Add `notebook` resource type** to the existing `DEPLOY_RESOURCE_TYPES` / `DESTROY_SUPPORTED_RESOURCE_TYPES` registries for destroy support
-6. **Upsert strategy (create-or-replace)** — StartNotebookImport always creates a new notebook (duplicate names allowed), then old version with same name is deleted only after new one is ACTIVE + metadata-updated. This ensures zero data loss.
-7. **Name-only filtering** — `include_names` and `exclude_names` match by notebook name only (case-sensitive exact match), no ID matching
+1. **StartNotebookSync replaces StartNotebookImport** — single API for both create (no notebookId) and update (with notebookId). No delete-old-version flow. Preserves run history.
+2. **Notebook ID-only operation** — manifest uses `notebook_ids` list (optional). No include_names/exclude_names. No name-based filtering anywhere.
+3. **Separate helper modules** rather than embedding logic in command files — follows `catalog_export.py` / `catalog_import.py` pattern
+4. **JSON manifest inside the bundle** (`notebooks/notebook_export_manifest.json`) — mirrors `catalog/catalog_export.json` approach
+5. **Async polling with exponential backoff** for export (GetNotebookExport) — avoids hammering APIs
+6. **Notebook ID used directly for file paths** — the notebook ID (pattern: `[a-zA-Z0-9_-]{1,36}`) is inherently safe for both filesystem and S3 key usage
+7. **Add `notebook` resource type** to the existing `DEPLOY_RESOURCE_TYPES` / `DESTROY_SUPPORTED_RESOURCE_TYPES` registries for destroy support
+8. **Metadata-based source tracking** — deploy discovers existing target notebooks via ListNotebooks + GetNotebook, checks for `smus-cicd-source-notebook-id` in metadata
+9. **No unique name enforcement** — IDs are unique by definition; duplicate names are allowed in DataZone
+10. **UpdateNotebook failure = FAILED** — no separate warning category; if metadata/config porting fails, the notebook counts as failed
+
 
 ---
 
@@ -32,35 +38,43 @@ This feature adds native Data Notebooks support to the SMUS CI/CD CLI, enabling 
 graph TD
     subgraph BundlePhase["Bundle Phase (source project)"]
         A[Bundle Command] --> B[NotebookExporter]
-        B --> C[ListNotebooks API]
-        B --> D[GetNotebook API]
-        B --> E[StartNotebookExport API]
-        B --> F[GetNotebookExport API - polling]
+        B --> B1{notebook_ids specified?}
+        B1 -->|Yes| B2[Validate ALL IDs via GetNotebook]
+        B2 -->|Any invalid| B3[FAIL immediately — list invalid IDs]
+        B2 -->|All valid| B4[Export specified notebooks]
+        B1 -->|No| B5[ListNotebooks API — all active]
+        B5 --> B4
+        B4 --> E[StartNotebookExport API per notebook]
+        E --> F[GetNotebookExport — poll with backoff]
         F --> G[Download .ipynb from S3]
         G --> H[Write to notebooks/ in bundle ZIP]
-        D --> I[Write notebook_export_manifest.json]
+        B2 --> I[GetNotebook retrieves parameters/metadata/envConfig]
+        I --> J[Write notebook_export_manifest.json]
     end
 
-    subgraph DeployPhase["Deploy Phase (target project) - Upsert"]
-        J[Deploy Command] --> K[NotebookImporter]
-        K --> K1[ListNotebooks - find old versions by name]
-        K1 --> L[Upload .ipynb to target S3]
-        L --> M[StartNotebookImport API - always creates new]
-        M --> N[Poll GetNotebook until ACTIVE]
-        N --> O[UpdateNotebook API - metadata porting]
-        O --> O1[DeleteNotebook API - remove old version]
-        O1 --> P[Report Summary: new/updated/failed]
+    subgraph DeployPhase["Deploy Phase (target project)"]
+        K[Deploy Command] --> L[NotebookImporter]
+        L --> L1["Step 1: Upload .ipynb files to S3"]
+        L1 --> L2["Step 2: ListNotebooks + GetNotebook each → read metadata"]
+        L2 --> L3["Step 3: Build source→target map from metadata"]
+        L3 --> L4["Step 4: For each manifest entry → StartNotebookSync"]
+        L4 --> L5["Step 5: UpdateNotebook (name, desc, metadata, params, envConfig)"]
+        L5 --> L6["Step 6: Report created/updated/failed"]
     end
 
     subgraph DestroyPhase["Destroy Phase (target project)"]
-        Q[Destroy Command] --> R[ListNotebooks API]
-        R --> R1[Apply include_names/exclude_names filters]
-        R1 --> S[Display destruction plan]
-        S --> T[DeleteNotebook API per notebook]
+        Q[Destroy Command] --> R["ListNotebooks + GetNotebook each"]
+        R --> R1["Filter: has smus-cicd-source-notebook-id metadata"]
+        R1 --> R2{"notebook_ids in manifest?"}
+        R2 -->|Yes| R3["Additionally filter by source IDs in list"]
+        R2 -->|No| R4["Include all with metadata key"]
+        R3 --> S[Display destruction plan]
+        R4 --> S
+        S --> T[DeleteNotebook per notebook]
     end
 
-    H --> |bundle.zip| J
-    I --> |bundle.zip| J
+    H --> |bundle.zip| K
+    J --> |bundle.zip| K
 ```
 
 ### Module Placement
@@ -69,7 +83,7 @@ graph TD
 src/smus_cicd/
 ├── helpers/
 │   ├── notebook_export.py          # NEW: Notebook export logic for bundle
-│   ├── notebook_import.py          # NEW: Notebook import logic for deploy
+│   ├── notebook_import.py          # NEW: Notebook sync logic for deploy
 │   └── ...
 ├── commands/
 │   ├── bundle.py                   # MODIFIED: call notebook_export when enabled
@@ -88,9 +102,9 @@ src/smus_cicd/
 | Command | Integration Point | Action |
 |---------|-------------------|--------|
 | `bundle` | After catalog export | Call `export_notebooks()` if `content.notebooks.enabled` |
-| `deploy` | After catalog import, before bootstrap | Call `import_notebooks()` if manifest present |
-| `destroy` | Validation phase | Call `ListNotebooks` to discover notebooks, apply `include_names`/`exclude_names` filters |
-| `destroy` | Execution phase | Call `DeleteNotebook` for each filtered notebook |
+| `deploy` | After catalog import, before bootstrap | Call `sync_notebooks()` if manifest present and not disabled |
+| `destroy` | Validation phase | ListNotebooks + GetNotebook → filter by metadata → optional `notebook_ids` filter |
+| `destroy` | Execution phase | DeleteNotebook for each filtered notebook |
 | `dry-run` | After catalog checker | `NotebookChecker.check()` validates prerequisites |
 
 ---
@@ -106,8 +120,8 @@ New dataclass for the `content.notebooks` section:
 class NotebookConfig:
     """Notebook export configuration for bundle."""
     enabled: bool = False
-    include_names: Optional[List[str]] = None  # notebook names only (case-sensitive exact match)
-    exclude_names: Optional[List[str]] = None  # notebook names only (case-sensitive exact match)
+    notebook_ids: Optional[List[str]] = None  # Optional list of notebook IDs to export
+    # Pattern per ID: [a-zA-Z0-9_-]{1,36}
 ```
 
 **Parsing**: Added to `ContentConfig`:
@@ -142,57 +156,62 @@ def export_notebooks(
     domain_id: str,
     project_id: str,
     region: str,
-    include_names: Optional[List[str]] = None,
-    exclude_names: Optional[List[str]] = None,
+    notebook_ids: Optional[List[str]] = None,
     polling_timeout: int = 300,
-) -> Tuple[List[ExportedNotebook], NotebookExportManifest]:
+) -> Tuple[List[ExportedNotebook], Dict[str, Any]]:
     """
     Export notebooks from a DataZone project.
+
+    If notebook_ids is specified:
+      1. Validate ALL IDs upfront via GetNotebook (fail-fast)
+      2. If any ID is invalid, fail immediately listing all invalid IDs
+      3. If all valid, export only those notebooks
+
+    If notebook_ids is omitted:
+      1. Call ListNotebooks to discover all active notebooks
+      2. Export all discovered notebooks
 
     Args:
         domain_id: DataZone domain identifier
         project_id: DataZone project identifier
         region: AWS region
-        include_names: Optional list of notebook names to include (case-sensitive exact match)
-        exclude_names: Optional list of notebook names to exclude (case-sensitive exact match)
+        notebook_ids: Optional list of specific notebook IDs to export
         polling_timeout: Max seconds to wait per notebook export (default 300)
 
     Returns:
-        Tuple of (list of exported notebook file contents, manifest object)
+        Tuple of (list of exported notebook objects, manifest dict)
 
     Raises:
         Exception: If ListNotebooks API fails entirely
+        SystemExit: If any notebook_ids are invalid (fail-fast)
     """
 ```
 
 **Internal functions:**
 
 ```python
+def _validate_notebook_ids(
+    client, domain_id: str, notebook_ids: List[str],
+) -> Tuple[List[Dict], List[str]]:
+    """Validate ALL notebook IDs upfront via GetNotebook.
+    Returns (valid_notebooks_with_details, invalid_ids).
+    Calls GetNotebook for EACH ID — retrieves parameters, metadata, envConfig."""
+
 def _list_all_notebooks(client, domain_id: str, project_id: str) -> List[Dict]:
-    """List all active notebooks with pagination."""
-
-def _apply_filters(
-    notebooks: List[Dict],
-    include_names: Optional[List[str]],
-    exclude_names: Optional[List[str]],
-) -> List[Dict]:
-    """Apply include_names/exclude_names filters by notebook name only.
-    Include first, then exclude. Case-sensitive exact match."""
-
-def _matches_name_filter(notebook: Dict, filter_names: List[str]) -> bool:
-    """Check if notebook name matches any entry in the filter list (case-sensitive exact match)."""
+    """List all active notebooks with pagination (follows nextToken)."""
 
 def _export_single_notebook(
     client, s3_client, domain_id: str, project_id: str,
     notebook: Dict, polling_timeout: int,
 ) -> Optional[ExportedNotebook]:
-    """Export a single notebook, poll for completion, download file."""
+    """Export a single notebook: StartNotebookExport → poll → download."""
 
 def _poll_export_status(
     client, domain_id: str, export_id: str, notebook_id: str,
     polling_timeout: int,
 ) -> Optional[str]:
-    """Poll GetNotebookExport with exponential backoff. Returns S3 URI or None."""
+    """Poll GetNotebookExport with exponential backoff + jitter.
+    Initial: 1s, doubles each poll, capped at 30s. Returns S3 URI or None."""
 
 def _build_export_manifest(
     exported: List[ExportedNotebook],
@@ -200,33 +219,31 @@ def _build_export_manifest(
     project_id: str,
 ) -> Dict[str, Any]:
     """Build the notebook_export_manifest.json structure."""
-
-def _warn_duplicate_names(notebooks: List[Dict]) -> None:
-    """Raise error if any duplicate notebook names in the filtered set.
-    This enforces unique names to ensure reliable upsert behavior."""
 ```
 
 ### 3. NotebookImporter (`helpers/notebook_import.py`)
 
 ```python
-def import_notebooks(
+def sync_notebooks(
     domain_id: str,
     project_id: str,
     region: str,
     manifest_data: Dict[str, Any],
     notebook_files: Dict[str, bytes],
     s3_uri: str,
-) -> NotebookImportSummary:
+) -> NotebookSyncSummary:
     """
-    Import notebooks into a target DataZone project using upsert strategy.
+    Sync notebooks into a target DataZone project using StartNotebookSync.
 
-    Upsert flow per notebook:
-    1. ListNotebooks on target to find existing notebook(s) with same name ("old versions")
-    2. Upload .ipynb to S3
-    3. StartNotebookImport (always creates new notebook; duplicate names allowed)
-    4. Poll GetNotebook until ACTIVE
-    5. UpdateNotebook (port metadata from manifest)
-    6. Delete old version(s) via DeleteNotebook (only after new is ACTIVE + updated)
+    Deployment sequence (strict order):
+      Step 1: Upload all .ipynb files to S3 at {s3Uri}/notebooks/imports/{sourceNotebookId}.ipynb
+      Step 2: ListNotebooks + GetNotebook for each → read metadata
+      Step 3: Build {sourceNotebookId → targetNotebookId} map from metadata key
+      Step 4: For each manifest entry: lookup in map →
+              StartNotebookSync WITH notebookId (update) or WITHOUT (create)
+      Step 5: After sync → UpdateNotebook (name, description, metadata with tracking key,
+              parameters, environmentConfiguration)
+      Step 6: Report created/updated/failed
 
     Args:
         domain_id: Target domain identifier
@@ -237,7 +254,7 @@ def import_notebooks(
         s3_uri: Target S3 URI from default.s3_shared connection
 
     Returns:
-        NotebookImportSummary with counts (new, updated, failed)
+        NotebookSyncSummary with counts (created, updated, failed)
 
     Raises:
         ValidationError: If manifest structure is invalid
@@ -249,74 +266,70 @@ def import_notebooks(
 
 ```python
 def _validate_notebook_manifest(manifest_data: Dict[str, Any]) -> None:
-    """Validate manifest has required metadata and notebooks keys."""
+    """Validate manifest has required metadata and notebooks keys.
+    Required metadata fields: sourceProjectId, sourceDomainId, exportTimestamp, notebookCount."""
 
-def _list_existing_notebooks_by_name(
+def _discover_target_notebooks(
     client, domain_id: str, project_id: str,
-) -> Dict[str, List[str]]:
-    """List all ACTIVE notebooks in target project, return dict mapping
-    name -> list of notebook IDs. Used for old version detection."""
-
-def _find_old_versions(
-    existing_by_name: Dict[str, List[str]], notebook_name: str,
-) -> List[str]:
-    """Return list of existing notebook IDs with the same name (old versions to delete)."""
+) -> Dict[str, str]:
+    """ListNotebooks + GetNotebook for each → build {sourceNotebookId → targetNotebookId}
+    map by reading smus-cicd-source-notebook-id from metadata."""
 
 def _upload_notebook_to_s3(
     s3_client, s3_uri: str, source_notebook_id: str, content: bytes,
 ) -> str:
-    """Upload .ipynb file to S3 using notebook ID as the key and return the full S3 URI.
-    Overwrites any existing file at the same key (safe for re-deploys)."""
+    """Upload .ipynb file to S3: {s3Uri}/notebooks/imports/{sourceNotebookId}.ipynb.
+    Returns the full S3 URI for the uploaded file."""
 
-def _generate_client_token(notebook_name: str, timestamp: str) -> str:
-    """Generate deterministic idempotent client token, max 64 chars."""
+def _generate_client_token(source_notebook_id: str, timestamp: str) -> str:
+    """Generate deterministic idempotent client token, max 64 chars.
+    Derived from source notebook ID + deployment timestamp, truncated."""
 
-def _import_single_notebook(
-    client, s3_client, domain_id: str, project_id: str,
-    notebook_entry: Dict, notebook_content: bytes, s3_uri: str,
-    deployment_timestamp: str, old_version_ids: List[str],
-) -> ImportResult:
-    """Import a single notebook using upsert:
-    upload -> StartNotebookImport -> poll ACTIVE -> UpdateNotebook -> delete old versions."""
-
-def _poll_notebook_active(
-    client, domain_id: str, notebook_id: str, timeout: int = 120,
-) -> bool:
-    """Poll GetNotebook until status is ACTIVE. Returns True if reached ACTIVE."""
+def _sync_single_notebook(
+    client, domain_id: str, project_id: str,
+    notebook_entry: Dict, s3_location: str,
+    target_notebook_id: Optional[str],
+    deployment_timestamp: str,
+) -> SyncResult:
+    """Sync a single notebook:
+    - If target_notebook_id: StartNotebookSync WITH notebookId (update in-place)
+    - If None: StartNotebookSync WITHOUT notebookId (create new)
+    - If ResourceNotFoundException on update: retry WITHOUT notebookId (create)
+    - After success: call UpdateNotebook to apply metadata/config"""
 
 def _apply_notebook_metadata(
-    client, domain_id: str, notebook_id: str, notebook_entry: Dict,
+    client, domain_id: str, project_id: str,
+    notebook_id: str, notebook_entry: Dict,
 ) -> bool:
-    """Call UpdateNotebook API to apply parameters, metadata, and environmentConfiguration
-    from the manifest entry. Returns True if successful, False if warning occurred."""
+    """Call UpdateNotebook API to apply name, description, parameters, metadata
+    (including smus-cicd-source-notebook-id), and environmentConfiguration.
+    Returns True if successful, False if error (counts as FAILED)."""
 
 def _build_update_kwargs(notebook_entry: Dict) -> Dict[str, Any]:
-    """Build UpdateNotebook API kwargs, omitting empty fields."""
-
-def _delete_old_versions(
-    client, domain_id: str, old_version_ids: List[str], notebook_name: str,
-) -> None:
-    """Delete old notebook versions. Logs warnings on failure but does not raise."""
-
-def _warn_manifest_duplicates(manifest_data: Dict[str, Any]) -> None:
-    """Raise validation error if manifest contains multiple entries with the same name.
-    Duplicate names should have been caught at bundle time, but validate here as a safety check."""
+    """Build UpdateNotebook API kwargs:
+    - Always include metadata with smus-cicd-source-notebook-id
+    - Omit parameters if empty dict
+    - Omit environmentConfiguration if None
+    - Always include name and description"""
 ```
 
 ### 4. Dry-Run Checker (`commands/dry_run/checkers/notebook_checker.py`)
 
 ```python
 class NotebookChecker:
-    """Validates notebook import prerequisites during dry-run."""
+    """Validates notebook sync prerequisites during dry-run."""
 
     def check(self, context: DryRunContext) -> List[Finding]:
         """
         Checks:
-        1. S3 connection (default.s3_shared) exists and bucket is accessible
-        2. IAM permissions: datazone:StartNotebookImport, datazone:UpdateNotebook,
-           datazone:GetNotebook, datazone:DeleteNotebook, datazone:ListNotebooks,
-           s3:PutObject
-        3. Report notebook count from manifest
+        1. S3 connection (default.s3_shared) exists and bucket is accessible (HEAD request)
+        2. IAM permissions via SimulatePrincipalPolicy:
+           - datazone:StartNotebookSync
+           - datazone:UpdateNotebook
+           - datazone:GetNotebook
+           - datazone:ListNotebooks
+           - s3:PutObject
+        3. Report notebook count from manifest's notebookCount field
         """
 ```
 
@@ -327,23 +340,32 @@ class NotebookChecker:
 ```python
 def _discover_notebooks(
     client, domain_id: str, project_id: str,
-    include_names: Optional[List[str]], exclude_names: Optional[List[str]],
+    notebook_ids: Optional[List[str]],
 ) -> List[ResourceToDelete]:
-    """List all ACTIVE notebooks in the project, apply include_names/exclude_names
-    filters (name-only matching), return matching notebooks for destruction."""
+    """
+    Discover target notebooks for destruction:
+    1. ListNotebooks with owningProjectIdentifier + status=ACTIVE (paginated)
+    2. GetNotebook for each → check metadata for smus-cicd-source-notebook-id
+    3. Include only notebooks WITH the metadata key
+    4. If notebook_ids specified: additionally filter to only those whose
+       metadata value is in the notebook_ids list
+    5. Return matching notebooks as ResourceToDelete with type='notebook'
+    """
 ```
 
 **destroy_executor.py** addition:
 
 ```python
 def _delete_notebook(client, domain_id: str, notebook_id: str) -> ResourceResult:
-    """Delete a single notebook resource."""
+    """Delete a single notebook via DeleteNotebook API.
+    - ResourceNotFoundException → status='not_found'
+    - Other errors → status='error', continue"""
 ```
 
-**destroy_models.py** update:
+**resource_types.py** update:
 
 ```python
-DESTROY_SUPPORTED_RESOURCE_TYPES = frozenset({
+DEPLOY_RESOURCE_TYPES = frozenset({
     ...,
     "notebook",  # NEW
 })
@@ -358,20 +380,20 @@ DESTROY_SUPPORTED_RESOURCE_TYPES = frozenset({
 ```json
 {
   "metadata": {
-    "sourceProjectId": "string",
-    "sourceDomainId": "string",
+    "sourceProjectId": "proj-abc123",
+    "sourceDomainId": "dzd-xyz789",
     "exportTimestamp": "2024-01-15T10:30:00Z",
-    "notebookCount": 3
+    "notebookCount": 2
   },
   "notebooks": [
     {
-      "sourceNotebookId": "abc123",
-      "name": "My Analysis Notebook",
-      "description": "Exploratory analysis",
-      "filePath": "notebooks/abc123.ipynb",
-      "exportedAt": "2024-01-15T10:30:00Z",
-      "parameters": {"key1": "value1"},
-      "metadata": {"owner": "team-a"},
+      "sourceNotebookId": "nb-abc123",
+      "name": "Customer Churn Prediction",
+      "description": "ML notebook for churn analysis",
+      "filePath": "notebooks/nb-abc123.ipynb",
+      "exportedAt": "2024-01-15T10:30:05Z",
+      "parameters": {"dataset_path": "s3://bucket/data.csv"},
+      "metadata": {"owner": "team-ds", "version": "2.1"},
       "environmentConfiguration": {
         "imageVersion": "v2.0",
         "packageConfig": {
@@ -379,6 +401,16 @@ DESTROY_SUPPORTED_RESOURCE_TYPES = frozenset({
           "packageSpecification": "pandas>=2.0\nnumpy>=1.24"
         }
       }
+    },
+    {
+      "sourceNotebookId": "nb-def456",
+      "name": "Sales Forecasting",
+      "description": "",
+      "filePath": "notebooks/nb-def456.ipynb",
+      "exportedAt": "2024-01-15T10:30:12Z",
+      "parameters": {},
+      "metadata": {},
+      "environmentConfiguration": null
     }
   ]
 }
@@ -395,44 +427,45 @@ class ExportedNotebook:
     description: str
     file_content: bytes
     file_path: str  # relative path in bundle: notebooks/{sourceNotebookId}.ipynb
-    exported_at: str
-    parameters: Dict[str, str]
-    metadata: Dict[str, str]
-    environment_configuration: Optional[Dict[str, Any]]
+    exported_at: str  # ISO 8601
+    parameters: Dict[str, str]  # empty dict if no parameters
+    metadata: Dict[str, str]    # empty dict if no metadata
+    environment_configuration: Optional[Dict[str, Any]]  # None if not set
 ```
 
-### NotebookImportSummary (internal dataclass)
+### NotebookSyncSummary (internal dataclass)
 
 ```python
 @dataclass
-class NotebookImportSummary:
-    """Summary of notebook import operation."""
-    imported: int = 0   # new notebooks (no previous version with same name existed)
-    updated: int = 0    # replaced existing notebook (old version deleted after new is active)
-    failed: int = 0
-    metadata_warnings: int = 0  # imported/updated but UpdateNotebook had issues
-    
+class NotebookSyncSummary:
+    """Summary of notebook sync operation."""
+    created: int = 0    # new notebooks (no previous target with matching source ID)
+    updated: int = 0    # synced to existing target notebook (in-place update)
+    failed: int = 0     # sync or UpdateNotebook error
+
+    @property
+    def total(self) -> int:
+        return self.created + self.updated + self.failed
+
     @property
     def has_failures(self) -> bool:
         return self.failed > 0
 ```
 
-### ImportResult (internal enum/dataclass)
+### SyncResult (internal dataclass)
 
 ```python
-class ImportStatus(enum.Enum):
-    IMPORTED = "imported"       # new notebook, no prior version
-    UPDATED = "updated"         # replaced existing notebook with same name
-    FAILED = "failed"
-    IMPORTED_WITH_WARNING = "imported_with_warning"
-    UPDATED_WITH_WARNING = "updated_with_warning"
+class SyncStatus(enum.Enum):
+    CREATED = "created"    # new notebook, no prior target existed
+    UPDATED = "updated"    # synced to existing target (in-place update)
+    FAILED = "failed"      # sync or UpdateNotebook error
 
 @dataclass
-class ImportResult:
-    status: ImportStatus
-    notebook_name: str
+class SyncResult:
+    status: SyncStatus
+    source_notebook_id: str
+    target_notebook_id: Optional[str] = None  # set on success
     message: str = ""
-    old_version_deleted: bool = False
 ```
 
 ### Manifest YAML Configuration
@@ -442,19 +475,23 @@ class ImportResult:
 content:
   notebooks:
     enabled: true
-    include_names:           # optional, notebook names only (case-sensitive)
-      - "My Notebook"
-      - "Analysis Pipeline"
-    exclude_names:           # optional, notebook names only (case-sensitive)
-      - "Draft Notebook"
+    notebook_ids:              # optional — list of source notebook IDs
+      - "nb-abc123"
+      - "nb-def456"
 
 # deployment_configuration per stage (target configuration for deploy)
 stages:
   test:
     deployment_configuration:
       notebooks:
-        disable: false   # optional, default false
+        disable: false   # optional, default false — follows catalog pattern
 ```
+
+### Validation Rules
+
+- `notebook_ids` entries must match pattern `[a-zA-Z0-9_-]{1,36}`
+- `notebook_ids` if present must contain at least one entry (empty list = validation error)
+- `enabled: false` (or absent) skips notebook export regardless of `notebook_ids`
 
 ---
 
@@ -462,23 +499,23 @@ stages:
 
 *A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
 
-### Property 1: Include/Exclude Name-Only Filter Algebra
+### Property 1: Fail-Fast Validation Completeness
 
-*For any* list of notebooks (each with a name), any `include_names` filter list, and any `exclude_names` filter list, the resulting filtered set SHALL equal: first select notebooks where the notebook name matches any entry in `include_names` via case-sensitive exact match (or all notebooks if `include_names` is None), then remove notebooks where the notebook name matches any entry in `exclude_names` via case-sensitive exact match. No ID matching is performed.
+*For any* list of notebook IDs where at least one ID is invalid (GetNotebook returns ResourceNotFoundException), the bundle command SHALL (a) validate every ID in the list before starting any export, (b) collect all invalid IDs, (c) fail with an error message listing all invalid IDs, and (d) produce zero exported notebook files.
 
-**Validates: Requirements 1.5, 1.7, 1.8, 9.2**
+**Validates: Requirements 1.4, 1.5, 2.1, 2.2**
 
 ### Property 2: Pagination Completeness
 
-*For any* paginated ListNotebooks response sequence (where each page may contain a nextToken pointing to the next page), the exporter SHALL collect all notebook entries across all pages, and the total count SHALL equal the sum of entries across all individual pages.
+*For any* paginated ListNotebooks response sequence (where each page may contain a `nextToken` pointing to the next page), the collector SHALL accumulate all notebook entries across all pages, and the total count SHALL equal the sum of entries across all individual pages.
 
-**Validates: Requirements 2.2**
+**Validates: Requirements 2.3, 2.4, 9.1**
 
-### Property 3: Export Manifest Schema Completeness
+### Property 3: Export Manifest Schema Correctness
 
-*For any* set of exported notebooks (including the empty set), the serialized `notebook_export_manifest.json` SHALL contain exactly two top-level keys (`metadata` and `notebooks`), the `metadata` object SHALL contain `sourceProjectId`, `sourceDomainId`, `exportTimestamp` (ISO 8601), and `notebookCount` (equal to array length), and each entry in the `notebooks` array SHALL contain all required fields: `sourceNotebookId`, `name`, `description`, `filePath`, `exportedAt`, `parameters`, `metadata`, and `environmentConfiguration`.
+*For any* set of exported notebooks (including the empty set), the serialized `notebook_export_manifest.json` SHALL contain exactly two top-level keys (`metadata` and `notebooks`), the `metadata` object SHALL contain `sourceProjectId`, `sourceDomainId`, `exportTimestamp` (ISO 8601), and `notebookCount` (equal to the length of the `notebooks` array), and each entry in the `notebooks` array SHALL contain all required fields: `sourceNotebookId`, `name`, `description`, `filePath`, `exportedAt`, `parameters`, `metadata`, and `environmentConfiguration`.
 
-**Validates: Requirements 3.2, 3.3, 3.4**
+**Validates: Requirements 3.2, 3.3, 3.4, 3.6**
 
 ### Property 4: Bundle Internal Consistency
 
@@ -488,9 +525,9 @@ stages:
 
 ### Property 5: Client Token Determinism and Bounds
 
-*For any* notebook name and deployment timestamp, the generated client token SHALL be deterministic (same inputs → same output), SHALL not exceed 64 characters in length, and distinct (name, timestamp) pairs SHALL produce distinct tokens.
+*For any* source notebook ID and deployment timestamp, the generated client token SHALL be deterministic (same inputs produce same output), SHALL not exceed 64 characters in length, and distinct (sourceNotebookId, timestamp) pairs SHALL produce distinct tokens.
 
-**Validates: Requirements 4.6**
+**Validates: Requirements 4.7**
 
 ### Property 6: Manifest Validation Rejects Malformed Input
 
@@ -498,29 +535,43 @@ stages:
 
 **Validates: Requirements 7.4**
 
-### Property 7: UpdateNotebook Omits Empty Fields
+### Property 7: UpdateNotebook Kwargs Construction
 
-*For any* notebook manifest entry, the constructed `UpdateNotebook` API kwargs SHALL omit the `parameters` key when the entry's parameters is an empty dict, SHALL omit the `metadata` key when the entry's metadata is an empty dict, and SHALL omit the `environmentConfiguration` key when the entry's environmentConfiguration is None.
+*For any* notebook manifest entry, the constructed `UpdateNotebook` API kwargs SHALL:
+- Always include `metadata` with the key `smus-cicd-source-notebook-id` set to the entry's `sourceNotebookId` (merged with any existing metadata from the manifest)
+- Omit the `parameters` key when the entry's parameters is an empty dict
+- Include the `metadata` key even when the entry's metadata is an empty dict (containing only the tracking key)
+- Omit the `environmentConfiguration` key when the entry's environmentConfiguration is None
+- Always include `name` and `description`
 
-**Validates: Requirements 10.2, 10.3, 10.4**
+**Validates: Requirements 10.1, 10.2, 10.3, 10.4, 10.5**
 
 ### Property 8: Exponential Backoff Intervals
 
-*For any* sequence of N poll attempts, the delay before attempt i (0-indexed, starting from i=1) SHALL equal min(initial_interval × 2^(i-1), max_interval), where initial_interval and max_interval are configurable parameters.
+*For any* sequence of N poll attempts (0-indexed), the delay before attempt i (starting from i=1) SHALL equal min(initial_interval × 2^(i-1), max_interval), where initial_interval defaults to 1 second and max_interval defaults to 30 seconds.
 
-**Validates: Requirements 2.5, 7.6**
+**Validates: Requirements 2.6, 7.6**
 
-### Property 9: Upsert Ordering Safety
+### Property 9: Source-to-Target Metadata Mapping Correctness
 
-*For any* notebook import where an old version with the same name exists in the target project, the old version SHALL NOT be deleted until the new notebook has reached ACTIVE status AND the UpdateNotebook call has completed (successfully or with a warning). If the new notebook fails to reach ACTIVE status, the old version SHALL NOT be deleted.
+*For any* set of target notebooks (each with an optional `metadata` dict), the source-to-target mapping SHALL include exactly those target notebooks whose metadata contains the key `smus-cicd-source-notebook-id`, and for each such notebook the mapping SHALL be `{metadata["smus-cicd-source-notebook-id"] → targetNotebookId}`. Notebooks without this metadata key SHALL NOT appear in the mapping.
 
-**Validates: Requirements 4.10, 10.1**
+**Validates: Requirements 4.3, 9.2, 9.3**
 
-### Property 10: Unique Name Enforcement
+### Property 10: Destroy Metadata-Based Filtering
 
-*For any* set of notebooks selected for export (after applying include_names/exclude_names filters), if two or more notebooks share the same name (case-sensitive), the bundle operation SHALL fail with a non-zero exit code and SHALL NOT produce any exported notebook files or manifest.
+*For any* set of target notebooks with metadata, and any optional `notebook_ids` list from the manifest:
+- If `notebook_ids` is omitted: all target notebooks whose metadata contains `smus-cicd-source-notebook-id` SHALL be included in the destruction plan
+- If `notebook_ids` is specified: only target notebooks whose `smus-cicd-source-notebook-id` metadata value is present in the `notebook_ids` list SHALL be included in the destruction plan
+- Target notebooks WITHOUT the `smus-cicd-source-notebook-id` metadata key SHALL never be included regardless of configuration
 
-**Validates: Requirements 11.1, 11.2**
+**Validates: Requirements 9.2, 9.3, 9.4, 9.5**
+
+### Property 11: Summary Count Invariant
+
+*For any* notebook sync operation processing N notebooks from the manifest, the sum `created + updated + failed` SHALL equal N (the total number of notebooks attempted).
+
+**Validates: Requirements 4.12, 10.7**
 
 ---
 
@@ -530,29 +581,28 @@ stages:
 
 | Error Source | Behavior | Impact |
 |---|---|---|
+| GetNotebook fails for ID in `notebook_ids` (ResourceNotFoundException) | Collect invalid ID, continue validating remaining IDs, then fail bundle with all invalid IDs listed | Bundle fails (fail-fast) |
 | ListNotebooks API failure (export) | Raise exception, abort export | Bundle fails |
-| GetNotebook API failure (single) | Log warning, skip notebook metadata | Export continues |
-| StartNotebookExport failure (single) | Log error, count as failed, continue | Export continues |
-| Export polling timeout (single) | Log warning, count as failed, continue | Export continues |
+| StartNotebookExport failure (single) | Log error with notebook ID, count as failed, continue | Export continues |
+| Export polling timeout (single) | Log warning with notebook ID and elapsed time, count as failed, continue | Export continues |
 | S3 download failure (single) | Log error, count as failed, continue | Export continues |
-| S3 upload failure (single) | Log error, skip import, continue | Import continues |
-| ListNotebooks API failure (import) | Log error, skip old-version detection for that notebook | Import continues |
-| StartNotebookImport error (any) | Log error, count as failed, continue | Import continues |
-| GetNotebook polling timeout (post-import) | Log warning, count as failed, continue | Import continues |
-| UpdateNotebook ValidationException | Log warning, count as metadata_warning | Import continues |
-| UpdateNotebook other error | Log warning, count as metadata_warning | Import continues |
-| DeleteNotebook (old version) failure | Log warning, do NOT count notebook as failed | Import continues |
-| ThrottlingException (any API) | Retry with exponential backoff (max 3) | Transparent retry |
-| Missing S3 connection (deploy) | Raise error, skip all notebook imports | Deploy reports failure |
-| Missing manifest keys (deploy) | Raise validation error, skip imports | Deploy reports failure |
-| DeleteNotebook ResourceNotFoundException (destroy) | Record as not_found | Destroy continues |
-| DeleteNotebook other error (destroy) | Record as error, continue | Destroy continues |
+| S3 upload failure (single, deploy) | Log error with notebook ID and S3 key, skip sync for that notebook, continue | Sync continues |
+| Missing S3 connection (deploy) | Raise error, skip all notebook sync operations | Deploy reports failure |
+| StartNotebookSync error (non-ResourceNotFoundException) | Log error with notebook ID, count as FAILED, continue | Sync continues |
+| StartNotebookSync with notebookId → ResourceNotFoundException | Log warning (target may have been manually deleted), retry WITHOUT notebookId (create new) | Transparent retry |
+| UpdateNotebook any error | Log notebook ID and error details, count as FAILED | Sync continues |
+| Missing manifest keys (deploy) | Raise validation error before any API calls | Deploy reports failure |
+| Missing filePath in bundle (deploy) | Log error with notebook ID and path, count as FAILED, continue | Sync continues |
+| ThrottlingException (any DataZone API) | Retry with exponential backoff (initial 1s, doubling, max 3 retries) | Transparent retry |
+| ListNotebooks API failure (destroy validation) | Report error, fail validation for that stage | Destroy aborts |
+| DeleteNotebook ResourceNotFoundException (destroy) | Record as `not_found`, continue | Destroy continues |
+| DeleteNotebook other error (destroy) | Log name and error, record as `error`, continue | Destroy continues |
 
 ### Exit Code Rules
 
-- **Bundle command**: Non-zero if ANY notebook failed to export (requirement 2.12)
-- **Deploy command**: Non-zero if ANY notebook failed to import OR update (requirement 4.14, 7.5)
-- **Destroy command**: Reports counts; exits non-zero if any unexpected errors
+- **Bundle command**: Non-zero if `notebook_ids` contains any invalid IDs (fail-fast), OR if ANY notebook failed to export
+- **Deploy command**: Non-zero if ANY notebook failed to sync OR UpdateNotebook failed
+- **Destroy command**: Reports counts (deleted, not_found, error); exits non-zero if any unexpected errors
 
 ### Throttling Retry Strategy
 
@@ -560,7 +610,7 @@ All DataZone API calls are wrapped with a retry decorator:
 
 ```python
 def _retry_on_throttle(func, max_retries=3, initial_delay=1.0):
-    """Retry on ThrottlingException with exponential backoff."""
+    """Retry on ThrottlingException with exponential backoff + jitter."""
     for attempt in range(max_retries + 1):
         try:
             return func()
@@ -578,24 +628,25 @@ def _retry_on_throttle(func, max_retries=3, initial_delay=1.0):
 
 ### Property-Based Testing (Hypothesis)
 
-The following properties will be tested using the `hypothesis` library (already in dev dependencies) with a minimum of 100 iterations per property. The tests focus on pure functions that are decoupled from AWS API calls.
+The following properties will be tested using the `hypothesis` library with a minimum of 100 iterations per property. The tests focus on pure functions that are decoupled from AWS API calls.
 
 **Test file**: `tests/unit/helpers/test_notebook_properties.py`
 
 | Property | Function Under Test | Generator Strategy |
 |---|---|---|
-| P1: Name-Only Filter Algebra | `_apply_filters()` | Random notebook lists (with names) + random include_names/exclude_names lists |
-| P2: Pagination Completeness | `_list_all_notebooks()` (mocked paginator) | Random page counts and page sizes |
-| P3: Manifest Schema | `_build_export_manifest()` | Random ExportedNotebook lists |
-| P4: Bundle Consistency | Integration of export pipeline | Random notebook sets |
-| P5: Client Token | `_generate_client_token()` | Random names + timestamps |
-| P6: Manifest Validation | `_validate_notebook_manifest()` | Random dicts with missing keys |
-| P7: UpdateNotebook kwargs | `_build_update_kwargs()` | Random manifest entries with empty/non-empty fields |
-| P8: Backoff Intervals | Backoff calculation function | Random poll counts |
-| P9: Upsert Ordering | `_import_single_notebook()` (mocked APIs) | Random notebooks with/without old versions |
-| P10: Unique Name Enforcement | `_warn_duplicate_names()` | Random notebook lists with intentional duplicates |
+| P1: Fail-Fast Validation | `_validate_notebook_ids()` (mocked GetNotebook) | Random lists of IDs with random invalid subsets |
+| P2: Pagination Completeness | `_list_all_notebooks()` (mocked paginator) | Random page counts (1-10) and page sizes (1-50) |
+| P3: Manifest Schema | `_build_export_manifest()` | Random ExportedNotebook lists (0-20 entries) |
+| P4: Bundle Consistency | End-to-end export pipeline (mocked APIs) | Random notebook sets with file content |
+| P5: Client Token | `_generate_client_token()` | Random source IDs + timestamps |
+| P6: Manifest Validation | `_validate_notebook_manifest()` | Random dicts with strategically missing keys |
+| P7: UpdateNotebook kwargs | `_build_update_kwargs()` | Random manifest entries with various empty/None/populated fields |
+| P8: Backoff Intervals | Backoff calculation function | Random poll counts (1-20) |
+| P9: Metadata Mapping | `_discover_target_notebooks()` (mocked APIs) | Random notebooks with/without metadata key |
+| P10: Destroy Filtering | `_discover_notebooks()` (mocked APIs) | Random target notebooks + random notebook_ids lists |
+| P11: Summary Count | NotebookSyncSummary accumulation | Random sequences of SyncResult outcomes |
 
-**Configuration**: Each test runs minimum 100 iterations via `@settings(max_examples=100)`.
+**Configuration**: Each test uses `@settings(max_examples=100)`.
 
 **Tag format**: `# Feature: data-notebooks-support, Property {N}: {description}`
 
@@ -603,53 +654,43 @@ The following properties will be tested using the `hypothesis` library (already 
 
 **Test files**:
 - `tests/unit/helpers/test_notebook_export.py` — Export logic with mocked APIs
-- `tests/unit/helpers/test_notebook_import.py` — Import logic with mocked APIs
+- `tests/unit/helpers/test_notebook_import.py` — Import/sync logic with mocked APIs
 - `tests/unit/commands/test_notebook_dry_run.py` — Dry-run checker
 - `tests/unit/commands/test_notebook_destroy.py` — Destroy validation/execution
 
 **Key unit test scenarios**:
-- Manifest parsing with notebooks section (enabled/disabled, include_names/exclude_names)
-- Export flow happy path (mock ListNotebooks → GetNotebook → StartNotebookExport → GetNotebookExport → S3 download)
-- Export with partial failures (some notebooks fail, others succeed)
-- Export with duplicate notebook names (bundle fails with error listing duplicates)
-- Import upsert flow happy path: ListNotebooks finds old version → upload → StartNotebookImport → poll ACTIVE → UpdateNotebook → DeleteNotebook (old)
-- Import new notebook (no old version exists)
-- Import with missing file in bundle (count as failed)
-- Import with UpdateNotebook failure (metadata warning, not failed)
-- Import with DeleteNotebook failure for old version (warning, not failed)
-- Import with manifest containing duplicate names (validation error, import rejected)
-- Destroy validation discovers notebooks with name-only filtering
-- Destroy execution with mixed results (deleted, not_found, error)
-- Dry-run checks permissions (including DeleteNotebook and ListNotebooks) and connectivity
-- Empty include_names/exclude_names list raises validation error
+- Manifest parsing: `content.notebooks` section (enabled/disabled, with/without notebook_ids)
+- Fail-fast: `notebook_ids` with mix of valid/invalid IDs → error lists all invalid
+- Fail-fast: `notebook_ids` with empty list → validation error
+- Export happy path: GetNotebook validates → StartNotebookExport → GetNotebookExport → S3 download
+- Export partial failure: some notebooks fail export, others succeed
+- Sync happy path: upload → discover targets → StartNotebookSync (create) → UpdateNotebook
+- Sync update path: existing target found via metadata → StartNotebookSync WITH notebookId
+- Sync fallback: StartNotebookSync with notebookId → ResourceNotFoundException → retry without
+- Sync with UpdateNotebook failure → notebook counts as FAILED (not warning)
+- Sync with missing file in bundle → count as FAILED
+- Deploy integration: `deployment_configuration.notebooks.disable: true` → skip
+- Deploy integration: no `notebook_export_manifest.json` in bundle → skip silently
+- Destroy: discovers notebooks by metadata, filters by `notebook_ids` if specified
+- Destroy: handles ResourceNotFoundException (not_found) and other errors
+- Destroy: source environment (no metadata on notebooks) → zero deletions
+- Dry-run: checks S3 connection, IAM permissions, reports notebook count
 
 ### Integration Tests / Example
 
-**Example directory**: `examples/notebook-import-export/` (mirrors the existing `examples/catalog-import-export/` structure)
+**Example directory**: `examples/analytic-workflow/data-notebooks/` (existing structure)
 
-**Example structure**:
-```
-examples/notebook-import-export/
-├── manifest.yaml           # content.notebooks config with include_names
-├── app_tests/
-│   └── test_notebook_lifecycle.py  # End-to-end test
-└── README.md               # Example documentation
-```
-
-**Test file**: `examples/notebook-import-export/app_tests/test_notebook_lifecycle.py`
-
-End-to-end test with real AWS APIs:
-1. Create test notebooks in source project with known description and custom parameters
-2. Bundle with notebook export
-3. Deploy to target project (upsert — first time creates new)
-4. Verify notebooks exist in target with correct name, description, and parameters
-5. Update the source notebook description and add new custom parameters (differentiate versions)
-6. Bundle again (creates new version with updated metadata)
-7. Deploy again (upsert — replaces existing, old version deleted)
-8. Verify notebooks in target have the updated description and parameters (version update confirmed)
-9. Verify old versions were deleted (only one notebook per name remains)
-10. Destroy notebooks in target
-11. Verify notebooks are removed
+**End-to-end test scenario** (real AWS APIs):
+1. Create test notebooks in source project with known parameters and metadata
+2. Bundle with `content.notebooks.enabled: true` and `notebook_ids` pointing to specific IDs
+3. Deploy to target project → first run creates new notebooks
+4. Verify target notebooks have correct name, description, parameters, environmentConfiguration
+5. Verify target notebooks have `smus-cicd-source-notebook-id` in metadata
+6. Deploy again → second run updates existing notebooks in-place (StartNotebookSync with notebookId)
+7. Verify run history is preserved (notebook ID unchanged between deploys)
+8. Verify metadata and parameters are updated
+9. Destroy notebooks in target (filtered by metadata)
+10. Verify only CI/CD-managed notebooks are deleted; manually created ones remain
 
 ### Test Utilities
 
@@ -673,7 +714,7 @@ def sample_notebook_manifest():
             "filePath": "notebooks/nb-001.ipynb",
             "exportedAt": "2024-01-15T10:30:00Z",
             "parameters": {"key": "value"},
-            "metadata": {},
+            "metadata": {"owner": "test-team"},
             "environmentConfiguration": None,
         }],
     }

--- a/.kiro/specs/data-notebooks-support/design.md
+++ b/.kiro/specs/data-notebooks-support/design.md
@@ -1,0 +1,690 @@
+# Design Document: Data Notebooks Support
+
+## Overview
+
+This feature adds native Data Notebooks support to the SMUS CI/CD CLI, enabling promotion of SageMaker Unified Studio notebooks across environments (dev → test → prod) using the DataZone Notebook Import/Export APIs. The implementation follows the existing CLI architecture patterns — specifically mirroring the catalog import/export approach — with two new helper modules (`notebook_export.py` and `notebook_import.py`) and integration into the existing `bundle`, `deploy`, `destroy`, and `dry-run` commands.
+
+### Design Goals
+
+- **Consistency**: Follow the same module structure, error handling, and reporting patterns established by the catalog import/export feature
+- **Resilience**: Individual notebook failures do not block the entire export/import operation; failures are collected and reported
+- **Upsert Safety**: Import uses a create-or-replace strategy — old versions are only deleted after the new version is confirmed ACTIVE and updated
+- **Idempotency**: Import operations use client tokens to prevent duplicate notebook creation on retries
+- **Extensibility**: The `content.notebooks` manifest section and `deployment_configuration.notebooks` section follow the same convention as `content.catalog` and `deployment_configuration.catalog`
+
+### Key Design Decisions
+
+1. **Separate helper modules** rather than embedding logic in command files — follows `catalog_export.py` / `catalog_import.py` pattern
+2. **JSON manifest inside the bundle** (`notebooks/notebook_export_manifest.json`) — mirrors `catalog/catalog_export.json` approach
+3. **Async polling with exponential backoff** for both export (GetNotebookExport) and post-import status (GetNotebook) — avoids hammering APIs
+4. **Notebook ID used directly for file paths** — the notebook ID (pattern: `[a-zA-Z0-9_-]{1,36}`) is inherently safe for both filesystem and S3 key usage, eliminating the need for name sanitization
+5. **Add `notebook` resource type** to the existing `DEPLOY_RESOURCE_TYPES` / `DESTROY_SUPPORTED_RESOURCE_TYPES` registries for destroy support
+6. **Upsert strategy (create-or-replace)** — StartNotebookImport always creates a new notebook (duplicate names allowed), then old version with same name is deleted only after new one is ACTIVE + metadata-updated. This ensures zero data loss.
+7. **Name-only filtering** — `include_names` and `exclude_names` match by notebook name only (case-sensitive exact match), no ID matching
+
+---
+
+## Architecture
+
+### High-Level Data Flow
+
+```mermaid
+graph TD
+    subgraph BundlePhase["Bundle Phase (source project)"]
+        A[Bundle Command] --> B[NotebookExporter]
+        B --> C[ListNotebooks API]
+        B --> D[GetNotebook API]
+        B --> E[StartNotebookExport API]
+        B --> F[GetNotebookExport API - polling]
+        F --> G[Download .ipynb from S3]
+        G --> H[Write to notebooks/ in bundle ZIP]
+        D --> I[Write notebook_export_manifest.json]
+    end
+
+    subgraph DeployPhase["Deploy Phase (target project) - Upsert"]
+        J[Deploy Command] --> K[NotebookImporter]
+        K --> K1[ListNotebooks - find old versions by name]
+        K1 --> L[Upload .ipynb to target S3]
+        L --> M[StartNotebookImport API - always creates new]
+        M --> N[Poll GetNotebook until ACTIVE]
+        N --> O[UpdateNotebook API - metadata porting]
+        O --> O1[DeleteNotebook API - remove old version]
+        O1 --> P[Report Summary: new/updated/failed]
+    end
+
+    subgraph DestroyPhase["Destroy Phase (target project)"]
+        Q[Destroy Command] --> R[ListNotebooks API]
+        R --> R1[Apply include_names/exclude_names filters]
+        R1 --> S[Display destruction plan]
+        S --> T[DeleteNotebook API per notebook]
+    end
+
+    H --> |bundle.zip| J
+    I --> |bundle.zip| J
+```
+
+### Module Placement
+
+```
+src/smus_cicd/
+├── helpers/
+│   ├── notebook_export.py          # NEW: Notebook export logic for bundle
+│   ├── notebook_import.py          # NEW: Notebook import logic for deploy
+│   └── ...
+├── commands/
+│   ├── bundle.py                   # MODIFIED: call notebook_export when enabled
+│   ├── deploy.py                   # MODIFIED: call notebook_import after catalog
+│   ├── destroy.py                  # MODIFIED: (via destroy_validator/executor)
+│   └── dry_run/
+│       └── checkers/
+│           └── notebook_checker.py # NEW: Dry-run validation for notebooks
+├── application/
+│   └── application_manifest.py     # MODIFIED: add NotebookConfig dataclass
+└── resource_types.py               # MODIFIED: add "notebook" resource type
+```
+
+### Integration Points
+
+| Command | Integration Point | Action |
+|---------|-------------------|--------|
+| `bundle` | After catalog export | Call `export_notebooks()` if `content.notebooks.enabled` |
+| `deploy` | After catalog import, before bootstrap | Call `import_notebooks()` if manifest present |
+| `destroy` | Validation phase | Call `ListNotebooks` to discover notebooks, apply `include_names`/`exclude_names` filters |
+| `destroy` | Execution phase | Call `DeleteNotebook` for each filtered notebook |
+| `dry-run` | After catalog checker | `NotebookChecker.check()` validates prerequisites |
+
+---
+
+## Components and Interfaces
+
+### 1. Manifest Configuration (`application_manifest.py`)
+
+New dataclass for the `content.notebooks` section:
+
+```python
+@dataclass
+class NotebookConfig:
+    """Notebook export configuration for bundle."""
+    enabled: bool = False
+    include_names: Optional[List[str]] = None  # notebook names only (case-sensitive exact match)
+    exclude_names: Optional[List[str]] = None  # notebook names only (case-sensitive exact match)
+```
+
+**Parsing**: Added to `ContentConfig`:
+
+```python
+@dataclass
+class ContentConfig:
+    storage: List[StorageConfig] = field(default_factory=list)
+    git: List[GitContentConfig] = field(default_factory=list)
+    catalog: Optional[CatalogConfig] = None
+    notebooks: Optional[NotebookConfig] = None  # NEW
+    quicksight: List[QuickSightDashboardConfig] = field(default_factory=list)
+    workflows: List[Dict[str, Any]] = field(default_factory=list)
+```
+
+**Deployment configuration** (per-stage disable):
+
+```python
+@dataclass
+class DeploymentConfiguration:
+    storage: List[StorageConfig] = field(default_factory=list)
+    git: List[GitTargetConfig] = field(default_factory=list)
+    catalog: Optional[Dict[str, Any]] = None
+    notebooks: Optional[Dict[str, Any]] = None  # NEW: {"disable": bool}
+    quicksight: Optional[Dict[str, Any]] = None
+```
+
+### 2. NotebookExporter (`helpers/notebook_export.py`)
+
+```python
+def export_notebooks(
+    domain_id: str,
+    project_id: str,
+    region: str,
+    include_names: Optional[List[str]] = None,
+    exclude_names: Optional[List[str]] = None,
+    polling_timeout: int = 300,
+) -> Tuple[List[ExportedNotebook], NotebookExportManifest]:
+    """
+    Export notebooks from a DataZone project.
+
+    Args:
+        domain_id: DataZone domain identifier
+        project_id: DataZone project identifier
+        region: AWS region
+        include_names: Optional list of notebook names to include (case-sensitive exact match)
+        exclude_names: Optional list of notebook names to exclude (case-sensitive exact match)
+        polling_timeout: Max seconds to wait per notebook export (default 300)
+
+    Returns:
+        Tuple of (list of exported notebook file contents, manifest object)
+
+    Raises:
+        Exception: If ListNotebooks API fails entirely
+    """
+```
+
+**Internal functions:**
+
+```python
+def _list_all_notebooks(client, domain_id: str, project_id: str) -> List[Dict]:
+    """List all active notebooks with pagination."""
+
+def _apply_filters(
+    notebooks: List[Dict],
+    include_names: Optional[List[str]],
+    exclude_names: Optional[List[str]],
+) -> List[Dict]:
+    """Apply include_names/exclude_names filters by notebook name only.
+    Include first, then exclude. Case-sensitive exact match."""
+
+def _matches_name_filter(notebook: Dict, filter_names: List[str]) -> bool:
+    """Check if notebook name matches any entry in the filter list (case-sensitive exact match)."""
+
+def _export_single_notebook(
+    client, s3_client, domain_id: str, project_id: str,
+    notebook: Dict, polling_timeout: int,
+) -> Optional[ExportedNotebook]:
+    """Export a single notebook, poll for completion, download file."""
+
+def _poll_export_status(
+    client, domain_id: str, export_id: str, notebook_id: str,
+    polling_timeout: int,
+) -> Optional[str]:
+    """Poll GetNotebookExport with exponential backoff. Returns S3 URI or None."""
+
+def _build_export_manifest(
+    exported: List[ExportedNotebook],
+    domain_id: str,
+    project_id: str,
+) -> Dict[str, Any]:
+    """Build the notebook_export_manifest.json structure."""
+
+def _warn_duplicate_names(notebooks: List[Dict]) -> None:
+    """Raise error if any duplicate notebook names in the filtered set.
+    This enforces unique names to ensure reliable upsert behavior."""
+```
+
+### 3. NotebookImporter (`helpers/notebook_import.py`)
+
+```python
+def import_notebooks(
+    domain_id: str,
+    project_id: str,
+    region: str,
+    manifest_data: Dict[str, Any],
+    notebook_files: Dict[str, bytes],
+    s3_uri: str,
+) -> NotebookImportSummary:
+    """
+    Import notebooks into a target DataZone project using upsert strategy.
+
+    Upsert flow per notebook:
+    1. ListNotebooks on target to find existing notebook(s) with same name ("old versions")
+    2. Upload .ipynb to S3
+    3. StartNotebookImport (always creates new notebook; duplicate names allowed)
+    4. Poll GetNotebook until ACTIVE
+    5. UpdateNotebook (port metadata from manifest)
+    6. Delete old version(s) via DeleteNotebook (only after new is ACTIVE + updated)
+
+    Args:
+        domain_id: Target domain identifier
+        project_id: Target project identifier
+        region: AWS region
+        manifest_data: Parsed notebook_export_manifest.json
+        notebook_files: Dict mapping filePath -> file content bytes
+        s3_uri: Target S3 URI from default.s3_shared connection
+
+    Returns:
+        NotebookImportSummary with counts (new, updated, failed)
+
+    Raises:
+        ValidationError: If manifest structure is invalid
+        ConnectionError: If S3 connection is missing/invalid
+    """
+```
+
+**Internal functions:**
+
+```python
+def _validate_notebook_manifest(manifest_data: Dict[str, Any]) -> None:
+    """Validate manifest has required metadata and notebooks keys."""
+
+def _list_existing_notebooks_by_name(
+    client, domain_id: str, project_id: str,
+) -> Dict[str, List[str]]:
+    """List all ACTIVE notebooks in target project, return dict mapping
+    name -> list of notebook IDs. Used for old version detection."""
+
+def _find_old_versions(
+    existing_by_name: Dict[str, List[str]], notebook_name: str,
+) -> List[str]:
+    """Return list of existing notebook IDs with the same name (old versions to delete)."""
+
+def _upload_notebook_to_s3(
+    s3_client, s3_uri: str, source_notebook_id: str, content: bytes,
+) -> str:
+    """Upload .ipynb file to S3 using notebook ID as the key and return the full S3 URI.
+    Overwrites any existing file at the same key (safe for re-deploys)."""
+
+def _generate_client_token(notebook_name: str, timestamp: str) -> str:
+    """Generate deterministic idempotent client token, max 64 chars."""
+
+def _import_single_notebook(
+    client, s3_client, domain_id: str, project_id: str,
+    notebook_entry: Dict, notebook_content: bytes, s3_uri: str,
+    deployment_timestamp: str, old_version_ids: List[str],
+) -> ImportResult:
+    """Import a single notebook using upsert:
+    upload -> StartNotebookImport -> poll ACTIVE -> UpdateNotebook -> delete old versions."""
+
+def _poll_notebook_active(
+    client, domain_id: str, notebook_id: str, timeout: int = 120,
+) -> bool:
+    """Poll GetNotebook until status is ACTIVE. Returns True if reached ACTIVE."""
+
+def _apply_notebook_metadata(
+    client, domain_id: str, notebook_id: str, notebook_entry: Dict,
+) -> bool:
+    """Call UpdateNotebook API to apply parameters, metadata, and environmentConfiguration
+    from the manifest entry. Returns True if successful, False if warning occurred."""
+
+def _build_update_kwargs(notebook_entry: Dict) -> Dict[str, Any]:
+    """Build UpdateNotebook API kwargs, omitting empty fields."""
+
+def _delete_old_versions(
+    client, domain_id: str, old_version_ids: List[str], notebook_name: str,
+) -> None:
+    """Delete old notebook versions. Logs warnings on failure but does not raise."""
+
+def _warn_manifest_duplicates(manifest_data: Dict[str, Any]) -> None:
+    """Raise validation error if manifest contains multiple entries with the same name.
+    Duplicate names should have been caught at bundle time, but validate here as a safety check."""
+```
+
+### 4. Dry-Run Checker (`commands/dry_run/checkers/notebook_checker.py`)
+
+```python
+class NotebookChecker:
+    """Validates notebook import prerequisites during dry-run."""
+
+    def check(self, context: DryRunContext) -> List[Finding]:
+        """
+        Checks:
+        1. S3 connection (default.s3_shared) exists and bucket is accessible
+        2. IAM permissions: datazone:StartNotebookImport, datazone:UpdateNotebook,
+           datazone:GetNotebook, datazone:DeleteNotebook, datazone:ListNotebooks,
+           s3:PutObject
+        3. Report notebook count from manifest
+        """
+```
+
+### 5. Destroy Integration
+
+**destroy_validator.py** addition:
+
+```python
+def _discover_notebooks(
+    client, domain_id: str, project_id: str,
+    include_names: Optional[List[str]], exclude_names: Optional[List[str]],
+) -> List[ResourceToDelete]:
+    """List all ACTIVE notebooks in the project, apply include_names/exclude_names
+    filters (name-only matching), return matching notebooks for destruction."""
+```
+
+**destroy_executor.py** addition:
+
+```python
+def _delete_notebook(client, domain_id: str, notebook_id: str) -> ResourceResult:
+    """Delete a single notebook resource."""
+```
+
+**destroy_models.py** update:
+
+```python
+DESTROY_SUPPORTED_RESOURCE_TYPES = frozenset({
+    ...,
+    "notebook",  # NEW
+})
+```
+
+---
+
+## Data Models
+
+### NotebookExportManifest (JSON in bundle)
+
+```json
+{
+  "metadata": {
+    "sourceProjectId": "string",
+    "sourceDomainId": "string",
+    "exportTimestamp": "2024-01-15T10:30:00Z",
+    "notebookCount": 3
+  },
+  "notebooks": [
+    {
+      "sourceNotebookId": "abc123",
+      "name": "My Analysis Notebook",
+      "description": "Exploratory analysis",
+      "filePath": "notebooks/abc123.ipynb",
+      "exportedAt": "2024-01-15T10:30:00Z",
+      "parameters": {"key1": "value1"},
+      "metadata": {"owner": "team-a"},
+      "environmentConfiguration": {
+        "imageVersion": "v2.0",
+        "packageConfig": {
+          "packageManager": "pip",
+          "packageSpecification": "pandas>=2.0\nnumpy>=1.24"
+        }
+      }
+    }
+  ]
+}
+```
+
+### ExportedNotebook (internal dataclass)
+
+```python
+@dataclass
+class ExportedNotebook:
+    """Result of a single notebook export operation."""
+    source_notebook_id: str
+    name: str
+    description: str
+    file_content: bytes
+    file_path: str  # relative path in bundle: notebooks/{sourceNotebookId}.ipynb
+    exported_at: str
+    parameters: Dict[str, str]
+    metadata: Dict[str, str]
+    environment_configuration: Optional[Dict[str, Any]]
+```
+
+### NotebookImportSummary (internal dataclass)
+
+```python
+@dataclass
+class NotebookImportSummary:
+    """Summary of notebook import operation."""
+    imported: int = 0   # new notebooks (no previous version with same name existed)
+    updated: int = 0    # replaced existing notebook (old version deleted after new is active)
+    failed: int = 0
+    metadata_warnings: int = 0  # imported/updated but UpdateNotebook had issues
+    
+    @property
+    def has_failures(self) -> bool:
+        return self.failed > 0
+```
+
+### ImportResult (internal enum/dataclass)
+
+```python
+class ImportStatus(enum.Enum):
+    IMPORTED = "imported"       # new notebook, no prior version
+    UPDATED = "updated"         # replaced existing notebook with same name
+    FAILED = "failed"
+    IMPORTED_WITH_WARNING = "imported_with_warning"
+    UPDATED_WITH_WARNING = "updated_with_warning"
+
+@dataclass
+class ImportResult:
+    status: ImportStatus
+    notebook_name: str
+    message: str = ""
+    old_version_deleted: bool = False
+```
+
+### Manifest YAML Configuration
+
+```yaml
+# content section (source configuration for bundle)
+content:
+  notebooks:
+    enabled: true
+    include_names:           # optional, notebook names only (case-sensitive)
+      - "My Notebook"
+      - "Analysis Pipeline"
+    exclude_names:           # optional, notebook names only (case-sensitive)
+      - "Draft Notebook"
+
+# deployment_configuration per stage (target configuration for deploy)
+stages:
+  test:
+    deployment_configuration:
+      notebooks:
+        disable: false   # optional, default false
+```
+
+---
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Include/Exclude Name-Only Filter Algebra
+
+*For any* list of notebooks (each with a name), any `include_names` filter list, and any `exclude_names` filter list, the resulting filtered set SHALL equal: first select notebooks where the notebook name matches any entry in `include_names` via case-sensitive exact match (or all notebooks if `include_names` is None), then remove notebooks where the notebook name matches any entry in `exclude_names` via case-sensitive exact match. No ID matching is performed.
+
+**Validates: Requirements 1.5, 1.7, 1.8, 9.2**
+
+### Property 2: Pagination Completeness
+
+*For any* paginated ListNotebooks response sequence (where each page may contain a nextToken pointing to the next page), the exporter SHALL collect all notebook entries across all pages, and the total count SHALL equal the sum of entries across all individual pages.
+
+**Validates: Requirements 2.2**
+
+### Property 3: Export Manifest Schema Completeness
+
+*For any* set of exported notebooks (including the empty set), the serialized `notebook_export_manifest.json` SHALL contain exactly two top-level keys (`metadata` and `notebooks`), the `metadata` object SHALL contain `sourceProjectId`, `sourceDomainId`, `exportTimestamp` (ISO 8601), and `notebookCount` (equal to array length), and each entry in the `notebooks` array SHALL contain all required fields: `sourceNotebookId`, `name`, `description`, `filePath`, `exportedAt`, `parameters`, `metadata`, and `environmentConfiguration`.
+
+**Validates: Requirements 3.2, 3.3, 3.4**
+
+### Property 4: Bundle Internal Consistency
+
+*For any* successful notebook export operation, every `filePath` value in the `notebook_export_manifest.json` SHALL correspond to a file that exists in the bundle archive, and conversely every `.ipynb` file under the `notebooks/` directory in the bundle SHALL be referenced by exactly one entry in the manifest.
+
+**Validates: Requirements 3.5**
+
+### Property 5: Client Token Determinism and Bounds
+
+*For any* notebook name and deployment timestamp, the generated client token SHALL be deterministic (same inputs → same output), SHALL not exceed 64 characters in length, and distinct (name, timestamp) pairs SHALL produce distinct tokens.
+
+**Validates: Requirements 4.6**
+
+### Property 6: Manifest Validation Rejects Malformed Input
+
+*For any* JSON object that is missing the top-level `metadata` key, the `notebooks` key, or any of `metadata.sourceProjectId`, `metadata.sourceDomainId`, `metadata.exportTimestamp`, or `metadata.notebookCount`, the manifest validation function SHALL raise a validation error before any API calls are made.
+
+**Validates: Requirements 7.4**
+
+### Property 7: UpdateNotebook Omits Empty Fields
+
+*For any* notebook manifest entry, the constructed `UpdateNotebook` API kwargs SHALL omit the `parameters` key when the entry's parameters is an empty dict, SHALL omit the `metadata` key when the entry's metadata is an empty dict, and SHALL omit the `environmentConfiguration` key when the entry's environmentConfiguration is None.
+
+**Validates: Requirements 10.2, 10.3, 10.4**
+
+### Property 8: Exponential Backoff Intervals
+
+*For any* sequence of N poll attempts, the delay before attempt i (0-indexed, starting from i=1) SHALL equal min(initial_interval × 2^(i-1), max_interval), where initial_interval and max_interval are configurable parameters.
+
+**Validates: Requirements 2.5, 7.6**
+
+### Property 9: Upsert Ordering Safety
+
+*For any* notebook import where an old version with the same name exists in the target project, the old version SHALL NOT be deleted until the new notebook has reached ACTIVE status AND the UpdateNotebook call has completed (successfully or with a warning). If the new notebook fails to reach ACTIVE status, the old version SHALL NOT be deleted.
+
+**Validates: Requirements 4.10, 10.1**
+
+### Property 10: Unique Name Enforcement
+
+*For any* set of notebooks selected for export (after applying include_names/exclude_names filters), if two or more notebooks share the same name (case-sensitive), the bundle operation SHALL fail with a non-zero exit code and SHALL NOT produce any exported notebook files or manifest.
+
+**Validates: Requirements 11.1, 11.2**
+
+---
+
+## Error Handling
+
+### Error Categories and Behavior
+
+| Error Source | Behavior | Impact |
+|---|---|---|
+| ListNotebooks API failure (export) | Raise exception, abort export | Bundle fails |
+| GetNotebook API failure (single) | Log warning, skip notebook metadata | Export continues |
+| StartNotebookExport failure (single) | Log error, count as failed, continue | Export continues |
+| Export polling timeout (single) | Log warning, count as failed, continue | Export continues |
+| S3 download failure (single) | Log error, count as failed, continue | Export continues |
+| S3 upload failure (single) | Log error, skip import, continue | Import continues |
+| ListNotebooks API failure (import) | Log error, skip old-version detection for that notebook | Import continues |
+| StartNotebookImport error (any) | Log error, count as failed, continue | Import continues |
+| GetNotebook polling timeout (post-import) | Log warning, count as failed, continue | Import continues |
+| UpdateNotebook ValidationException | Log warning, count as metadata_warning | Import continues |
+| UpdateNotebook other error | Log warning, count as metadata_warning | Import continues |
+| DeleteNotebook (old version) failure | Log warning, do NOT count notebook as failed | Import continues |
+| ThrottlingException (any API) | Retry with exponential backoff (max 3) | Transparent retry |
+| Missing S3 connection (deploy) | Raise error, skip all notebook imports | Deploy reports failure |
+| Missing manifest keys (deploy) | Raise validation error, skip imports | Deploy reports failure |
+| DeleteNotebook ResourceNotFoundException (destroy) | Record as not_found | Destroy continues |
+| DeleteNotebook other error (destroy) | Record as error, continue | Destroy continues |
+
+### Exit Code Rules
+
+- **Bundle command**: Non-zero if ANY notebook failed to export (requirement 2.12)
+- **Deploy command**: Non-zero if ANY notebook failed to import OR update (requirement 4.14, 7.5)
+- **Destroy command**: Reports counts; exits non-zero if any unexpected errors
+
+### Throttling Retry Strategy
+
+All DataZone API calls are wrapped with a retry decorator:
+
+```python
+def _retry_on_throttle(func, max_retries=3, initial_delay=1.0):
+    """Retry on ThrottlingException with exponential backoff."""
+    for attempt in range(max_retries + 1):
+        try:
+            return func()
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'ThrottlingException' and attempt < max_retries:
+                delay = initial_delay * (2 ** attempt)
+                time.sleep(delay + random.uniform(0, 0.5))  # jitter
+            else:
+                raise
+```
+
+---
+
+## Testing Strategy
+
+### Property-Based Testing (Hypothesis)
+
+The following properties will be tested using the `hypothesis` library (already in dev dependencies) with a minimum of 100 iterations per property. The tests focus on pure functions that are decoupled from AWS API calls.
+
+**Test file**: `tests/unit/helpers/test_notebook_properties.py`
+
+| Property | Function Under Test | Generator Strategy |
+|---|---|---|
+| P1: Name-Only Filter Algebra | `_apply_filters()` | Random notebook lists (with names) + random include_names/exclude_names lists |
+| P2: Pagination Completeness | `_list_all_notebooks()` (mocked paginator) | Random page counts and page sizes |
+| P3: Manifest Schema | `_build_export_manifest()` | Random ExportedNotebook lists |
+| P4: Bundle Consistency | Integration of export pipeline | Random notebook sets |
+| P5: Client Token | `_generate_client_token()` | Random names + timestamps |
+| P6: Manifest Validation | `_validate_notebook_manifest()` | Random dicts with missing keys |
+| P7: UpdateNotebook kwargs | `_build_update_kwargs()` | Random manifest entries with empty/non-empty fields |
+| P8: Backoff Intervals | Backoff calculation function | Random poll counts |
+| P9: Upsert Ordering | `_import_single_notebook()` (mocked APIs) | Random notebooks with/without old versions |
+| P10: Unique Name Enforcement | `_warn_duplicate_names()` | Random notebook lists with intentional duplicates |
+
+**Configuration**: Each test runs minimum 100 iterations via `@settings(max_examples=100)`.
+
+**Tag format**: `# Feature: data-notebooks-support, Property {N}: {description}`
+
+### Unit Tests (pytest)
+
+**Test files**:
+- `tests/unit/helpers/test_notebook_export.py` — Export logic with mocked APIs
+- `tests/unit/helpers/test_notebook_import.py` — Import logic with mocked APIs
+- `tests/unit/commands/test_notebook_dry_run.py` — Dry-run checker
+- `tests/unit/commands/test_notebook_destroy.py` — Destroy validation/execution
+
+**Key unit test scenarios**:
+- Manifest parsing with notebooks section (enabled/disabled, include_names/exclude_names)
+- Export flow happy path (mock ListNotebooks → GetNotebook → StartNotebookExport → GetNotebookExport → S3 download)
+- Export with partial failures (some notebooks fail, others succeed)
+- Export with duplicate notebook names (bundle fails with error listing duplicates)
+- Import upsert flow happy path: ListNotebooks finds old version → upload → StartNotebookImport → poll ACTIVE → UpdateNotebook → DeleteNotebook (old)
+- Import new notebook (no old version exists)
+- Import with missing file in bundle (count as failed)
+- Import with UpdateNotebook failure (metadata warning, not failed)
+- Import with DeleteNotebook failure for old version (warning, not failed)
+- Import with manifest containing duplicate names (validation error, import rejected)
+- Destroy validation discovers notebooks with name-only filtering
+- Destroy execution with mixed results (deleted, not_found, error)
+- Dry-run checks permissions (including DeleteNotebook and ListNotebooks) and connectivity
+- Empty include_names/exclude_names list raises validation error
+
+### Integration Tests / Example
+
+**Example directory**: `examples/notebook-import-export/` (mirrors the existing `examples/catalog-import-export/` structure)
+
+**Example structure**:
+```
+examples/notebook-import-export/
+├── manifest.yaml           # content.notebooks config with include_names
+├── app_tests/
+│   └── test_notebook_lifecycle.py  # End-to-end test
+└── README.md               # Example documentation
+```
+
+**Test file**: `examples/notebook-import-export/app_tests/test_notebook_lifecycle.py`
+
+End-to-end test with real AWS APIs:
+1. Create test notebooks in source project with known description and custom parameters
+2. Bundle with notebook export
+3. Deploy to target project (upsert — first time creates new)
+4. Verify notebooks exist in target with correct name, description, and parameters
+5. Update the source notebook description and add new custom parameters (differentiate versions)
+6. Bundle again (creates new version with updated metadata)
+7. Deploy again (upsert — replaces existing, old version deleted)
+8. Verify notebooks in target have the updated description and parameters (version update confirmed)
+9. Verify old versions were deleted (only one notebook per name remains)
+10. Destroy notebooks in target
+11. Verify notebooks are removed
+
+### Test Utilities
+
+```python
+# tests/unit/helpers/conftest.py additions
+
+@pytest.fixture
+def sample_notebook_manifest():
+    """Return a valid notebook_export_manifest.json dict."""
+    return {
+        "metadata": {
+            "sourceProjectId": "proj-123",
+            "sourceDomainId": "dzd-456",
+            "exportTimestamp": "2024-01-15T10:30:00Z",
+            "notebookCount": 1,
+        },
+        "notebooks": [{
+            "sourceNotebookId": "nb-001",
+            "name": "Test Notebook",
+            "description": "A test notebook",
+            "filePath": "notebooks/nb-001.ipynb",
+            "exportedAt": "2024-01-15T10:30:00Z",
+            "parameters": {"key": "value"},
+            "metadata": {},
+            "environmentConfiguration": None,
+        }],
+    }
+
+@pytest.fixture
+def sample_ipynb_content():
+    """Return minimal valid .ipynb file content."""
+    return json.dumps({
+        "cells": [],
+        "metadata": {"kernelspec": {"display_name": "Python 3"}},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }).encode("utf-8")
+```

--- a/.kiro/specs/data-notebooks-support/requirements.md
+++ b/.kiro/specs/data-notebooks-support/requirements.md
@@ -2,9 +2,9 @@
 
 ## Introduction
 
-This feature adds native Data Notebooks support to the SMUS CI/CD package, enabling promotion of SageMaker Unified Studio notebooks across environments (dev → test → prod) using the DataZone Import/Export Notebook APIs. Unlike the current approach where notebooks are deployed as raw `.ipynb` files to S3 storage connections (and then executed via the SageMakerNotebookOperator in Airflow), this feature uses the DataZone `StartNotebookExport` and `StartNotebookImport` APIs to export notebooks from a source SMUS project and import them as first-class notebook resources into target SMUS projects. This enables notebooks to appear natively in the SageMaker Unified Studio IDE in the target environment, preserving their metadata, name, and description rather than existing only as S3 files that require workflow-based execution.
+This feature adds native Data Notebooks support to the SMUS CI/CD package, enabling promotion of SageMaker Unified Studio notebooks across environments (dev → test → prod) using the DataZone Notebook APIs. The export process discovers and downloads notebooks from a source project via `GetNotebook`, `StartNotebookExport`, and `GetNotebookExport`. When specific notebook IDs are configured in the manifest, each ID is validated directly via `GetNotebook`; when no IDs are specified, `ListNotebooks` with pagination retrieves all active notebooks. During deployment, the `StartNotebookSync` API handles both creation and in-place update of notebooks in the target project: when called without a `notebookId` it creates a new notebook, and when called with a `notebookId` it updates the existing notebook's `.ipynb` content in-place, preserving run history. After syncing, `UpdateNotebook` applies metadata including a special tracking key (`smus-cicd-source-notebook-id`) that maps target notebooks back to their source. On subsequent deploys, the tool discovers existing target notebooks via `ListNotebooks` + `GetNotebook`, checks metadata for the source ID marker, and passes the matched target `notebookId` to `StartNotebookSync` for an in-place update — or omits it to create a new notebook if no match is found.
 
-The export process uses `ListNotebooks` to discover notebooks in the source project, `GetNotebook` to retrieve each notebook's full metadata (including parameters, metadata, and environmentConfiguration), `StartNotebookExport` to initiate an asynchronous export of each notebook to IPYNB format, and `GetNotebookExport` to poll for completion and retrieve the S3 output location. The exported `.ipynb` files are included in the bundle archive. During deployment, the import follows an upsert (create-or-replace) strategy: existing notebooks with the same name in the target project are detected via `ListNotebooks`, the new notebook is always created via `StartNotebookImport` (since duplicate names are allowed), polled until ACTIVE via `GetNotebook`, updated with metadata via `UpdateNotebook`, and only then is the old notebook (if any) deleted via `DeleteNotebook`. This ensures zero data loss — the old version is only removed after the new version is confirmed working.
+Key benefits of this architecture: run history is preserved across deployments (no delete + recreate), the flow is simpler (StartNotebookSync handles both create and update), and source-to-target mapping is maintained via metadata. All operations reference notebooks by their unique IDs, eliminating ambiguity from name-based matching.
 
 **Out of Scope:** Notebook schedules are explicitly out of scope for this iteration. No public API for schedule management currently exists; this will be revisited with the team in a future iteration.
 
@@ -13,25 +13,24 @@ The export process uses `ListNotebooks` to discover notebooks in the source proj
 - **CLI**: The `aws-smus-cicd-cli` command-line interface for SMUS CI/CD operations
 - **Bundle_Command**: The CLI command that packages application content into a deployable ZIP archive
 - **Deploy_Command**: The CLI command that deploys a bundle archive to a target stage's DataZone project
-- **Notebook_Exporter**: The component responsible for listing project notebooks via `ListNotebooks`, exporting them via `StartNotebookExport`, polling via `GetNotebookExport`, and downloading the exported `.ipynb` files
-- **Notebook_Importer**: The component responsible for uploading `.ipynb` files to S3, performing upsert operations (create new notebook via `StartNotebookImport`, poll until ACTIVE, apply metadata via `UpdateNotebook`, then delete old notebook with same name if one existed)
+- **Notebook_Exporter**: The component responsible for resolving notebook IDs (either from the manifest list or via `ListNotebooks`), exporting them via `StartNotebookExport`, polling via `GetNotebookExport`, and downloading the exported `.ipynb` files
+- **Notebook_Importer**: The component responsible for uploading `.ipynb` files to S3, discovering existing target notebooks via metadata lookup, performing sync operations via `StartNotebookSync` (create or update in-place), and applying metadata via `UpdateNotebook`
 - **DataZone_Domain**: An Amazon DataZone domain that contains projects and notebook resources
 - **DataZone_Project**: A project within a DataZone domain that owns notebook resources
 - **SMUS_Notebook**: A notebook resource natively managed by SageMaker Unified Studio, identified by a notebook ID and owned by a project
 - **Notebook_Export**: An asynchronous operation initiated by `StartNotebookExport` that exports a notebook to a specified file format and stores the output in S3
-- **Notebook_Import**: An operation initiated by `StartNotebookImport` that creates a notebook resource in a project from an S3 source location (always creates a new notebook; duplicate names are allowed)
+- **StartNotebookSync_API**: The DataZone API that creates or updates a notebook's content from an S3 source. Without `notebookId` it creates a new notebook; with `notebookId` it updates existing content in-place, preserving run history
 - **Notebook_Export_Manifest**: A JSON metadata file included in the bundle that records the mapping between notebook names, IDs, and exported file paths
+- **Source_Notebook_Metadata_Key**: The metadata key `smus-cicd-source-notebook-id` stored in the target notebook's metadata field to track which source notebook it originated from
 - **ListNotebooks_API**: The DataZone API that lists notebooks owned by a project, supporting pagination, status filtering, and sorting
 - **GetNotebook_API**: The DataZone API that retrieves the full details of a notebook resource including its parameters, metadata, and environmentConfiguration fields
 - **StartNotebookExport_API**: The DataZone API that initiates an asynchronous notebook export to PDF or IPYNB format
 - **GetNotebookExport_API**: The DataZone API that retrieves the status and output location of a notebook export operation
-- **StartNotebookImport_API**: The DataZone API that imports a notebook from an S3 location into a project, creating a new notebook resource (duplicate names are allowed, so this always succeeds without ConflictException)
-- **UpdateNotebook_API**: The DataZone API that updates a notebook resource's mutable fields including parameters, metadata, and environmentConfiguration
-- **DeleteNotebook_API**: The DataZone API that deletes a notebook resource from a project, used to remove old versions after a successful upsert
+- **UpdateNotebook_API**: The DataZone API that updates a notebook resource's mutable fields including name, description, parameters, metadata, and environmentConfiguration. Note: `cellOrder` is handled by StartNotebookSync via the .ipynb file content, and `status` is not ported (target notebooks are always ACTIVE)
+- **DeleteNotebook_API**: The DataZone API that deletes a notebook resource from a project, used during destroy operations
 - **Manifest**: The `manifest.yaml` file that defines application content, stages, and deployment configuration
 - **S3_Connection**: An S3 connection associated with a DataZone project, used for storing exported notebook files
 - **Output_Location**: The S3 URI where an exported notebook file is stored after a successful export operation
-- **Upsert**: The import strategy where a notebook is always created as new, and if an existing notebook with the same name was found, the old one is deleted only after the new one is fully active and updated
 
 ## Requirements
 
@@ -43,15 +42,13 @@ The export process uses `ListNotebooks` to discover notebooks in the source proj
 
 1. THE Manifest SHALL support a `content.notebooks` section to configure notebook export
 2. THE `content.notebooks` section SHALL support an `enabled` boolean field to enable or disable notebook export (default: false)
-3. IF `content.notebooks.enabled` is set to true and no `include_names` filter is specified, THEN THE Bundle_Command SHALL export all active notebooks owned by the source project
-4. THE `content.notebooks` section SHALL support an optional `include_names` field containing a list of notebook name strings to export, where each entry is a notebook name (up to 256 characters, case-sensitive exact match)
-5. IF `content.notebooks.include_names` is specified, THEN THE Bundle_Command SHALL match each entry against the notebook name (case-sensitive exact match) and export notebooks that match
-6. THE `content.notebooks` section SHALL support an optional `exclude_names` field containing a list of notebook name strings to exclude from export, where each entry is a notebook name (up to 256 characters, case-sensitive exact match)
-7. IF `content.notebooks.exclude_names` is specified, THEN THE Bundle_Command SHALL match each entry against the notebook name (case-sensitive exact match) and exclude notebooks that match
-8. IF both `include_names` and `exclude_names` are specified, THEN THE Bundle_Command SHALL apply `include_names` first (selecting matching notebooks), then apply `exclude_names` to remove any matches from the selected set
-9. IF `content.notebooks.enabled` is false or absent, THEN THE Bundle_Command SHALL skip notebook export regardless of whether `include_names` or `exclude_names` fields are present
-10. IF an entry in the `include_names` list does not match any active notebook in the source project, THEN THE Bundle_Command SHALL log a warning identifying the unmatched name and continue exporting the remaining matched notebooks
-11. IF the `include_names` or `exclude_names` field is present but contains an empty list, THEN THE Bundle_Command SHALL raise a validation error indicating that the list must contain at least one entry
+3. THE `content.notebooks` section SHALL support an optional `notebook_ids` field containing a list of notebook ID strings to export, where each entry matches the pattern `[a-zA-Z0-9_-]{1,36}`
+4. IF `content.notebooks.enabled` is true and `notebook_ids` is specified, THEN THE Bundle_Command SHALL validate all listed IDs upfront by calling the GetNotebook_API for each ID before starting any export operations
+5. IF any notebook ID in the `notebook_ids` list does not exist (GetNotebook_API returns ResourceNotFoundException), THEN THE Bundle_Command SHALL immediately fail with a non-zero exit code and an error message listing the invalid notebook ID — no exports shall proceed
+6. IF all notebook IDs in the `notebook_ids` list are validated successfully, THEN THE Bundle_Command SHALL proceed to export only those notebooks
+7. IF `content.notebooks.enabled` is true and `notebook_ids` is omitted, THEN THE Bundle_Command SHALL call the ListNotebooks_API to discover and export all active notebooks owned by the source project
+8. IF the `notebook_ids` field is present but contains an empty list, THEN THE Bundle_Command SHALL raise a validation error indicating that the list must contain at least one entry
+9. IF `content.notebooks.enabled` is false or absent, THEN THE Bundle_Command SHALL skip notebook export regardless of whether a `notebook_ids` field is present
 
 ### Requirement 2: Export Notebooks During Bundle
 
@@ -59,22 +56,23 @@ The export process uses `ListNotebooks` to discover notebooks in the source proj
 
 #### Acceptance Criteria
 
-1. WHEN the bundle command runs and `content.notebooks.enabled` is true, THE Notebook_Exporter SHALL call the ListNotebooks_API to discover all active notebooks owned by the source project, using the `domainIdentifier`, `owningProjectIdentifier` parameter, and filtering by `status=ACTIVE`
-2. THE Notebook_Exporter SHALL handle pagination by following `nextToken` until all notebooks are retrieved from the ListNotebooks_API
-3. WHEN a notebook is selected for export, THE Notebook_Exporter SHALL call the GetNotebook_API with `domainIdentifier` and `notebookIdentifier` to retrieve the notebook's `parameters`, `metadata`, and `environmentConfiguration` fields
-4. WHEN a notebook is selected for export, THE Notebook_Exporter SHALL call the StartNotebookExport_API with `domainIdentifier`, `fileFormat` set to `IPYNB`, the notebook's identifier as `notebookIdentifier`, and the source project identifier as `owningProjectIdentifier`
-5. WHEN the StartNotebookExport_API returns an export identifier, THE Notebook_Exporter SHALL poll the GetNotebookExport_API using exponential backoff starting at 2 seconds and capped at 30 seconds per interval, until the export status transitions from `IN_PROGRESS` to `SUCCEEDED` or `FAILED`
-6. WHEN the export status is `SUCCEEDED`, THE Notebook_Exporter SHALL download the exported `.ipynb` file from the `outputLocation` S3 URI returned by GetNotebookExport_API
-7. IF the export status is `FAILED`, THEN THE Notebook_Exporter SHALL log the error message from the `error` field, count the notebook as failed, and continue with the next notebook
-8. THE Notebook_Exporter SHALL store each exported `.ipynb` file in a `notebooks/` directory within the bundle archive, using the notebook's source identifier as the filename (e.g., `notebooks/{sourceNotebookId}.ipynb`)
-9. THE Notebook_Exporter SHALL produce a `notebooks/notebook_export_manifest.json` metadata file in the bundle containing the list of exported notebooks with their source IDs, names, descriptions, file paths within the bundle, and the `parameters`, `metadata`, and `environmentConfiguration` fields retrieved from the GetNotebook_API
-10. THE Notebook_Exporter SHALL implement a configurable polling timeout with a default of 300 seconds per notebook to avoid indefinite waiting on stuck export operations
-11. IF the polling timeout is exceeded for a notebook export, THEN THE Notebook_Exporter SHALL log a warning including the notebook name and elapsed time, count the notebook as failed, and continue with the next notebook
-12. WHEN all notebooks have been processed, IF any notebooks failed to export, THEN THE Bundle_Command SHALL exit with a non-zero exit code and output a failure message listing the names of all notebooks that failed and their respective error messages
+1. WHEN the bundle command runs and `content.notebooks.enabled` is true and `notebook_ids` is specified, THE Notebook_Exporter SHALL first validate all IDs by calling the GetNotebook_API with `domainIdentifier` and `notebookIdentifier` for each ID in the list to retrieve the notebook's `parameters`, `metadata`, and `environmentConfiguration` fields
+2. IF any ID validation fails with ResourceNotFoundException during the upfront validation pass, THEN THE Bundle_Command SHALL immediately fail with a non-zero exit code and an error message listing all invalid IDs — no exports shall be initiated
+3. WHEN the bundle command runs and `content.notebooks.enabled` is true and `notebook_ids` is omitted, THE Notebook_Exporter SHALL call the ListNotebooks_API to discover all active notebooks owned by the source project, using the `domainIdentifier`, `owningProjectIdentifier` parameter, and filtering by `status=ACTIVE`
+4. THE Notebook_Exporter SHALL handle pagination by following `nextToken` until all notebooks are retrieved from the ListNotebooks_API (when listing all notebooks)
+5. WHEN a notebook is selected for export, THE Notebook_Exporter SHALL call the StartNotebookExport_API with `domainIdentifier`, `fileFormat` set to `IPYNB`, the notebook's identifier as `notebookIdentifier`, and the source project identifier as `owningProjectIdentifier`
+6. WHEN the StartNotebookExport_API returns an export identifier, THE Notebook_Exporter SHALL poll the GetNotebookExport_API using exponential backoff starting at 2 seconds and capped at 30 seconds per interval, until the export status transitions from `IN_PROGRESS` to `SUCCEEDED` or `FAILED`
+7. WHEN the export status is `SUCCEEDED`, THE Notebook_Exporter SHALL download the exported `.ipynb` file from the `outputLocation` S3 URI returned by GetNotebookExport_API
+8. IF the export status is `FAILED`, THEN THE Notebook_Exporter SHALL log the error message from the `error` field, count the notebook as failed, and continue with the next notebook
+9. THE Notebook_Exporter SHALL store each exported `.ipynb` file in a `notebooks/` directory within the bundle archive, using the notebook's source identifier as the filename (e.g., `notebooks/{sourceNotebookId}.ipynb`)
+10. THE Notebook_Exporter SHALL produce a `notebooks/notebook_export_manifest.json` metadata file in the bundle containing the list of exported notebooks with their source IDs, names, descriptions, file paths within the bundle, and the `parameters`, `metadata`, and `environmentConfiguration` fields retrieved from the GetNotebook_API
+11. THE Notebook_Exporter SHALL implement a configurable polling timeout with a default of 300 seconds per notebook to avoid indefinite waiting on stuck export operations
+12. IF the polling timeout is exceeded for a notebook export, THEN THE Notebook_Exporter SHALL log a warning including the notebook ID and elapsed time, count the notebook as failed, and continue with the next notebook
+13. WHEN all notebooks have been processed, IF any notebooks failed to export, THEN THE Bundle_Command SHALL exit with a non-zero exit code and output a failure message listing the IDs of all notebooks that failed and their respective error messages
 
 ### Requirement 3: Notebook Export Manifest Serialization
 
-**User Story:** As a developer, I want the exported notebook metadata to be stored in a structured manifest file, so that the import process has the information needed to recreate notebooks in the target project.
+**User Story:** As a developer, I want the exported notebook metadata to be stored in a structured manifest file, so that the sync process has the information needed to create or update notebooks in the target project.
 
 #### Acceptance Criteria
 
@@ -82,127 +80,130 @@ The export process uses `ListNotebooks` to discover notebooks in the source proj
 2. THE Notebook_Export_Manifest SHALL contain a top-level object with exactly two keys: `metadata` (object) and `notebooks` (array)
 3. THE `metadata` section SHALL include `sourceProjectId` (string), `sourceDomainId` (string), `exportTimestamp` (string in ISO 8601 format, e.g. `2024-01-15T10:30:00Z`), and `notebookCount` (integer equal to the length of the `notebooks` array)
 4. EACH entry in the `notebooks` array SHALL include `sourceNotebookId` (string), `name` (string), `description` (string, empty string if the source notebook has no description), `filePath` (string, relative path within the bundle pointing to an existing `.ipynb` file), `exportedAt` (string in ISO 8601 format), `parameters` (object, string-to-string map with up to 50 entries where keys are max 128 characters and values are max 1024 characters, empty object if the source notebook has no parameters), `metadata` (object, string-to-string map with up to 50 entries where keys are max 128 characters and values are max 1024 characters, empty object if the source notebook has no metadata), and `environmentConfiguration` (object containing `imageVersion` string, and `packageConfig` object with `packageManager` string and `packageSpecification` string; null if the source notebook has no environment configuration)
-5. THE Notebook_Export_Manifest SHALL be valid JSON parseable by a standard JSON parser, and every `filePath` entry SHALL correspond to a file present in the bundle archive
-6. IF the source project has no notebooks matching the configured filters, THEN THE Notebook_Exporter SHALL produce a Notebook_Export_Manifest with an empty `notebooks` array and `notebookCount` set to 0
+5. THE Notebook_Export_Manifest SHALL store ALL fields needed for the UpdateNotebook_API call on the target: `name`, `description`, `parameters`, `metadata`, and `environmentConfiguration` — these are the fields that will be applied to the target notebook via UpdateNotebook after sync
+6. THE Notebook_Export_Manifest SHALL be valid JSON parseable by a standard JSON parser, and every `filePath` entry SHALL correspond to a file present in the bundle archive
+7. IF the source project has no active notebooks (when listing all) or all specified notebook IDs failed validation, THEN THE Notebook_Exporter SHALL produce a Notebook_Export_Manifest with an empty `notebooks` array and `notebookCount` set to 0
 
-### Requirement 4: Import Notebooks During Deploy (Upsert)
+### Requirement 4: Sync Notebooks During Deploy
 
-**User Story:** As a developer, I want the deploy command to import notebooks into the target SMUS project using an upsert strategy, so that exported notebooks appear as native notebook resources in the target environment and existing notebooks with the same name are seamlessly replaced without data loss.
+**User Story:** As a developer, I want the deploy command to sync notebooks into the target SMUS project using StartNotebookSync, so that notebooks are created or updated in-place (preserving run history) in the target environment.
 
 #### Acceptance Criteria
 
 1. WHEN the deploy command processes a bundle containing a `notebooks/notebook_export_manifest.json` file, THE Deploy_Command SHALL invoke the Notebook_Importer after storage deployments
-2. WHEN the Notebook_Importer is invoked, THE Notebook_Importer SHALL upload each exported `.ipynb` file referenced in the Notebook_Export_Manifest from the bundle to the target project's `default.s3_shared` connection S3 URI under a `notebooks/imports/` prefix
-3. WHEN a notebook entry in the Notebook_Export_Manifest references a `filePath` that does not exist in the bundle archive, THE Notebook_Importer SHALL log an error identifying the missing file and notebook name, count it as failed, and continue with the next notebook
-4. BEFORE importing each notebook, THE Notebook_Importer SHALL call the ListNotebooks_API with `owningProjectIdentifier` and `status=ACTIVE` filter on the target project to discover existing notebooks, and identify any notebook with a name matching the notebook being imported as the "old version"
-5. FOR EACH notebook in the Notebook_Export_Manifest whose file was successfully uploaded, THE Notebook_Importer SHALL call the StartNotebookImport_API with the notebook's `name`, `description`, the target project's `owningProjectIdentifier`, the target project's domain identifier as `domainIdentifier`, and the `sourceLocation` pointing to the uploaded S3 file
-6. THE Notebook_Importer SHALL use a client token derived from the notebook name and deployment timestamp, truncated to a maximum of 64 characters, to ensure idempotent import operations (retrying the same deploy produces the same notebook, not a duplicate)
-7. WHEN the StartNotebookImport_API returns a notebook identifier, THE Notebook_Importer SHALL poll the GetNotebook_API with exponential backoff (starting at 1 second, doubling on each poll, capped at 10 seconds) until the newly created notebook's status is `ACTIVE`
-8. IF the newly created notebook does not reach `ACTIVE` status within 120 seconds, THEN THE Notebook_Importer SHALL log a warning including the notebook name and elapsed time, count the notebook as failed, and continue with the next notebook
-9. WHEN the newly created notebook status is `ACTIVE`, THE Notebook_Importer SHALL call the UpdateNotebook_API with the target project's `domainIdentifier`, the newly imported notebook's identifier, `owningProjectIdentifier`, and the `parameters`, `metadata`, and `environmentConfiguration` values from the manifest
-10. IF an old version notebook with the same name was identified in step 4, THEN THE Notebook_Importer SHALL delete the old notebook via the DeleteNotebook_API only after the new notebook has reached ACTIVE status and the UpdateNotebook_API call has completed (successfully or with a warning)
-11. IF the DeleteNotebook_API call for the old version fails, THEN THE Notebook_Importer SHALL log a warning including the old notebook name and identifier and error details, but SHALL NOT count the overall notebook import as failed (the new notebook is already active)
-12. IF the StartNotebookImport_API returns any error, THEN THE Notebook_Importer SHALL log the error with notebook name and error details, count the notebook as failed, and continue with the next notebook
-13. WHEN all notebooks in the Notebook_Export_Manifest have been processed, THE Notebook_Importer SHALL output to stdout the counts of imported (new, no previous version existed), updated (replaced an existing notebook with the same name), and failed notebooks as the import summary
-14. WHEN all notebooks in the Notebook_Export_Manifest have been processed, IF any notebooks failed to import or update, THEN THE Deploy_Command SHALL exit with a non-zero exit code and output a failure message listing the names of all notebooks that failed and their respective error messages
+2. THE Notebook_Importer SHALL execute the following deployment sequence in strict order:
+   - Step 1: Upload all `.ipynb` files referenced in the Notebook_Export_Manifest to the target project's `default.s3_shared` connection S3 URI under a `notebooks/imports/` prefix
+   - Step 2: Call ListNotebooks_API on the target project with `owningProjectIdentifier` and `status=ACTIVE` filter (handling pagination via `nextToken`), then call GetNotebook_API for EACH discovered notebook to read its metadata
+   - Step 3: Build a source-to-target mapping: for each target notebook whose metadata contains the key `smus-cicd-source-notebook-id`, record the mapping `{sourceNotebookId → targetNotebookId}`
+   - Step 4: For each notebook in the Notebook_Export_Manifest whose file was successfully uploaded, perform the sync operation (see AC#3 through AC#7)
+   - Step 5: After each successful StartNotebookSync, call UpdateNotebook_API to apply `name`, `description`, `metadata` (including `smus-cicd-source-notebook-id`), `parameters`, and `environmentConfiguration` from the manifest
+   - Step 6: Report sync summary with counts of created, updated, and failed notebooks
+3. FOR EACH notebook in the manifest, THE Notebook_Importer SHALL look up the manifest entry's `sourceNotebookId` in the source-to-target mapping built in Step 3
+4. IF a matching target notebook is found in the mapping, THEN THE Notebook_Importer SHALL call StartNotebookSync_API WITH the matched target `notebookId` (update in-place, preserving run history)
+5. IF no matching target notebook is found in the mapping, THEN THE Notebook_Importer SHALL call StartNotebookSync_API WITHOUT a `notebookId` (create new notebook)
+6. IF StartNotebookSync_API called WITH a `notebookId` returns a ResourceNotFoundException, THEN THE Notebook_Importer SHALL log a warning indicating the target notebook was manually deleted, and retry the call WITHOUT `notebookId` (create new notebook instead)
+7. THE Notebook_Importer SHALL call the StartNotebookSync_API with `domainIdentifier`, `owningProjectIdentifier`, `sourceLocation` (the uploaded S3 URI), and optionally `notebookId`, `name`, `description`, and a `clientToken` derived from the source notebook ID and deployment timestamp (truncated to a maximum of 64 characters) to ensure idempotent operations
+8. WHEN StartNotebookSync_API succeeds and returns a notebook identifier, THE Notebook_Importer SHALL call the UpdateNotebook_API with the target project's `domainIdentifier`, the synced notebook's identifier, `owningProjectIdentifier`, and the `name`, `description`, `parameters`, `metadata` (including `smus-cicd-source-notebook-id` set to the manifest entry's `sourceNotebookId`), and `environmentConfiguration` values from the manifest
+9. IF the UpdateNotebook_API returns any error, THEN THE Notebook_Importer SHALL log the notebook ID and error details, and count the notebook as FAILED (the notebook is not in its intended final state)
+10. IF the StartNotebookSync_API returns any error other than ResourceNotFoundException, THEN THE Notebook_Importer SHALL log the error with notebook ID and error details, count the notebook as failed, and continue with the next notebook
+11. WHEN a notebook entry in the Notebook_Export_Manifest references a `filePath` that does not exist in the bundle archive, THE Notebook_Importer SHALL log an error identifying the missing file and notebook ID, count it as failed, and continue with the next notebook
+12. WHEN all notebooks in the Notebook_Export_Manifest have been processed, THE Notebook_Importer SHALL output to stdout the counts of created (new, no previous target notebook existed), updated (synced to an existing target notebook), and failed notebooks as the sync summary
+13. WHEN all notebooks in the Notebook_Export_Manifest have been processed, IF any notebooks failed to sync or update, THEN THE Deploy_Command SHALL exit with a non-zero exit code and output a failure message listing the IDs of all notebooks that failed and their respective error messages
 
 ### Requirement 5: Deploy Command Integration
 
-**User Story:** As a developer, I want notebook import to be integrated into the existing deploy command flow, so that notebooks are deployed alongside other bundle content.
+**User Story:** As a developer, I want notebook sync to be integrated into the existing deploy command flow, so that notebooks are deployed alongside other bundle content.
 
 #### Acceptance Criteria
 
-1. THE Deploy_Command SHALL process notebook imports after storage and catalog deployments, and before bootstrap actions
-2. WHERE the stage's `deployment_configuration.notebooks.disable` is set to true, THE Deploy_Command SHALL skip notebook import for that stage and log an informational message indicating notebook import was skipped due to configuration
-3. IF notebook import is not disabled and the bundle contains a `notebooks/notebook_export_manifest.json`, THEN THE Deploy_Command SHALL invoke the Notebook_Importer to process the notebooks listed in the manifest
-4. IF the bundle does not contain a `notebooks/notebook_export_manifest.json`, THEN THE Deploy_Command SHALL skip notebook import without producing any warning or error output
-5. WHEN the Notebook_Importer completes processing, THE Deploy_Command SHALL report the notebook import summary (imported count, updated count, failed count) in the overall deployment output
+1. THE Deploy_Command SHALL process notebook sync after storage and catalog deployments, and before bootstrap actions
+2. WHERE the stage's `deployment_configuration.notebooks.disable` is set to true, THE Deploy_Command SHALL skip notebook sync for that stage and log an informational message indicating notebook sync was skipped due to configuration
+3. IF notebook sync is not disabled and the bundle contains a `notebooks/notebook_export_manifest.json`, THEN THE Deploy_Command SHALL invoke the Notebook_Importer to process the notebooks listed in the manifest
+4. IF the bundle does not contain a `notebooks/notebook_export_manifest.json`, THEN THE Deploy_Command SHALL skip notebook sync without producing any warning or error output
+5. WHEN the Notebook_Importer completes processing, THE Deploy_Command SHALL report the notebook sync summary (created count, updated count, failed count) in the overall deployment output
 
-### Requirement 6: S3 Upload for Notebook Import
+### Requirement 6: S3 Upload for Notebook Sync
 
-**User Story:** As a developer, I want exported notebook files to be uploaded to an accessible S3 location before import, so that the StartNotebookImport API can read them.
+**User Story:** As a developer, I want exported notebook files to be uploaded to an accessible S3 location before sync, so that the StartNotebookSync API can read them.
 
 #### Acceptance Criteria
 
 1. THE Notebook_Importer SHALL upload `.ipynb` files to the target project's `default.s3_shared` connection S3 URI under a `notebooks/imports/` prefix, constructing the full S3 key as `{s3Uri}/notebooks/imports/{sourceNotebookId}.ipynb`
 2. WHEN uploading notebook files, THE Notebook_Importer SHALL verify that the target project's `default.s3_shared` connection exists and contains a non-empty `s3Uri` value before attempting any uploads
-3. IF the S3 upload fails for a notebook file, THEN THE Notebook_Importer SHALL log the error including the notebook name and S3 destination key, skip the import for that notebook, and continue processing remaining notebooks
-4. IF the target project's `default.s3_shared` connection does not exist or does not contain an `s3Uri` value, THEN THE Notebook_Importer SHALL raise an error indicating the missing connection and skip all notebook imports for that project
+3. IF the S3 upload fails for a notebook file, THEN THE Notebook_Importer SHALL log the error including the notebook ID and S3 destination key, skip the sync for that notebook, and continue processing remaining notebooks
+4. IF the target project's `default.s3_shared` connection does not exist or does not contain an `s3Uri` value, THEN THE Notebook_Importer SHALL raise an error indicating the missing connection and skip all notebook sync operations for that project
 
 ### Requirement 7: Error Handling and Resilience
 
-**User Story:** As a developer, I want robust error handling during notebook export and import, so that partial failures do not block the entire deployment.
+**User Story:** As a developer, I want robust error handling during notebook export and sync, so that partial failures do not block the entire deployment.
 
 #### Acceptance Criteria
 
-1. IF the ListNotebooks_API returns an error during export, THEN THE Notebook_Exporter SHALL raise an exception with an error message including the domain identifier, project identifier, and the error response from the API
-2. IF the source project has no notebooks matching the configured filters, THEN THE Notebook_Exporter SHALL produce an empty Notebook_Export_Manifest with zero notebooks and log an informational message indicating the project identifier and the filters that were applied
-3. IF a StartNotebookExport_API call fails for a specific notebook during export, THEN THE Notebook_Exporter SHALL log the notebook name and error, then continue with the next notebook
+1. IF the ListNotebooks_API returns an error during export (when listing all notebooks), THEN THE Notebook_Exporter SHALL raise an exception with an error message including the domain identifier, project identifier, and the error response from the API
+2. IF the source project has no active notebooks (when listing all) or all specified notebook IDs are not found, THEN THE Notebook_Exporter SHALL produce an empty Notebook_Export_Manifest with zero notebooks and log an informational message indicating the project identifier and any IDs that were not found
+3. IF a StartNotebookExport_API call fails for a specific notebook during export, THEN THE Notebook_Exporter SHALL log the notebook ID and error, then continue with the next notebook
 4. IF the Notebook_Export_Manifest is missing the top-level `metadata` or `notebooks` keys, or if `metadata` is missing any of `sourceProjectId`, `sourceDomainId`, `exportTimestamp`, or `notebookCount`, THEN THE Notebook_Importer SHALL raise a validation error before attempting any API calls
-5. IF any notebook imports or updates fail, THEN THE Deploy_Command SHALL fail the overall deployment with a non-zero exit code and output a failure message listing the names of all notebooks that failed and their respective error messages
+5. IF any notebook syncs or UpdateNotebook calls fail, THEN THE Deploy_Command SHALL fail the overall deployment with a non-zero exit code and output a failure message listing the IDs of all notebooks that failed and their respective error messages
 6. THE Notebook_Exporter SHALL implement exponential backoff with jitter when polling GetNotebookExport_API, starting at an initial interval of 1 second, doubling on each poll, up to a maximum interval of 30 seconds per poll
 7. IF a ThrottlingException is received from any DataZone API call, THEN THE component SHALL retry the request with exponential backoff starting at 1 second and doubling on each retry, up to a maximum of 3 retries
+8. IF StartNotebookSync_API with a `notebookId` returns a ResourceNotFoundException, THEN THE Notebook_Importer SHALL log a warning indicating the notebook may have been manually deleted in the target, and retry without `notebookId` to create a new notebook
 
 ### Requirement 8: Dry Run Validation for Notebooks
 
-**User Story:** As a developer, I want the deploy dry-run to validate notebook import prerequisites, so that I can detect issues before actual deployment.
+**User Story:** As a developer, I want the deploy dry-run to validate notebook sync prerequisites, so that I can detect issues before actual deployment.
 
 #### Acceptance Criteria
 
 1. WHEN the deploy command runs with `--dry-run` and the bundle contains a `notebooks/notebook_export_manifest.json` file, THE Dry_Run_Engine SHALL verify that the target project's `default.s3_shared` connection exists and is reachable by performing a HEAD request against the S3 bucket resolved from the connection
-2. WHEN the deploy command runs with `--dry-run` and the bundle contains a `notebooks/notebook_export_manifest.json` file, THE Dry_Run_Engine SHALL verify that the IAM identity has the `datazone:StartNotebookImport`, `datazone:UpdateNotebook`, `datazone:GetNotebook`, `datazone:DeleteNotebook`, `datazone:ListNotebooks`, and `s3:PutObject` permissions using `iam:SimulatePrincipalPolicy`
-3. WHEN the deploy command runs with `--dry-run` and the bundle contains a `notebooks/notebook_export_manifest.json` file, THE Dry_Run_Engine SHALL report the number of notebooks that would be imported (read from the manifest's `notebookCount` field) in the dry-run output
+2. WHEN the deploy command runs with `--dry-run` and the bundle contains a `notebooks/notebook_export_manifest.json` file, THE Dry_Run_Engine SHALL verify that the IAM identity has the `datazone:StartNotebookSync`, `datazone:UpdateNotebook`, `datazone:GetNotebook`, `datazone:ListNotebooks`, and `s3:PutObject` permissions using `iam:SimulatePrincipalPolicy`
+3. WHEN the deploy command runs with `--dry-run` and the bundle contains a `notebooks/notebook_export_manifest.json` file, THE Dry_Run_Engine SHALL report the number of notebooks that would be synced (read from the manifest's `notebookCount` field) in the dry-run output
 4. IF the S3 connection is not found or the HEAD request to the resolved S3 bucket fails, THEN THE Dry_Run_Engine SHALL report a WARNING finding indicating the connection name and the failure reason
-5. IF `iam:SimulatePrincipalPolicy` reports a denied decision for `datazone:StartNotebookImport`, `datazone:UpdateNotebook`, `datazone:GetNotebook`, `datazone:DeleteNotebook`, `datazone:ListNotebooks`, or `s3:PutObject`, THEN THE Dry_Run_Engine SHALL report a WARNING finding indicating the denied permission name and resource ARN
+5. IF `iam:SimulatePrincipalPolicy` reports a denied decision for `datazone:StartNotebookSync`, `datazone:UpdateNotebook`, `datazone:GetNotebook`, `datazone:ListNotebooks`, or `s3:PutObject`, THEN THE Dry_Run_Engine SHALL report a WARNING finding indicating the denied permission name and resource ARN
 
 ### Requirement 9: Destroy Command Support for Notebooks
 
-**User Story:** As a developer, I want the destroy command to clean up imported notebooks, so that I can remove all deployed resources from a target environment.
+**User Story:** As a developer, I want the destroy command to clean up synced notebooks, so that I can remove all deployed resources from a target environment.
 
 #### Acceptance Criteria
 
 1. WHEN the destroy command validates a target stage and `content.notebooks.enabled` is true in the manifest, THE Destroy_Command SHALL call the ListNotebooks_API with the target project's `owningProjectIdentifier` and `status=ACTIVE` filter to discover notebook resources, handling pagination by following `nextToken` until all notebooks are retrieved
-2. THE Destroy_Command SHALL apply the same `include_names` and `exclude_names` filters from the manifest's `content.notebooks` section to the discovered notebooks, matching by notebook name (case-sensitive exact match) only
-3. IF the ListNotebooks_API returns an error during validation, THEN THE Destroy_Command SHALL report the error and fail validation for that stage
-4. THE Destroy_Command SHALL display each filtered notebook's name and identifier in the destruction plan under a `notebook` resource type for user confirmation before deletion
-5. IF the user confirms destruction, THEN THE Destroy_Command SHALL delete each notebook resource in the target project using the DataZone domain identifier and notebook identifier, continuing to the next notebook if an individual deletion fails
-6. IF a notebook is not found at deletion time (ResourceNotFoundException), THEN THE Destroy_Command SHALL record the notebook as `not_found` and continue with the next notebook
-7. IF a notebook deletion fails with any other error, THEN THE Destroy_Command SHALL log the notebook name and error details, record the notebook as `error`, and continue with the next notebook
-8. THE Destroy_Command SHALL report the count of deleted, not_found, and failed notebook deletions in the destruction summary consistent with the existing summary format
+2. FOR EACH discovered target notebook, THE Destroy_Command SHALL call the GetNotebook_API to read its metadata and check whether the metadata contains the key `smus-cicd-source-notebook-id`
+3. THE Destroy_Command SHALL include a target notebook in the destruction plan only if its metadata contains the `smus-cicd-source-notebook-id` key (indicating it was deployed by this CI/CD tool)
+4. IF `notebook_ids` is specified in the manifest's `content.notebooks` section, THEN THE Destroy_Command SHALL additionally filter the destruction plan to include only target notebooks whose `smus-cicd-source-notebook-id` metadata value is present in the manifest's `notebook_ids` list
+5. IF `notebook_ids` is omitted in the manifest's `content.notebooks` section, THEN THE Destroy_Command SHALL include all target notebooks that have the `smus-cicd-source-notebook-id` metadata key in the destruction plan
+6. THE Destroy_Command SHALL display each filtered notebook's name and identifier in the destruction plan under a `notebook` resource type for user confirmation before deletion
+7. IF the user confirms destruction, THEN THE Destroy_Command SHALL delete each notebook resource in the target project using the DeleteNotebook_API with the DataZone domain identifier and notebook identifier, continuing to the next notebook if an individual deletion fails
+8. IF a notebook is not found at deletion time (ResourceNotFoundException), THEN THE Destroy_Command SHALL record the notebook as `not_found` and continue with the next notebook
+9. IF a notebook deletion fails with any other error, THEN THE Destroy_Command SHALL log the notebook name and error details, record the notebook as `error`, and continue with the next notebook
+10. THE Destroy_Command SHALL report the count of deleted, not_found, and failed notebook deletions in the destruction summary consistent with the existing summary format
+11. IF the ListNotebooks_API returns an error during validation, THEN THE Destroy_Command SHALL report the error and fail validation for that stage
 
-### Requirement 10: Port Notebook Metadata via UpdateNotebook (Upsert Flow)
+**Note on source environment behavior:** The `notebook_ids` in the manifest are SOURCE notebook IDs. The destroy command looks for target notebooks tagged with `smus-cicd-source-notebook-id` matching those source IDs. If the user runs destroy on the SOURCE environment (where notebooks do not have this metadata tag), no notebooks will match and the command will report zero deletions. This is expected behavior — destroy is designed for TARGET environments where notebooks were deployed by this tool. Running destroy on the source environment is not a supported use-case since the source notebooks are the authoritative versions needed for future deployments.
 
-**User Story:** As a developer, I want imported notebooks to retain their parameters, metadata, and environment configuration from the source notebook, so that notebooks in the target environment behave identically to those in the source environment.
+### Requirement 10: Port Notebook Metadata via UpdateNotebook
 
-#### Acceptance Criteria
-
-1. WITHIN the upsert flow, WHEN the newly imported notebook reaches `ACTIVE` status, THE Notebook_Importer SHALL call the UpdateNotebook_API with the target project's `domainIdentifier`, the newly imported notebook's identifier, `owningProjectIdentifier`, and the `parameters`, `metadata`, and `environmentConfiguration` values from the manifest, BEFORE deleting the old notebook (if one exists)
-2. IF the `parameters` field in the manifest entry is an empty object, THEN THE Notebook_Importer SHALL omit the `parameters` field from the UpdateNotebook_API call
-3. IF the `metadata` field in the manifest entry is an empty object, THEN THE Notebook_Importer SHALL omit the `metadata` field from the UpdateNotebook_API call
-4. IF the `environmentConfiguration` field in the manifest entry is null, THEN THE Notebook_Importer SHALL omit the `environmentConfiguration` field from the UpdateNotebook_API call
-5. IF the UpdateNotebook_API returns a ValidationException due to invalid parameter constraints (keys exceeding 128 characters, values exceeding 1024 characters, or more than 50 entries), THEN THE Notebook_Importer SHALL log a warning including the notebook name and validation error, and count the notebook as imported with a metadata warning
-6. IF the UpdateNotebook_API returns any other error, THEN THE Notebook_Importer SHALL log the notebook name and error details, and count the notebook as imported with a metadata warning rather than failed
-7. WHEN the Notebook_Importer reports the import summary, THE Notebook_Importer SHALL include a count of notebooks where metadata porting encountered warnings alongside the imported, updated, and failed counts
-
-### Requirement 11: Unique Notebook Names Enforcement
-
-**User Story:** As a developer, I want the bundle command to enforce unique notebook names, so that the upsert logic can reliably identify which notebook is being created or updated in the target environment.
+**User Story:** As a developer, I want synced notebooks to retain their parameters, metadata, and environment configuration from the source notebook, so that notebooks in the target environment behave identically to those in the source environment.
 
 #### Acceptance Criteria
 
-1. AFTER applying the `include_names` and `exclude_names` filters, THE Notebook_Exporter SHALL verify that all selected notebooks have unique names (case-sensitive comparison)
-2. IF the selected notebooks contain two or more notebooks with the same name, THEN THE Bundle_Command SHALL skip exporting any notebooks and fail with a non-zero exit code, outputting an error message listing the duplicate notebook name(s) and the count of notebooks sharing each name
-3. THE error message SHALL instruct the user to resolve the duplicate names in the source project or use `include_names`/`exclude_names` filters to select only one notebook per name before re-running the bundle command
-4. WHEN the Notebook_Importer reads the `notebook_export_manifest.json` during deploy, THE Notebook_Importer SHALL validate that all notebook entries in the manifest have unique `name` values (case-sensitive comparison) before attempting any import operations
-5. IF the manifest contains two or more notebook entries with the same `name` value, THEN THE Notebook_Importer SHALL raise a validation error and skip all notebook imports for that deployment
+1. WHEN StartNotebookSync_API succeeds, THE Notebook_Importer SHALL call the UpdateNotebook_API with the target project's `domainIdentifier`, the synced notebook's identifier, `owningProjectIdentifier`, and the `name`, `description`, `parameters`, `metadata` (including `smus-cicd-source-notebook-id` set to the manifest entry's `sourceNotebookId`), and `environmentConfiguration` values from the manifest
+2. THE Notebook_Importer SHALL always include `smus-cicd-source-notebook-id` with the value of the manifest entry's `sourceNotebookId` in the metadata passed to UpdateNotebook_API, merging it with any existing metadata from the manifest
+3. IF the `parameters` field in the manifest entry is an empty object, THEN THE Notebook_Importer SHALL omit the `parameters` field from the UpdateNotebook_API call
+4. IF the `metadata` field in the manifest entry is an empty object, THEN THE Notebook_Importer SHALL still include the `metadata` field in the UpdateNotebook_API call containing only the `smus-cicd-source-notebook-id` key
+5. IF the `environmentConfiguration` field in the manifest entry is null, THEN THE Notebook_Importer SHALL omit the `environmentConfiguration` field from the UpdateNotebook_API call
+6. IF the UpdateNotebook_API returns any error (including ValidationException), THEN THE Notebook_Importer SHALL log the notebook ID and error details, and count the notebook as FAILED
+7. WHEN the Notebook_Importer reports the sync summary, THE Notebook_Importer SHALL report counts of created, updated, and failed notebooks — there is no separate warning category
+8. THE UpdateNotebook_API call covers the fields `name`, `description`, `parameters`, `metadata`, and `environmentConfiguration`. The `cellOrder` field (notebook cell structure) is handled by StartNotebookSync via the .ipynb file content. The `status` field is not ported — target notebooks remain ACTIVE
 
-### Requirement 12: Documentation — Notebook Name-Based Update Semantics
+### Requirement 11: Documentation — Source ID-Based Tracking Semantics
 
-**User Story:** As a developer reading the documentation, I want to clearly understand that notebook updates are matched by name, so that I am aware that notebooks with the same name in the target environment will be replaced during deployment.
+**User Story:** As a developer reading the documentation, I want to clearly understand that notebooks are tracked by source ID via metadata, so that I am aware of how deployments create, update, and destroy notebooks in the target environment.
 
 #### Acceptance Criteria
 
-1. THE customer-facing documentation for this feature SHALL prominently state that notebooks are identified by name across environments, and that any existing notebook with the same name in the target project will be replaced (old version deleted) during deployment
-2. THE documentation SHALL include a warning or callout box emphasizing that notebooks in the target environment with matching names will be overwritten regardless of whether they were originally deployed by this CI/CD tool
-3. THE documentation SHALL recommend that users adopt a consistent notebook naming convention across environments and verify notebook names before running the deploy command
-4. THE documentation SHALL appear in the CLI help text for the deploy command (when notebooks are involved) as a brief reminder that notebook updates are name-based
+1. THE customer-facing documentation for this feature SHALL prominently state that notebooks are tracked across environments using the `smus-cicd-source-notebook-id` metadata key, and that existing notebooks with matching source IDs in the target project will be updated in-place during deployment
+2. THE documentation SHALL include a warning or callout box emphasizing that run history is preserved when updating existing notebooks, and that notebooks without the metadata marker are never modified or deleted by the deploy command
+3. THE documentation SHALL explain that the destroy command only removes notebooks that contain the `smus-cicd-source-notebook-id` metadata key, ensuring manually created notebooks in the target are not affected
+4. THE documentation SHALL recommend that users do not manually modify the `smus-cicd-source-notebook-id` metadata key in target notebooks, as doing so could disrupt the source-to-target tracking mechanism
+5. THE documentation SHALL explain that the optional `notebook_ids` manifest field allows users to selectively export specific notebooks by their ID, and that omitting the field exports all active notebooks from the source project
+6. THE documentation SHALL appear in the CLI help text for the deploy command (when notebooks are involved) as a brief reminder that notebook updates preserve run history and are tracked by source ID

--- a/.kiro/specs/data-notebooks-support/requirements.md
+++ b/.kiro/specs/data-notebooks-support/requirements.md
@@ -1,0 +1,208 @@
+# Requirements Document
+
+## Introduction
+
+This feature adds native Data Notebooks support to the SMUS CI/CD package, enabling promotion of SageMaker Unified Studio notebooks across environments (dev → test → prod) using the DataZone Import/Export Notebook APIs. Unlike the current approach where notebooks are deployed as raw `.ipynb` files to S3 storage connections (and then executed via the SageMakerNotebookOperator in Airflow), this feature uses the DataZone `StartNotebookExport` and `StartNotebookImport` APIs to export notebooks from a source SMUS project and import them as first-class notebook resources into target SMUS projects. This enables notebooks to appear natively in the SageMaker Unified Studio IDE in the target environment, preserving their metadata, name, and description rather than existing only as S3 files that require workflow-based execution.
+
+The export process uses `ListNotebooks` to discover notebooks in the source project, `GetNotebook` to retrieve each notebook's full metadata (including parameters, metadata, and environmentConfiguration), `StartNotebookExport` to initiate an asynchronous export of each notebook to IPYNB format, and `GetNotebookExport` to poll for completion and retrieve the S3 output location. The exported `.ipynb` files are included in the bundle archive. During deployment, the import follows an upsert (create-or-replace) strategy: existing notebooks with the same name in the target project are detected via `ListNotebooks`, the new notebook is always created via `StartNotebookImport` (since duplicate names are allowed), polled until ACTIVE via `GetNotebook`, updated with metadata via `UpdateNotebook`, and only then is the old notebook (if any) deleted via `DeleteNotebook`. This ensures zero data loss — the old version is only removed after the new version is confirmed working.
+
+**Out of Scope:** Notebook schedules are explicitly out of scope for this iteration. No public API for schedule management currently exists; this will be revisited with the team in a future iteration.
+
+## Glossary
+
+- **CLI**: The `aws-smus-cicd-cli` command-line interface for SMUS CI/CD operations
+- **Bundle_Command**: The CLI command that packages application content into a deployable ZIP archive
+- **Deploy_Command**: The CLI command that deploys a bundle archive to a target stage's DataZone project
+- **Notebook_Exporter**: The component responsible for listing project notebooks via `ListNotebooks`, exporting them via `StartNotebookExport`, polling via `GetNotebookExport`, and downloading the exported `.ipynb` files
+- **Notebook_Importer**: The component responsible for uploading `.ipynb` files to S3, performing upsert operations (create new notebook via `StartNotebookImport`, poll until ACTIVE, apply metadata via `UpdateNotebook`, then delete old notebook with same name if one existed)
+- **DataZone_Domain**: An Amazon DataZone domain that contains projects and notebook resources
+- **DataZone_Project**: A project within a DataZone domain that owns notebook resources
+- **SMUS_Notebook**: A notebook resource natively managed by SageMaker Unified Studio, identified by a notebook ID and owned by a project
+- **Notebook_Export**: An asynchronous operation initiated by `StartNotebookExport` that exports a notebook to a specified file format and stores the output in S3
+- **Notebook_Import**: An operation initiated by `StartNotebookImport` that creates a notebook resource in a project from an S3 source location (always creates a new notebook; duplicate names are allowed)
+- **Notebook_Export_Manifest**: A JSON metadata file included in the bundle that records the mapping between notebook names, IDs, and exported file paths
+- **ListNotebooks_API**: The DataZone API that lists notebooks owned by a project, supporting pagination, status filtering, and sorting
+- **GetNotebook_API**: The DataZone API that retrieves the full details of a notebook resource including its parameters, metadata, and environmentConfiguration fields
+- **StartNotebookExport_API**: The DataZone API that initiates an asynchronous notebook export to PDF or IPYNB format
+- **GetNotebookExport_API**: The DataZone API that retrieves the status and output location of a notebook export operation
+- **StartNotebookImport_API**: The DataZone API that imports a notebook from an S3 location into a project, creating a new notebook resource (duplicate names are allowed, so this always succeeds without ConflictException)
+- **UpdateNotebook_API**: The DataZone API that updates a notebook resource's mutable fields including parameters, metadata, and environmentConfiguration
+- **DeleteNotebook_API**: The DataZone API that deletes a notebook resource from a project, used to remove old versions after a successful upsert
+- **Manifest**: The `manifest.yaml` file that defines application content, stages, and deployment configuration
+- **S3_Connection**: An S3 connection associated with a DataZone project, used for storing exported notebook files
+- **Output_Location**: The S3 URI where an exported notebook file is stored after a successful export operation
+- **Upsert**: The import strategy where a notebook is always created as new, and if an existing notebook with the same name was found, the old one is deleted only after the new one is fully active and updated
+
+## Requirements
+
+### Requirement 1: Manifest Configuration for Notebook Export
+
+**User Story:** As a developer, I want to configure notebook export in my manifest.yaml, so that the bundle command knows which notebooks to export from my SMUS project.
+
+#### Acceptance Criteria
+
+1. THE Manifest SHALL support a `content.notebooks` section to configure notebook export
+2. THE `content.notebooks` section SHALL support an `enabled` boolean field to enable or disable notebook export (default: false)
+3. IF `content.notebooks.enabled` is set to true and no `include_names` filter is specified, THEN THE Bundle_Command SHALL export all active notebooks owned by the source project
+4. THE `content.notebooks` section SHALL support an optional `include_names` field containing a list of notebook name strings to export, where each entry is a notebook name (up to 256 characters, case-sensitive exact match)
+5. IF `content.notebooks.include_names` is specified, THEN THE Bundle_Command SHALL match each entry against the notebook name (case-sensitive exact match) and export notebooks that match
+6. THE `content.notebooks` section SHALL support an optional `exclude_names` field containing a list of notebook name strings to exclude from export, where each entry is a notebook name (up to 256 characters, case-sensitive exact match)
+7. IF `content.notebooks.exclude_names` is specified, THEN THE Bundle_Command SHALL match each entry against the notebook name (case-sensitive exact match) and exclude notebooks that match
+8. IF both `include_names` and `exclude_names` are specified, THEN THE Bundle_Command SHALL apply `include_names` first (selecting matching notebooks), then apply `exclude_names` to remove any matches from the selected set
+9. IF `content.notebooks.enabled` is false or absent, THEN THE Bundle_Command SHALL skip notebook export regardless of whether `include_names` or `exclude_names` fields are present
+10. IF an entry in the `include_names` list does not match any active notebook in the source project, THEN THE Bundle_Command SHALL log a warning identifying the unmatched name and continue exporting the remaining matched notebooks
+11. IF the `include_names` or `exclude_names` field is present but contains an empty list, THEN THE Bundle_Command SHALL raise a validation error indicating that the list must contain at least one entry
+
+### Requirement 2: Export Notebooks During Bundle
+
+**User Story:** As a developer, I want the bundle command to export SMUS notebooks from my source project, so that I can promote notebook resources across stages.
+
+#### Acceptance Criteria
+
+1. WHEN the bundle command runs and `content.notebooks.enabled` is true, THE Notebook_Exporter SHALL call the ListNotebooks_API to discover all active notebooks owned by the source project, using the `domainIdentifier`, `owningProjectIdentifier` parameter, and filtering by `status=ACTIVE`
+2. THE Notebook_Exporter SHALL handle pagination by following `nextToken` until all notebooks are retrieved from the ListNotebooks_API
+3. WHEN a notebook is selected for export, THE Notebook_Exporter SHALL call the GetNotebook_API with `domainIdentifier` and `notebookIdentifier` to retrieve the notebook's `parameters`, `metadata`, and `environmentConfiguration` fields
+4. WHEN a notebook is selected for export, THE Notebook_Exporter SHALL call the StartNotebookExport_API with `domainIdentifier`, `fileFormat` set to `IPYNB`, the notebook's identifier as `notebookIdentifier`, and the source project identifier as `owningProjectIdentifier`
+5. WHEN the StartNotebookExport_API returns an export identifier, THE Notebook_Exporter SHALL poll the GetNotebookExport_API using exponential backoff starting at 2 seconds and capped at 30 seconds per interval, until the export status transitions from `IN_PROGRESS` to `SUCCEEDED` or `FAILED`
+6. WHEN the export status is `SUCCEEDED`, THE Notebook_Exporter SHALL download the exported `.ipynb` file from the `outputLocation` S3 URI returned by GetNotebookExport_API
+7. IF the export status is `FAILED`, THEN THE Notebook_Exporter SHALL log the error message from the `error` field, count the notebook as failed, and continue with the next notebook
+8. THE Notebook_Exporter SHALL store each exported `.ipynb` file in a `notebooks/` directory within the bundle archive, using the notebook's source identifier as the filename (e.g., `notebooks/{sourceNotebookId}.ipynb`)
+9. THE Notebook_Exporter SHALL produce a `notebooks/notebook_export_manifest.json` metadata file in the bundle containing the list of exported notebooks with their source IDs, names, descriptions, file paths within the bundle, and the `parameters`, `metadata`, and `environmentConfiguration` fields retrieved from the GetNotebook_API
+10. THE Notebook_Exporter SHALL implement a configurable polling timeout with a default of 300 seconds per notebook to avoid indefinite waiting on stuck export operations
+11. IF the polling timeout is exceeded for a notebook export, THEN THE Notebook_Exporter SHALL log a warning including the notebook name and elapsed time, count the notebook as failed, and continue with the next notebook
+12. WHEN all notebooks have been processed, IF any notebooks failed to export, THEN THE Bundle_Command SHALL exit with a non-zero exit code and output a failure message listing the names of all notebooks that failed and their respective error messages
+
+### Requirement 3: Notebook Export Manifest Serialization
+
+**User Story:** As a developer, I want the exported notebook metadata to be stored in a structured manifest file, so that the import process has the information needed to recreate notebooks in the target project.
+
+#### Acceptance Criteria
+
+1. THE Notebook_Exporter SHALL produce a UTF-8 encoded JSON file at `notebooks/notebook_export_manifest.json` within the bundle archive
+2. THE Notebook_Export_Manifest SHALL contain a top-level object with exactly two keys: `metadata` (object) and `notebooks` (array)
+3. THE `metadata` section SHALL include `sourceProjectId` (string), `sourceDomainId` (string), `exportTimestamp` (string in ISO 8601 format, e.g. `2024-01-15T10:30:00Z`), and `notebookCount` (integer equal to the length of the `notebooks` array)
+4. EACH entry in the `notebooks` array SHALL include `sourceNotebookId` (string), `name` (string), `description` (string, empty string if the source notebook has no description), `filePath` (string, relative path within the bundle pointing to an existing `.ipynb` file), `exportedAt` (string in ISO 8601 format), `parameters` (object, string-to-string map with up to 50 entries where keys are max 128 characters and values are max 1024 characters, empty object if the source notebook has no parameters), `metadata` (object, string-to-string map with up to 50 entries where keys are max 128 characters and values are max 1024 characters, empty object if the source notebook has no metadata), and `environmentConfiguration` (object containing `imageVersion` string, and `packageConfig` object with `packageManager` string and `packageSpecification` string; null if the source notebook has no environment configuration)
+5. THE Notebook_Export_Manifest SHALL be valid JSON parseable by a standard JSON parser, and every `filePath` entry SHALL correspond to a file present in the bundle archive
+6. IF the source project has no notebooks matching the configured filters, THEN THE Notebook_Exporter SHALL produce a Notebook_Export_Manifest with an empty `notebooks` array and `notebookCount` set to 0
+
+### Requirement 4: Import Notebooks During Deploy (Upsert)
+
+**User Story:** As a developer, I want the deploy command to import notebooks into the target SMUS project using an upsert strategy, so that exported notebooks appear as native notebook resources in the target environment and existing notebooks with the same name are seamlessly replaced without data loss.
+
+#### Acceptance Criteria
+
+1. WHEN the deploy command processes a bundle containing a `notebooks/notebook_export_manifest.json` file, THE Deploy_Command SHALL invoke the Notebook_Importer after storage deployments
+2. WHEN the Notebook_Importer is invoked, THE Notebook_Importer SHALL upload each exported `.ipynb` file referenced in the Notebook_Export_Manifest from the bundle to the target project's `default.s3_shared` connection S3 URI under a `notebooks/imports/` prefix
+3. WHEN a notebook entry in the Notebook_Export_Manifest references a `filePath` that does not exist in the bundle archive, THE Notebook_Importer SHALL log an error identifying the missing file and notebook name, count it as failed, and continue with the next notebook
+4. BEFORE importing each notebook, THE Notebook_Importer SHALL call the ListNotebooks_API with `owningProjectIdentifier` and `status=ACTIVE` filter on the target project to discover existing notebooks, and identify any notebook with a name matching the notebook being imported as the "old version"
+5. FOR EACH notebook in the Notebook_Export_Manifest whose file was successfully uploaded, THE Notebook_Importer SHALL call the StartNotebookImport_API with the notebook's `name`, `description`, the target project's `owningProjectIdentifier`, the target project's domain identifier as `domainIdentifier`, and the `sourceLocation` pointing to the uploaded S3 file
+6. THE Notebook_Importer SHALL use a client token derived from the notebook name and deployment timestamp, truncated to a maximum of 64 characters, to ensure idempotent import operations (retrying the same deploy produces the same notebook, not a duplicate)
+7. WHEN the StartNotebookImport_API returns a notebook identifier, THE Notebook_Importer SHALL poll the GetNotebook_API with exponential backoff (starting at 1 second, doubling on each poll, capped at 10 seconds) until the newly created notebook's status is `ACTIVE`
+8. IF the newly created notebook does not reach `ACTIVE` status within 120 seconds, THEN THE Notebook_Importer SHALL log a warning including the notebook name and elapsed time, count the notebook as failed, and continue with the next notebook
+9. WHEN the newly created notebook status is `ACTIVE`, THE Notebook_Importer SHALL call the UpdateNotebook_API with the target project's `domainIdentifier`, the newly imported notebook's identifier, `owningProjectIdentifier`, and the `parameters`, `metadata`, and `environmentConfiguration` values from the manifest
+10. IF an old version notebook with the same name was identified in step 4, THEN THE Notebook_Importer SHALL delete the old notebook via the DeleteNotebook_API only after the new notebook has reached ACTIVE status and the UpdateNotebook_API call has completed (successfully or with a warning)
+11. IF the DeleteNotebook_API call for the old version fails, THEN THE Notebook_Importer SHALL log a warning including the old notebook name and identifier and error details, but SHALL NOT count the overall notebook import as failed (the new notebook is already active)
+12. IF the StartNotebookImport_API returns any error, THEN THE Notebook_Importer SHALL log the error with notebook name and error details, count the notebook as failed, and continue with the next notebook
+13. WHEN all notebooks in the Notebook_Export_Manifest have been processed, THE Notebook_Importer SHALL output to stdout the counts of imported (new, no previous version existed), updated (replaced an existing notebook with the same name), and failed notebooks as the import summary
+14. WHEN all notebooks in the Notebook_Export_Manifest have been processed, IF any notebooks failed to import or update, THEN THE Deploy_Command SHALL exit with a non-zero exit code and output a failure message listing the names of all notebooks that failed and their respective error messages
+
+### Requirement 5: Deploy Command Integration
+
+**User Story:** As a developer, I want notebook import to be integrated into the existing deploy command flow, so that notebooks are deployed alongside other bundle content.
+
+#### Acceptance Criteria
+
+1. THE Deploy_Command SHALL process notebook imports after storage and catalog deployments, and before bootstrap actions
+2. WHERE the stage's `deployment_configuration.notebooks.disable` is set to true, THE Deploy_Command SHALL skip notebook import for that stage and log an informational message indicating notebook import was skipped due to configuration
+3. IF notebook import is not disabled and the bundle contains a `notebooks/notebook_export_manifest.json`, THEN THE Deploy_Command SHALL invoke the Notebook_Importer to process the notebooks listed in the manifest
+4. IF the bundle does not contain a `notebooks/notebook_export_manifest.json`, THEN THE Deploy_Command SHALL skip notebook import without producing any warning or error output
+5. WHEN the Notebook_Importer completes processing, THE Deploy_Command SHALL report the notebook import summary (imported count, updated count, failed count) in the overall deployment output
+
+### Requirement 6: S3 Upload for Notebook Import
+
+**User Story:** As a developer, I want exported notebook files to be uploaded to an accessible S3 location before import, so that the StartNotebookImport API can read them.
+
+#### Acceptance Criteria
+
+1. THE Notebook_Importer SHALL upload `.ipynb` files to the target project's `default.s3_shared` connection S3 URI under a `notebooks/imports/` prefix, constructing the full S3 key as `{s3Uri}/notebooks/imports/{sourceNotebookId}.ipynb`
+2. WHEN uploading notebook files, THE Notebook_Importer SHALL verify that the target project's `default.s3_shared` connection exists and contains a non-empty `s3Uri` value before attempting any uploads
+3. IF the S3 upload fails for a notebook file, THEN THE Notebook_Importer SHALL log the error including the notebook name and S3 destination key, skip the import for that notebook, and continue processing remaining notebooks
+4. IF the target project's `default.s3_shared` connection does not exist or does not contain an `s3Uri` value, THEN THE Notebook_Importer SHALL raise an error indicating the missing connection and skip all notebook imports for that project
+
+### Requirement 7: Error Handling and Resilience
+
+**User Story:** As a developer, I want robust error handling during notebook export and import, so that partial failures do not block the entire deployment.
+
+#### Acceptance Criteria
+
+1. IF the ListNotebooks_API returns an error during export, THEN THE Notebook_Exporter SHALL raise an exception with an error message including the domain identifier, project identifier, and the error response from the API
+2. IF the source project has no notebooks matching the configured filters, THEN THE Notebook_Exporter SHALL produce an empty Notebook_Export_Manifest with zero notebooks and log an informational message indicating the project identifier and the filters that were applied
+3. IF a StartNotebookExport_API call fails for a specific notebook during export, THEN THE Notebook_Exporter SHALL log the notebook name and error, then continue with the next notebook
+4. IF the Notebook_Export_Manifest is missing the top-level `metadata` or `notebooks` keys, or if `metadata` is missing any of `sourceProjectId`, `sourceDomainId`, `exportTimestamp`, or `notebookCount`, THEN THE Notebook_Importer SHALL raise a validation error before attempting any API calls
+5. IF any notebook imports or updates fail, THEN THE Deploy_Command SHALL fail the overall deployment with a non-zero exit code and output a failure message listing the names of all notebooks that failed and their respective error messages
+6. THE Notebook_Exporter SHALL implement exponential backoff with jitter when polling GetNotebookExport_API, starting at an initial interval of 1 second, doubling on each poll, up to a maximum interval of 30 seconds per poll
+7. IF a ThrottlingException is received from any DataZone API call, THEN THE component SHALL retry the request with exponential backoff starting at 1 second and doubling on each retry, up to a maximum of 3 retries
+
+### Requirement 8: Dry Run Validation for Notebooks
+
+**User Story:** As a developer, I want the deploy dry-run to validate notebook import prerequisites, so that I can detect issues before actual deployment.
+
+#### Acceptance Criteria
+
+1. WHEN the deploy command runs with `--dry-run` and the bundle contains a `notebooks/notebook_export_manifest.json` file, THE Dry_Run_Engine SHALL verify that the target project's `default.s3_shared` connection exists and is reachable by performing a HEAD request against the S3 bucket resolved from the connection
+2. WHEN the deploy command runs with `--dry-run` and the bundle contains a `notebooks/notebook_export_manifest.json` file, THE Dry_Run_Engine SHALL verify that the IAM identity has the `datazone:StartNotebookImport`, `datazone:UpdateNotebook`, `datazone:GetNotebook`, `datazone:DeleteNotebook`, `datazone:ListNotebooks`, and `s3:PutObject` permissions using `iam:SimulatePrincipalPolicy`
+3. WHEN the deploy command runs with `--dry-run` and the bundle contains a `notebooks/notebook_export_manifest.json` file, THE Dry_Run_Engine SHALL report the number of notebooks that would be imported (read from the manifest's `notebookCount` field) in the dry-run output
+4. IF the S3 connection is not found or the HEAD request to the resolved S3 bucket fails, THEN THE Dry_Run_Engine SHALL report a WARNING finding indicating the connection name and the failure reason
+5. IF `iam:SimulatePrincipalPolicy` reports a denied decision for `datazone:StartNotebookImport`, `datazone:UpdateNotebook`, `datazone:GetNotebook`, `datazone:DeleteNotebook`, `datazone:ListNotebooks`, or `s3:PutObject`, THEN THE Dry_Run_Engine SHALL report a WARNING finding indicating the denied permission name and resource ARN
+
+### Requirement 9: Destroy Command Support for Notebooks
+
+**User Story:** As a developer, I want the destroy command to clean up imported notebooks, so that I can remove all deployed resources from a target environment.
+
+#### Acceptance Criteria
+
+1. WHEN the destroy command validates a target stage and `content.notebooks.enabled` is true in the manifest, THE Destroy_Command SHALL call the ListNotebooks_API with the target project's `owningProjectIdentifier` and `status=ACTIVE` filter to discover notebook resources, handling pagination by following `nextToken` until all notebooks are retrieved
+2. THE Destroy_Command SHALL apply the same `include_names` and `exclude_names` filters from the manifest's `content.notebooks` section to the discovered notebooks, matching by notebook name (case-sensitive exact match) only
+3. IF the ListNotebooks_API returns an error during validation, THEN THE Destroy_Command SHALL report the error and fail validation for that stage
+4. THE Destroy_Command SHALL display each filtered notebook's name and identifier in the destruction plan under a `notebook` resource type for user confirmation before deletion
+5. IF the user confirms destruction, THEN THE Destroy_Command SHALL delete each notebook resource in the target project using the DataZone domain identifier and notebook identifier, continuing to the next notebook if an individual deletion fails
+6. IF a notebook is not found at deletion time (ResourceNotFoundException), THEN THE Destroy_Command SHALL record the notebook as `not_found` and continue with the next notebook
+7. IF a notebook deletion fails with any other error, THEN THE Destroy_Command SHALL log the notebook name and error details, record the notebook as `error`, and continue with the next notebook
+8. THE Destroy_Command SHALL report the count of deleted, not_found, and failed notebook deletions in the destruction summary consistent with the existing summary format
+
+### Requirement 10: Port Notebook Metadata via UpdateNotebook (Upsert Flow)
+
+**User Story:** As a developer, I want imported notebooks to retain their parameters, metadata, and environment configuration from the source notebook, so that notebooks in the target environment behave identically to those in the source environment.
+
+#### Acceptance Criteria
+
+1. WITHIN the upsert flow, WHEN the newly imported notebook reaches `ACTIVE` status, THE Notebook_Importer SHALL call the UpdateNotebook_API with the target project's `domainIdentifier`, the newly imported notebook's identifier, `owningProjectIdentifier`, and the `parameters`, `metadata`, and `environmentConfiguration` values from the manifest, BEFORE deleting the old notebook (if one exists)
+2. IF the `parameters` field in the manifest entry is an empty object, THEN THE Notebook_Importer SHALL omit the `parameters` field from the UpdateNotebook_API call
+3. IF the `metadata` field in the manifest entry is an empty object, THEN THE Notebook_Importer SHALL omit the `metadata` field from the UpdateNotebook_API call
+4. IF the `environmentConfiguration` field in the manifest entry is null, THEN THE Notebook_Importer SHALL omit the `environmentConfiguration` field from the UpdateNotebook_API call
+5. IF the UpdateNotebook_API returns a ValidationException due to invalid parameter constraints (keys exceeding 128 characters, values exceeding 1024 characters, or more than 50 entries), THEN THE Notebook_Importer SHALL log a warning including the notebook name and validation error, and count the notebook as imported with a metadata warning
+6. IF the UpdateNotebook_API returns any other error, THEN THE Notebook_Importer SHALL log the notebook name and error details, and count the notebook as imported with a metadata warning rather than failed
+7. WHEN the Notebook_Importer reports the import summary, THE Notebook_Importer SHALL include a count of notebooks where metadata porting encountered warnings alongside the imported, updated, and failed counts
+
+### Requirement 11: Unique Notebook Names Enforcement
+
+**User Story:** As a developer, I want the bundle command to enforce unique notebook names, so that the upsert logic can reliably identify which notebook is being created or updated in the target environment.
+
+#### Acceptance Criteria
+
+1. AFTER applying the `include_names` and `exclude_names` filters, THE Notebook_Exporter SHALL verify that all selected notebooks have unique names (case-sensitive comparison)
+2. IF the selected notebooks contain two or more notebooks with the same name, THEN THE Bundle_Command SHALL skip exporting any notebooks and fail with a non-zero exit code, outputting an error message listing the duplicate notebook name(s) and the count of notebooks sharing each name
+3. THE error message SHALL instruct the user to resolve the duplicate names in the source project or use `include_names`/`exclude_names` filters to select only one notebook per name before re-running the bundle command
+4. WHEN the Notebook_Importer reads the `notebook_export_manifest.json` during deploy, THE Notebook_Importer SHALL validate that all notebook entries in the manifest have unique `name` values (case-sensitive comparison) before attempting any import operations
+5. IF the manifest contains two or more notebook entries with the same `name` value, THEN THE Notebook_Importer SHALL raise a validation error and skip all notebook imports for that deployment
+
+### Requirement 12: Documentation — Notebook Name-Based Update Semantics
+
+**User Story:** As a developer reading the documentation, I want to clearly understand that notebook updates are matched by name, so that I am aware that notebooks with the same name in the target environment will be replaced during deployment.
+
+#### Acceptance Criteria
+
+1. THE customer-facing documentation for this feature SHALL prominently state that notebooks are identified by name across environments, and that any existing notebook with the same name in the target project will be replaced (old version deleted) during deployment
+2. THE documentation SHALL include a warning or callout box emphasizing that notebooks in the target environment with matching names will be overwritten regardless of whether they were originally deployed by this CI/CD tool
+3. THE documentation SHALL recommend that users adopt a consistent notebook naming convention across environments and verify notebook names before running the deploy command
+4. THE documentation SHALL appear in the CLI help text for the deploy command (when notebooks are involved) as a brief reminder that notebook updates are name-based

--- a/.kiro/specs/data-notebooks-support/tasks.md
+++ b/.kiro/specs/data-notebooks-support/tasks.md
@@ -1,0 +1,256 @@
+# Implementation Plan: Data Notebooks Support
+
+## Overview
+
+Add native Data Notebooks support to the SMUS CI/CD CLI, enabling promotion of SageMaker Unified Studio notebooks across environments (dev → test → prod) using the DataZone Notebook Import/Export APIs. Implementation follows the existing catalog import/export architecture — new helper modules (`notebook_export.py`, `notebook_import.py`), manifest configuration, and integration into `bundle`, `deploy`, `destroy`, and `dry-run` commands.
+
+## Tasks
+
+- [ ] 1. Manifest configuration and data models
+  - [ ] 1.1 Add NotebookConfig dataclass and update ContentConfig in `application_manifest.py`
+    - Add `NotebookConfig` dataclass with `enabled: bool`, `include_names: Optional[List[str]]`, `exclude_names: Optional[List[str]]`
+    - Add `notebooks: Optional[NotebookConfig] = None` field to `ContentConfig`
+    - Add `notebooks: Optional[Dict[str, Any]] = None` field to `DeploymentConfiguration`
+    - Add parsing logic in `ApplicationManifest.from_dict()` for `content.notebooks` section and `deployment_configuration.notebooks` section
+    - Validate that `include_names`/`exclude_names` cannot be empty lists (raise validation error)
+    - _Requirements: 1.1, 1.2, 1.9, 1.11_
+
+  - [ ] 1.2 Add "notebook" resource type to destroy models
+    - Add `"notebook"` to `DESTROY_SUPPORTED_RESOURCE_TYPES` in `src/smus_cicd/helpers/destroy_models.py`
+    - Update `resource_types.py` to include `"notebook"` in `DEPLOY_RESOURCE_TYPES` if applicable
+    - _Requirements: 9.1, 9.4_
+
+  - [ ]* 1.3 Write unit tests for manifest NotebookConfig parsing
+    - Test enabled/disabled configurations
+    - Test include_names/exclude_names parsing
+    - Test empty list validation error
+    - Test deployment_configuration.notebooks.disable parsing
+    - **File**: `tests/unit/test_notebook_manifest_config.py`
+    - _Requirements: 1.1, 1.2, 1.9, 1.11_
+
+- [ ] 2. Implement notebook export helper
+  - [ ] 2.1 Create `src/smus_cicd/helpers/notebook_export.py` with core export logic
+    - Implement `export_notebooks()` main entry point
+    - Implement `_list_all_notebooks()` with pagination via `nextToken`
+    - Implement `_apply_filters()` with include-first-then-exclude logic (case-sensitive exact match on notebook name)
+    - Implement `_matches_name_filter()` helper
+    - Implement `_warn_duplicate_names()` to enforce unique names in the filtered set
+    - Implement `_export_single_notebook()` calling StartNotebookExport, polling, and downloading
+    - Implement `_poll_export_status()` with exponential backoff (initial 2s, cap 30s, timeout 300s)
+    - Implement `_build_export_manifest()` to produce the `notebook_export_manifest.json` structure
+    - Implement `_retry_on_throttle()` decorator for ThrottlingException handling (max 3 retries)
+    - Define `ExportedNotebook` and `NotebookExportManifest` dataclasses
+    - _Requirements: 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.10, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 2.10, 2.11, 2.12, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 7.1, 7.2, 7.3, 7.6, 7.7, 11.1, 11.2, 11.3_
+
+  - [ ]* 2.2 Write property test: Include/Exclude Name-Only Filter Algebra
+    - **Property 1: Include/Exclude Name-Only Filter Algebra**
+    - **Validates: Requirements 1.5, 1.7, 1.8, 9.2**
+    - **File**: `tests/unit/helpers/test_notebook_properties.py`
+
+  - [ ]* 2.3 Write property test: Pagination Completeness
+    - **Property 2: Pagination Completeness**
+    - **Validates: Requirements 2.2**
+    - **File**: `tests/unit/helpers/test_notebook_properties.py`
+
+  - [ ]* 2.4 Write property test: Export Manifest Schema Completeness
+    - **Property 3: Export Manifest Schema Completeness**
+    - **Validates: Requirements 3.2, 3.3, 3.4**
+    - **File**: `tests/unit/helpers/test_notebook_properties.py`
+
+  - [ ]* 2.5 Write property test: Bundle Internal Consistency
+    - **Property 4: Bundle Internal Consistency**
+    - **Validates: Requirements 3.5**
+    - **File**: `tests/unit/helpers/test_notebook_properties.py`
+
+  - [ ]* 2.6 Write property test: Unique Name Enforcement
+    - **Property 10: Unique Name Enforcement**
+    - **Validates: Requirements 11.1, 11.2**
+    - **File**: `tests/unit/helpers/test_notebook_properties.py`
+
+  - [ ]* 2.7 Write property test: Exponential Backoff Intervals
+    - **Property 8: Exponential Backoff Intervals**
+    - **Validates: Requirements 2.5, 7.6**
+    - **File**: `tests/unit/helpers/test_notebook_properties.py`
+
+  - [ ]* 2.8 Write unit tests for notebook export
+    - Test happy path: ListNotebooks → GetNotebook → StartNotebookExport → GetNotebookExport → S3 download
+    - Test partial failures (some notebooks fail, others succeed)
+    - Test duplicate notebook names (bundle fails)
+    - Test empty project (empty manifest produced)
+    - Test unmatched include_names (warning logged, continue)
+    - Test polling timeout handling
+    - **File**: `tests/unit/helpers/test_notebook_export.py`
+    - _Requirements: 2.1, 2.2, 2.7, 2.10, 2.11, 2.12, 3.6, 7.1, 7.2, 7.3, 11.1_
+
+- [ ] 3. Checkpoint - Ensure export tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 4. Implement notebook import helper
+  - [ ] 4.1 Create `src/smus_cicd/helpers/notebook_import.py` with upsert import logic
+    - Implement `import_notebooks()` main entry point
+    - Implement `_validate_notebook_manifest()` to validate required manifest keys
+    - Implement `_warn_manifest_duplicates()` to reject duplicate names in manifest
+    - Implement `_list_existing_notebooks_by_name()` to discover old versions in target project
+    - Implement `_find_old_versions()` helper
+    - Implement `_upload_notebook_to_s3()` using `{s3Uri}/notebooks/imports/{sourceNotebookId}.ipynb`
+    - Implement `_generate_client_token()` (deterministic, max 64 chars)
+    - Implement `_import_single_notebook()` with full upsert flow: upload → StartNotebookImport → poll ACTIVE → UpdateNotebook → delete old versions
+    - Implement `_poll_notebook_active()` (exponential backoff: initial 1s, cap 10s, timeout 120s)
+    - Implement `_apply_notebook_metadata()` calling UpdateNotebook API
+    - Implement `_build_update_kwargs()` omitting empty fields
+    - Implement `_delete_old_versions()` with warning-only on failure
+    - Define `NotebookImportSummary`, `ImportResult`, `ImportStatus` dataclasses/enum
+    - Reuse `_retry_on_throttle()` from notebook_export or shared utility
+    - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 4.10, 4.11, 4.12, 4.13, 4.14, 6.1, 6.2, 6.3, 6.4, 7.4, 7.5, 7.7, 10.1, 10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 11.4, 11.5_
+
+  - [ ]* 4.2 Write property test: Client Token Determinism and Bounds
+    - **Property 5: Client Token Determinism and Bounds**
+    - **Validates: Requirements 4.6**
+    - **File**: `tests/unit/helpers/test_notebook_properties.py`
+
+  - [ ]* 4.3 Write property test: Manifest Validation Rejects Malformed Input
+    - **Property 6: Manifest Validation Rejects Malformed Input**
+    - **Validates: Requirements 7.4**
+    - **File**: `tests/unit/helpers/test_notebook_properties.py`
+
+  - [ ]* 4.4 Write property test: UpdateNotebook Omits Empty Fields
+    - **Property 7: UpdateNotebook Omits Empty Fields**
+    - **Validates: Requirements 10.2, 10.3, 10.4**
+    - **File**: `tests/unit/helpers/test_notebook_properties.py`
+
+  - [ ]* 4.5 Write property test: Upsert Ordering Safety
+    - **Property 9: Upsert Ordering Safety**
+    - **Validates: Requirements 4.10, 10.1**
+    - **File**: `tests/unit/helpers/test_notebook_properties.py`
+
+  - [ ]* 4.6 Write unit tests for notebook import
+    - Test upsert happy path: old version found → upload → import → poll ACTIVE → UpdateNotebook → delete old
+    - Test new notebook import (no old version exists)
+    - Test missing file in bundle (counted as failed)
+    - Test UpdateNotebook failure (metadata warning, not failed)
+    - Test DeleteNotebook failure for old version (warning, not failed)
+    - Test manifest with duplicate names (validation error, import rejected)
+    - Test missing S3 connection (error raised, all imports skipped)
+    - Test malformed manifest (validation error before any API calls)
+    - **File**: `tests/unit/helpers/test_notebook_import.py`
+    - _Requirements: 4.1, 4.3, 4.10, 4.11, 4.12, 6.4, 7.4, 10.5, 10.6, 11.4, 11.5_
+
+- [ ] 5. Checkpoint - Ensure import tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 6. Integrate into bundle command
+  - [ ] 6.1 Modify `src/smus_cicd/commands/bundle.py` to call notebook export
+    - After catalog export section, check `content.notebooks.enabled`
+    - Call `export_notebooks()` with domain_id, project_id, region, include_names, exclude_names
+    - Write exported `.ipynb` files to `notebooks/` directory in the bundle ZIP
+    - Write `notebooks/notebook_export_manifest.json` to the bundle ZIP
+    - Fail bundle with non-zero exit code if any notebooks failed to export
+    - _Requirements: 1.3, 1.9, 2.1, 2.8, 2.9, 2.12_
+
+  - [ ]* 6.2 Write unit tests for bundle command notebook integration
+    - Test bundle with notebooks enabled (exports included in ZIP)
+    - Test bundle with notebooks disabled (no notebook processing)
+    - Test bundle with partial export failures (non-zero exit)
+    - **File**: `tests/unit/test_bundle_notebooks.py`
+    - _Requirements: 1.9, 2.12_
+
+- [ ] 7. Integrate into deploy command
+  - [ ] 7.1 Modify `src/smus_cicd/commands/deploy.py` to call notebook import
+    - After storage and catalog deployments, check for `notebooks/notebook_export_manifest.json` in bundle
+    - Check `deployment_configuration.notebooks.disable` for the stage — skip if true
+    - Resolve `default.s3_shared` connection's S3 URI from the target project
+    - Call `import_notebooks()` with domain_id, project_id, region, manifest_data, notebook_files, s3_uri
+    - Report import summary (imported, updated, failed counts) in deployment output
+    - Fail deploy with non-zero exit code if any notebooks failed
+    - _Requirements: 4.1, 4.13, 4.14, 5.1, 5.2, 5.3, 5.4, 5.5_
+
+  - [ ]* 7.2 Write unit tests for deploy command notebook integration
+    - Test deploy with notebook manifest present (imports invoked)
+    - Test deploy with no manifest (skip silently)
+    - Test deploy with notebooks disabled in deployment_configuration
+    - Test deploy with import failures (non-zero exit)
+    - **File**: `tests/unit/commands/test_deploy_notebooks.py`
+    - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5_
+
+- [ ] 8. Integrate into destroy command
+  - [ ] 8.1 Add notebook discovery and deletion to destroy validator and executor
+    - Add `_discover_notebooks()` to `src/smus_cicd/helpers/destroy_validator.py` using ListNotebooks with pagination and name-only filters
+    - Add `_delete_notebook()` to `src/smus_cicd/helpers/destroy_executor.py` calling DeleteNotebook API
+    - Handle ResourceNotFoundException as `not_found`, other errors as `error`
+    - Display notebooks in destruction plan under `notebook` resource type
+    - Report deleted/not_found/failed counts in destruction summary
+    - _Requirements: 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8_
+
+  - [ ]* 8.2 Write unit tests for destroy notebook integration
+    - Test notebook discovery with name filtering
+    - Test deletion with mixed results (deleted, not_found, error)
+    - Test ListNotebooks API failure during validation
+    - **File**: `tests/unit/commands/test_notebook_destroy.py`
+    - _Requirements: 9.1, 9.2, 9.3, 9.5, 9.6, 9.7, 9.8_
+
+- [ ] 9. Implement dry-run notebook checker
+  - [ ] 9.1 Create `src/smus_cicd/commands/dry_run/checkers/notebook_checker.py`
+    - Implement `NotebookChecker` class with `check()` method
+    - Verify `default.s3_shared` connection exists and bucket is accessible (HEAD request)
+    - Verify IAM permissions via `iam:SimulatePrincipalPolicy`: `datazone:StartNotebookImport`, `datazone:UpdateNotebook`, `datazone:GetNotebook`, `datazone:DeleteNotebook`, `datazone:ListNotebooks`, `s3:PutObject`
+    - Report notebook count from manifest's `notebookCount` field
+    - Report WARNING findings for missing connection or denied permissions
+    - Register checker in the dry-run engine (`src/smus_cicd/commands/dry_run/engine.py`)
+    - _Requirements: 8.1, 8.2, 8.3, 8.4, 8.5_
+
+  - [ ]* 9.2 Write unit tests for dry-run notebook checker
+    - Test S3 connection found and accessible
+    - Test S3 connection missing (WARNING finding)
+    - Test IAM permissions denied (WARNING findings)
+    - Test notebook count reported correctly
+    - **File**: `tests/unit/commands/test_notebook_dry_run.py`
+    - _Requirements: 8.1, 8.2, 8.3, 8.4, 8.5_
+
+- [ ] 10. Checkpoint - Ensure all integration tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 11. Create example and documentation
+  - [ ] 11.1 Create `examples/notebook-import-export/` example directory
+    - Create `examples/notebook-import-export/manifest.yaml` with `content.notebooks` configuration including `include_names`
+    - Create `examples/notebook-import-export/README.md` with usage documentation
+    - Create `examples/notebook-import-export/app_tests/test_notebook_lifecycle.py` end-to-end test
+    - Document name-based update semantics prominently with callout warning
+    - _Requirements: 12.1, 12.2, 12.3, 12.4_
+
+  - [ ]* 11.2 Write integration test for full notebook lifecycle
+    - Test flow: create notebooks → bundle → deploy (new) → verify → update source → bundle → deploy (upsert) → verify update → destroy → verify removed
+    - **File**: `examples/notebook-import-export/app_tests/test_notebook_lifecycle.py`
+    - _Requirements: 4.1, 4.10, 4.13, 9.5, 9.8_
+
+- [ ] 12. Final checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests validate universal correctness properties from the design document (Properties 1–10)
+- Unit tests validate specific examples, edge cases, and error paths
+- The implementation mirrors the existing `catalog_export.py` / `catalog_import.py` architecture
+- All property tests go in a single file `tests/unit/helpers/test_notebook_properties.py` following the existing `test_catalog_export_properties.py` pattern
+- The `_retry_on_throttle()` utility may be shared between export and import modules or extracted to a common helper
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "id": 0, "tasks": ["1.1", "1.2"] },
+    { "id": 1, "tasks": ["1.3", "2.1"] },
+    { "id": 2, "tasks": ["2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8"] },
+    { "id": 3, "tasks": ["4.1"] },
+    { "id": 4, "tasks": ["4.2", "4.3", "4.4", "4.5", "4.6"] },
+    { "id": 5, "tasks": ["6.1", "8.1", "9.1"] },
+    { "id": 6, "tasks": ["6.2", "7.1", "8.2", "9.2"] },
+    { "id": 7, "tasks": ["7.2"] },
+    { "id": 8, "tasks": ["11.1"] },
+    { "id": 9, "tasks": ["11.2"] }
+  ]
+}
+```

--- a/.kiro/specs/data-notebooks-support/tasks.md
+++ b/.kiro/specs/data-notebooks-support/tasks.md
@@ -2,225 +2,227 @@
 
 ## Overview
 
-Add native Data Notebooks support to the SMUS CI/CD CLI, enabling promotion of SageMaker Unified Studio notebooks across environments (dev → test → prod) using the DataZone Notebook Import/Export APIs. Implementation follows the existing catalog import/export architecture — new helper modules (`notebook_export.py`, `notebook_import.py`), manifest configuration, and integration into `bundle`, `deploy`, `destroy`, and `dry-run` commands.
+Implements native Data Notebooks support for the SMUS CI/CD CLI, enabling promotion of SageMaker Unified Studio notebooks across environments using DataZone Notebook APIs. The implementation follows the existing catalog import/export architecture with two new helper modules (`notebook_export.py` and `notebook_import.py`), manifest configuration extensions, and integration into the `bundle`, `deploy`, `destroy`, and `dry-run` commands.
 
 ## Tasks
 
-- [ ] 1. Manifest configuration and data models
-  - [ ] 1.1 Add NotebookConfig dataclass and update ContentConfig in `application_manifest.py`
-    - Add `NotebookConfig` dataclass with `enabled: bool`, `include_names: Optional[List[str]]`, `exclude_names: Optional[List[str]]`
-    - Add `notebooks: Optional[NotebookConfig] = None` field to `ContentConfig`
-    - Add `notebooks: Optional[Dict[str, Any]] = None` field to `DeploymentConfiguration`
-    - Add parsing logic in `ApplicationManifest.from_dict()` for `content.notebooks` section and `deployment_configuration.notebooks` section
-    - Validate that `include_names`/`exclude_names` cannot be empty lists (raise validation error)
-    - _Requirements: 1.1, 1.2, 1.9, 1.11_
+- [ ] 1. Extend manifest configuration and resource types
+  - [ ] 1.1 Add NotebookConfig dataclass and extend ContentConfig/DeploymentConfiguration in `application_manifest.py`
+    - Add `NotebookConfig` dataclass with `enabled: bool` and `notebook_ids: Optional[List[str]]` fields
+    - Add `notebooks: Optional[NotebookConfig] = None` to `ContentConfig`
+    - Add `notebooks: Optional[Dict[str, Any]] = None` to `DeploymentConfiguration`
+    - Update `ApplicationManifest.from_dict()` to parse `content.notebooks` and `deployment_configuration.notebooks` sections
+    - Validate `notebook_ids` entries match pattern `[a-zA-Z0-9_-]{1,36}` and list is non-empty when present
+    - _Requirements: 1.1, 1.2, 1.3, 1.8, 1.9_
 
-  - [ ] 1.2 Add "notebook" resource type to destroy models
-    - Add `"notebook"` to `DESTROY_SUPPORTED_RESOURCE_TYPES` in `src/smus_cicd/helpers/destroy_models.py`
-    - Update `resource_types.py` to include `"notebook"` in `DEPLOY_RESOURCE_TYPES` if applicable
-    - _Requirements: 9.1, 9.4_
+  - [ ] 1.2 Add `notebook` resource type to `resource_types.py` and `destroy.py`
+    - Add `"notebook"` to `DEPLOY_RESOURCE_TYPES` frozenset in `src/smus_cicd/resource_types.py`
+    - Add `"notebook"` to `DESTROY_SUPPORTED_RESOURCE_TYPES` in `src/smus_cicd/commands/destroy.py`
+    - Ensure the existing `TestDeployDestroyDrift` unit test still passes
+    - _Requirements: 9.6_
 
-  - [ ]* 1.3 Write unit tests for manifest NotebookConfig parsing
-    - Test enabled/disabled configurations
-    - Test include_names/exclude_names parsing
-    - Test empty list validation error
-    - Test deployment_configuration.notebooks.disable parsing
-    - **File**: `tests/unit/test_notebook_manifest_config.py`
-    - _Requirements: 1.1, 1.2, 1.9, 1.11_
-
-- [ ] 2. Implement notebook export helper
+- [ ] 2. Implement notebook export module
   - [ ] 2.1 Create `src/smus_cicd/helpers/notebook_export.py` with core export logic
-    - Implement `export_notebooks()` main entry point
-    - Implement `_list_all_notebooks()` with pagination via `nextToken`
-    - Implement `_apply_filters()` with include-first-then-exclude logic (case-sensitive exact match on notebook name)
-    - Implement `_matches_name_filter()` helper
-    - Implement `_warn_duplicate_names()` to enforce unique names in the filtered set
-    - Implement `_export_single_notebook()` calling StartNotebookExport, polling, and downloading
-    - Implement `_poll_export_status()` with exponential backoff (initial 2s, cap 30s, timeout 300s)
-    - Implement `_build_export_manifest()` to produce the `notebook_export_manifest.json` structure
-    - Implement `_retry_on_throttle()` decorator for ThrottlingException handling (max 3 retries)
-    - Define `ExportedNotebook` and `NotebookExportManifest` dataclasses
-    - _Requirements: 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.10, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 2.10, 2.11, 2.12, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 7.1, 7.2, 7.3, 7.6, 7.7, 11.1, 11.2, 11.3_
+    - Implement `export_notebooks()` public function with `domain_id`, `project_id`, `region`, `notebook_ids`, `polling_timeout` parameters
+    - Implement `_validate_notebook_ids()` — calls GetNotebook for each ID, collects invalid IDs, raises on any failure (fail-fast)
+    - Implement `_list_all_notebooks()` — paginated ListNotebooks with `owningProjectIdentifier` and `status=ACTIVE`
+    - Implement `_export_single_notebook()` — StartNotebookExport → poll → download from S3
+    - Implement `_poll_export_status()` — exponential backoff (initial 1s, double each poll, cap 30s) with jitter
+    - Implement `_build_export_manifest()` — builds the `notebook_export_manifest.json` structure
+    - Implement `_generate_client_token()` — deterministic, max 64 chars, from source ID + timestamp
+    - Define `ExportedNotebook` dataclass
+    - _Requirements: 1.4, 1.5, 1.6, 1.7, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 2.10, 2.11, 2.12, 2.13, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 7.1, 7.2, 7.3, 7.6, 7.7_
 
-  - [ ]* 2.2 Write property test: Include/Exclude Name-Only Filter Algebra
-    - **Property 1: Include/Exclude Name-Only Filter Algebra**
-    - **Validates: Requirements 1.5, 1.7, 1.8, 9.2**
-    - **File**: `tests/unit/helpers/test_notebook_properties.py`
+  - [ ]* 2.2 Write property test for fail-fast validation completeness (Property 1)
+    - **Property 1: Fail-Fast Validation Completeness**
+    - Test that for any list of notebook IDs with at least one invalid, all IDs are validated, all invalid IDs are collected, and zero exports occur
+    - Use hypothesis strategies: random lists of IDs with random invalid subsets, mock GetNotebook responses
+    - **Validates: Requirements 1.4, 1.5, 2.1, 2.2**
 
-  - [ ]* 2.3 Write property test: Pagination Completeness
+  - [ ]* 2.3 Write property test for pagination completeness (Property 2)
     - **Property 2: Pagination Completeness**
-    - **Validates: Requirements 2.2**
-    - **File**: `tests/unit/helpers/test_notebook_properties.py`
+    - Test that for any paginated ListNotebooks response, all entries across all pages are accumulated correctly
+    - Use hypothesis strategies: random page counts (1-10) and page sizes (1-50), mock paginator
+    - **Validates: Requirements 2.3, 2.4, 9.1**
 
-  - [ ]* 2.4 Write property test: Export Manifest Schema Completeness
-    - **Property 3: Export Manifest Schema Completeness**
-    - **Validates: Requirements 3.2, 3.3, 3.4**
-    - **File**: `tests/unit/helpers/test_notebook_properties.py`
+  - [ ]* 2.4 Write property test for export manifest schema correctness (Property 3)
+    - **Property 3: Export Manifest Schema Correctness**
+    - Test that `_build_export_manifest()` always produces valid schema with correct metadata and required fields
+    - Use hypothesis strategies: random ExportedNotebook lists (0-20 entries)
+    - **Validates: Requirements 3.2, 3.3, 3.4, 3.6**
 
-  - [ ]* 2.5 Write property test: Bundle Internal Consistency
-    - **Property 4: Bundle Internal Consistency**
-    - **Validates: Requirements 3.5**
-    - **File**: `tests/unit/helpers/test_notebook_properties.py`
-
-  - [ ]* 2.6 Write property test: Unique Name Enforcement
-    - **Property 10: Unique Name Enforcement**
-    - **Validates: Requirements 11.1, 11.2**
-    - **File**: `tests/unit/helpers/test_notebook_properties.py`
-
-  - [ ]* 2.7 Write property test: Exponential Backoff Intervals
-    - **Property 8: Exponential Backoff Intervals**
-    - **Validates: Requirements 2.5, 7.6**
-    - **File**: `tests/unit/helpers/test_notebook_properties.py`
-
-  - [ ]* 2.8 Write unit tests for notebook export
-    - Test happy path: ListNotebooks → GetNotebook → StartNotebookExport → GetNotebookExport → S3 download
-    - Test partial failures (some notebooks fail, others succeed)
-    - Test duplicate notebook names (bundle fails)
-    - Test empty project (empty manifest produced)
-    - Test unmatched include_names (warning logged, continue)
-    - Test polling timeout handling
-    - **File**: `tests/unit/helpers/test_notebook_export.py`
-    - _Requirements: 2.1, 2.2, 2.7, 2.10, 2.11, 2.12, 3.6, 7.1, 7.2, 7.3, 11.1_
-
-- [ ] 3. Checkpoint - Ensure export tests pass
-  - Ensure all tests pass, ask the user if questions arise.
-
-- [ ] 4. Implement notebook import helper
-  - [ ] 4.1 Create `src/smus_cicd/helpers/notebook_import.py` with upsert import logic
-    - Implement `import_notebooks()` main entry point
-    - Implement `_validate_notebook_manifest()` to validate required manifest keys
-    - Implement `_warn_manifest_duplicates()` to reject duplicate names in manifest
-    - Implement `_list_existing_notebooks_by_name()` to discover old versions in target project
-    - Implement `_find_old_versions()` helper
-    - Implement `_upload_notebook_to_s3()` using `{s3Uri}/notebooks/imports/{sourceNotebookId}.ipynb`
-    - Implement `_generate_client_token()` (deterministic, max 64 chars)
-    - Implement `_import_single_notebook()` with full upsert flow: upload → StartNotebookImport → poll ACTIVE → UpdateNotebook → delete old versions
-    - Implement `_poll_notebook_active()` (exponential backoff: initial 1s, cap 10s, timeout 120s)
-    - Implement `_apply_notebook_metadata()` calling UpdateNotebook API
-    - Implement `_build_update_kwargs()` omitting empty fields
-    - Implement `_delete_old_versions()` with warning-only on failure
-    - Define `NotebookImportSummary`, `ImportResult`, `ImportStatus` dataclasses/enum
-    - Reuse `_retry_on_throttle()` from notebook_export or shared utility
-    - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 4.10, 4.11, 4.12, 4.13, 4.14, 6.1, 6.2, 6.3, 6.4, 7.4, 7.5, 7.7, 10.1, 10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 11.4, 11.5_
-
-  - [ ]* 4.2 Write property test: Client Token Determinism and Bounds
+  - [ ]* 2.5 Write property test for client token determinism and bounds (Property 5)
     - **Property 5: Client Token Determinism and Bounds**
-    - **Validates: Requirements 4.6**
-    - **File**: `tests/unit/helpers/test_notebook_properties.py`
+    - Test that `_generate_client_token()` is deterministic, ≤64 chars, and distinct inputs produce distinct tokens
+    - Use hypothesis strategies: random source IDs + timestamps
+    - **Validates: Requirements 4.7**
 
-  - [ ]* 4.3 Write property test: Manifest Validation Rejects Malformed Input
-    - **Property 6: Manifest Validation Rejects Malformed Input**
-    - **Validates: Requirements 7.4**
-    - **File**: `tests/unit/helpers/test_notebook_properties.py`
+  - [ ]* 2.6 Write property test for exponential backoff intervals (Property 8)
+    - **Property 8: Exponential Backoff Intervals**
+    - Test that delay for attempt i equals min(initial × 2^(i-1), max_interval)
+    - Use hypothesis strategies: random poll counts (1-20)
+    - **Validates: Requirements 2.6, 7.6**
 
-  - [ ]* 4.4 Write property test: UpdateNotebook Omits Empty Fields
-    - **Property 7: UpdateNotebook Omits Empty Fields**
-    - **Validates: Requirements 10.2, 10.3, 10.4**
-    - **File**: `tests/unit/helpers/test_notebook_properties.py`
+  - [ ]* 2.7 Write unit tests for notebook export (`tests/unit/helpers/test_notebook_export.py`)
+    - Test manifest parsing: `content.notebooks` section (enabled/disabled, with/without notebook_ids)
+    - Test fail-fast: `notebook_ids` with mix of valid/invalid IDs → error lists all invalid
+    - Test fail-fast: `notebook_ids` with empty list → validation error
+    - Test export happy path: GetNotebook → StartNotebookExport → GetNotebookExport → S3 download
+    - Test export partial failure: some notebooks fail export, others succeed
+    - Test polling timeout: elapsed time exceeds limit → notebook counted as failed
+    - _Requirements: 1.4, 1.5, 1.8, 2.5, 2.6, 2.7, 2.8, 2.11, 2.12, 2.13, 7.1, 7.2, 7.3_
 
-  - [ ]* 4.5 Write property test: Upsert Ordering Safety
-    - **Property 9: Upsert Ordering Safety**
-    - **Validates: Requirements 4.10, 10.1**
-    - **File**: `tests/unit/helpers/test_notebook_properties.py`
+- [ ] 3. Integrate notebook export into the bundle command
+  - [ ] 3.1 Modify `src/smus_cicd/commands/bundle.py` to call `export_notebooks()` when `content.notebooks.enabled` is true
+    - After catalog export section, add notebook export integration
+    - Check `content.notebooks.enabled` flag; skip if false/absent
+    - Call `export_notebooks()` with domain_id, project_id, region, and optional notebook_ids
+    - Write exported `.ipynb` files to `notebooks/` directory in bundle ZIP
+    - Write `notebooks/notebook_export_manifest.json` to bundle ZIP
+    - Handle export failures: exit non-zero if any notebooks failed
+    - _Requirements: 1.4, 1.5, 1.6, 1.7, 1.9, 2.9, 2.10, 2.13, 3.1, 3.5_
 
-  - [ ]* 4.6 Write unit tests for notebook import
-    - Test upsert happy path: old version found → upload → import → poll ACTIVE → UpdateNotebook → delete old
-    - Test new notebook import (no old version exists)
-    - Test missing file in bundle (counted as failed)
-    - Test UpdateNotebook failure (metadata warning, not failed)
-    - Test DeleteNotebook failure for old version (warning, not failed)
-    - Test manifest with duplicate names (validation error, import rejected)
-    - Test missing S3 connection (error raised, all imports skipped)
-    - Test malformed manifest (validation error before any API calls)
-    - **File**: `tests/unit/helpers/test_notebook_import.py`
-    - _Requirements: 4.1, 4.3, 4.10, 4.11, 4.12, 6.4, 7.4, 10.5, 10.6, 11.4, 11.5_
+  - [ ]* 3.2 Write property test for bundle internal consistency (Property 4)
+    - **Property 4: Bundle Internal Consistency**
+    - Test that every `filePath` in manifest corresponds to a file in the bundle, and every `.ipynb` file is referenced
+    - Use hypothesis strategies: random notebook sets with file content, end-to-end export pipeline (mocked APIs)
+    - **Validates: Requirements 3.5**
 
-- [ ] 5. Checkpoint - Ensure import tests pass
+- [ ] 4. Checkpoint - Ensure all tests pass
   - Ensure all tests pass, ask the user if questions arise.
 
-- [ ] 6. Integrate into bundle command
-  - [ ] 6.1 Modify `src/smus_cicd/commands/bundle.py` to call notebook export
-    - After catalog export section, check `content.notebooks.enabled`
-    - Call `export_notebooks()` with domain_id, project_id, region, include_names, exclude_names
-    - Write exported `.ipynb` files to `notebooks/` directory in the bundle ZIP
-    - Write `notebooks/notebook_export_manifest.json` to the bundle ZIP
-    - Fail bundle with non-zero exit code if any notebooks failed to export
-    - _Requirements: 1.3, 1.9, 2.1, 2.8, 2.9, 2.12_
+- [ ] 5. Implement notebook import/sync module
+  - [ ] 5.1 Create `src/smus_cicd/helpers/notebook_import.py` with core sync logic
+    - Implement `sync_notebooks()` public function with the 6-step deployment sequence
+    - Implement `_validate_notebook_manifest()` — checks required metadata/notebooks keys
+    - Implement `_discover_target_notebooks()` — ListNotebooks + GetNotebook → build source→target map from metadata
+    - Implement `_upload_notebook_to_s3()` — upload to `{s3Uri}/notebooks/imports/{sourceNotebookId}.ipynb`
+    - Implement `_sync_single_notebook()` — StartNotebookSync with/without notebookId, fallback on ResourceNotFoundException
+    - Implement `_apply_notebook_metadata()` — UpdateNotebook API with name, description, metadata, params, envConfig
+    - Implement `_build_update_kwargs()` — construct kwargs with conditional field inclusion
+    - Define `NotebookSyncSummary`, `SyncResult`, `SyncStatus` dataclasses/enum
+    - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 4.10, 4.11, 4.12, 4.13, 6.1, 6.2, 6.3, 6.4, 7.4, 7.5, 7.7, 7.8, 10.1, 10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 10.8_
 
-  - [ ]* 6.2 Write unit tests for bundle command notebook integration
-    - Test bundle with notebooks enabled (exports included in ZIP)
-    - Test bundle with notebooks disabled (no notebook processing)
-    - Test bundle with partial export failures (non-zero exit)
-    - **File**: `tests/unit/test_bundle_notebooks.py`
-    - _Requirements: 1.9, 2.12_
+  - [ ]* 5.2 Write property test for manifest validation (Property 6)
+    - **Property 6: Manifest Validation Rejects Malformed Input**
+    - Test that any JSON missing required keys raises validation error before API calls
+    - Use hypothesis strategies: random dicts with strategically missing keys
+    - **Validates: Requirements 7.4**
 
-- [ ] 7. Integrate into deploy command
-  - [ ] 7.1 Modify `src/smus_cicd/commands/deploy.py` to call notebook import
-    - After storage and catalog deployments, check for `notebooks/notebook_export_manifest.json` in bundle
-    - Check `deployment_configuration.notebooks.disable` for the stage — skip if true
-    - Resolve `default.s3_shared` connection's S3 URI from the target project
-    - Call `import_notebooks()` with domain_id, project_id, region, manifest_data, notebook_files, s3_uri
-    - Report import summary (imported, updated, failed counts) in deployment output
-    - Fail deploy with non-zero exit code if any notebooks failed
-    - _Requirements: 4.1, 4.13, 4.14, 5.1, 5.2, 5.3, 5.4, 5.5_
+  - [ ]* 5.3 Write property test for UpdateNotebook kwargs construction (Property 7)
+    - **Property 7: UpdateNotebook Kwargs Construction**
+    - Test metadata always includes tracking key, parameters omitted when empty, environmentConfiguration omitted when None, name/description always present
+    - Use hypothesis strategies: random manifest entries with various empty/None/populated fields
+    - **Validates: Requirements 10.1, 10.2, 10.3, 10.4, 10.5**
 
-  - [ ]* 7.2 Write unit tests for deploy command notebook integration
-    - Test deploy with notebook manifest present (imports invoked)
-    - Test deploy with no manifest (skip silently)
-    - Test deploy with notebooks disabled in deployment_configuration
-    - Test deploy with import failures (non-zero exit)
-    - **File**: `tests/unit/commands/test_deploy_notebooks.py`
+  - [ ]* 5.4 Write property test for source-to-target metadata mapping (Property 9)
+    - **Property 9: Source-to-Target Metadata Mapping Correctness**
+    - Test that mapping includes exactly those notebooks with `smus-cicd-source-notebook-id` metadata
+    - Use hypothesis strategies: random notebooks with/without metadata key, mocked APIs
+    - **Validates: Requirements 4.3, 9.2, 9.3**
+
+  - [ ]* 5.5 Write property test for summary count invariant (Property 11)
+    - **Property 11: Summary Count Invariant**
+    - Test that `created + updated + failed` always equals total notebooks attempted
+    - Use hypothesis strategies: random sequences of SyncResult outcomes
+    - **Validates: Requirements 4.12, 10.7**
+
+  - [ ]* 5.6 Write unit tests for notebook import (`tests/unit/helpers/test_notebook_import.py`)
+    - Test sync happy path: upload → discover targets → StartNotebookSync (create) → UpdateNotebook
+    - Test sync update path: existing target found via metadata → StartNotebookSync WITH notebookId
+    - Test sync fallback: StartNotebookSync with notebookId → ResourceNotFoundException → retry without
+    - Test sync with UpdateNotebook failure → notebook counts as FAILED
+    - Test sync with missing file in bundle → count as FAILED
+    - Test manifest validation: missing keys → error before API calls
+    - Test S3 connection missing → raise error, skip all sync
+    - _Requirements: 4.3, 4.4, 4.5, 4.6, 4.8, 4.9, 4.10, 4.11, 6.2, 6.3, 6.4, 7.4, 7.8_
+
+- [ ] 6. Integrate notebook sync into the deploy command
+  - [ ] 6.1 Modify `src/smus_cicd/commands/deploy.py` to call `sync_notebooks()` after catalog import
+    - Add `_sync_notebooks_from_bundle()` function following `_import_catalog_from_bundle()` pattern
+    - Check `deployment_configuration.notebooks.disable` — skip with informational message if true
+    - Check bundle for `notebooks/notebook_export_manifest.json` — skip silently if absent
+    - Extract manifest and `.ipynb` files from bundle ZIP
+    - Resolve S3 connection (`default.s3_shared`) from target project
+    - Call `sync_notebooks()` with extracted data
+    - Report sync summary (created/updated/failed) in deployment output
+    - Return non-zero exit code if any notebooks failed
+    - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5, 7.5_
+
+  - [ ]* 6.2 Write unit tests for deploy notebook integration (`tests/unit/commands/test_deploy_notebook_sync.py`)
+    - Test `deployment_configuration.notebooks.disable: true` → skip with message
+    - Test no `notebook_export_manifest.json` in bundle → skip silently
+    - Test happy path: manifest present → sync invoked → summary reported
+    - Test sync failures → deploy exits non-zero
     - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5_
 
-- [ ] 8. Integrate into destroy command
-  - [ ] 8.1 Add notebook discovery and deletion to destroy validator and executor
-    - Add `_discover_notebooks()` to `src/smus_cicd/helpers/destroy_validator.py` using ListNotebooks with pagination and name-only filters
-    - Add `_delete_notebook()` to `src/smus_cicd/helpers/destroy_executor.py` calling DeleteNotebook API
-    - Handle ResourceNotFoundException as `not_found`, other errors as `error`
+- [ ] 7. Implement destroy support for notebooks
+  - [ ] 7.1 Add notebook discovery and deletion to `destroy_validator.py` and `destroy_executor.py`
+    - Add `_discover_notebooks()` to `destroy_validator.py`: ListNotebooks + GetNotebook → filter by `smus-cicd-source-notebook-id` metadata → optional `notebook_ids` filter
+    - Integrate into `_validate_stage()` after catalog resources section
+    - Add `_delete_notebook()` to `destroy_executor.py`: DeleteNotebook API, handle ResourceNotFoundException (not_found) and other errors
     - Display notebooks in destruction plan under `notebook` resource type
-    - Report deleted/not_found/failed counts in destruction summary
-    - _Requirements: 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8_
+    - Report counts (deleted, not_found, error) in destruction summary
+    - _Requirements: 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8, 9.9, 9.10, 9.11_
 
-  - [ ]* 8.2 Write unit tests for destroy notebook integration
-    - Test notebook discovery with name filtering
-    - Test deletion with mixed results (deleted, not_found, error)
-    - Test ListNotebooks API failure during validation
-    - **File**: `tests/unit/commands/test_notebook_destroy.py`
-    - _Requirements: 9.1, 9.2, 9.3, 9.5, 9.6, 9.7, 9.8_
+  - [ ]* 7.2 Write property test for destroy metadata-based filtering (Property 10)
+    - **Property 10: Destroy Metadata-Based Filtering**
+    - Test that only notebooks with metadata key are included; when `notebook_ids` specified, further filter by matching source IDs
+    - Use hypothesis strategies: random target notebooks + random notebook_ids lists, mocked APIs
+    - **Validates: Requirements 9.2, 9.3, 9.4, 9.5**
 
-- [ ] 9. Implement dry-run notebook checker
-  - [ ] 9.1 Create `src/smus_cicd/commands/dry_run/checkers/notebook_checker.py`
-    - Implement `NotebookChecker` class with `check()` method
-    - Verify `default.s3_shared` connection exists and bucket is accessible (HEAD request)
-    - Verify IAM permissions via `iam:SimulatePrincipalPolicy`: `datazone:StartNotebookImport`, `datazone:UpdateNotebook`, `datazone:GetNotebook`, `datazone:DeleteNotebook`, `datazone:ListNotebooks`, `s3:PutObject`
-    - Report notebook count from manifest's `notebookCount` field
-    - Report WARNING findings for missing connection or denied permissions
-    - Register checker in the dry-run engine (`src/smus_cicd/commands/dry_run/engine.py`)
-    - _Requirements: 8.1, 8.2, 8.3, 8.4, 8.5_
+  - [ ]* 7.3 Write unit tests for notebook destroy (`tests/unit/commands/test_notebook_destroy.py`)
+    - Test discovery: filters by metadata correctly, respects `notebook_ids` list
+    - Test deletion: handles ResourceNotFoundException (not_found), other errors
+    - Test source environment: no metadata → zero deletions
+    - Test ListNotebooks API failure → validation error
+    - _Requirements: 9.1, 9.2, 9.3, 9.4, 9.5, 9.7, 9.8, 9.9, 9.10, 9.11_
 
-  - [ ]* 9.2 Write unit tests for dry-run notebook checker
-    - Test S3 connection found and accessible
-    - Test S3 connection missing (WARNING finding)
-    - Test IAM permissions denied (WARNING findings)
-    - Test notebook count reported correctly
-    - **File**: `tests/unit/commands/test_notebook_dry_run.py`
-    - _Requirements: 8.1, 8.2, 8.3, 8.4, 8.5_
-
-- [ ] 10. Checkpoint - Ensure all integration tests pass
+- [ ] 8. Checkpoint - Ensure all tests pass
   - Ensure all tests pass, ask the user if questions arise.
 
-- [ ] 11. Create example and documentation
-  - [ ] 11.1 Create `examples/notebook-import-export/` example directory
-    - Create `examples/notebook-import-export/manifest.yaml` with `content.notebooks` configuration including `include_names`
-    - Create `examples/notebook-import-export/README.md` with usage documentation
-    - Create `examples/notebook-import-export/app_tests/test_notebook_lifecycle.py` end-to-end test
-    - Document name-based update semantics prominently with callout warning
-    - _Requirements: 12.1, 12.2, 12.3, 12.4_
+- [ ] 9. Implement dry-run checker for notebooks
+  - [ ] 9.1 Create `src/smus_cicd/commands/dry_run/checkers/notebook_checker.py`
+    - Implement `NotebookChecker` class following `catalog_checker.py` pattern
+    - Check S3 connection (`default.s3_shared`) exists and bucket is reachable (HEAD request)
+    - Check IAM permissions via SimulatePrincipalPolicy: `datazone:StartNotebookSync`, `datazone:UpdateNotebook`, `datazone:GetNotebook`, `datazone:ListNotebooks`, `s3:PutObject`
+    - Report notebook count from manifest's `notebookCount` field
+    - Report WARNING findings for missing connection or denied permissions
+    - _Requirements: 8.1, 8.2, 8.3, 8.4, 8.5_
 
-  - [ ]* 11.2 Write integration test for full notebook lifecycle
-    - Test flow: create notebooks → bundle → deploy (new) → verify → update source → bundle → deploy (upsert) → verify update → destroy → verify removed
-    - **File**: `examples/notebook-import-export/app_tests/test_notebook_lifecycle.py`
-    - _Requirements: 4.1, 4.10, 4.13, 9.5, 9.8_
+  - [ ] 9.2 Integrate `NotebookChecker` into the dry-run engine (`engine.py`)
+    - Register `NotebookChecker` in the checker list after catalog checker
+    - Invoke only when bundle contains `notebooks/notebook_export_manifest.json`
+    - _Requirements: 8.1, 8.2, 8.3_
+
+  - [ ]* 9.3 Write unit tests for notebook dry-run checker (`tests/unit/commands/test_notebook_dry_run.py`)
+    - Test S3 connection found and reachable → pass
+    - Test S3 connection missing → WARNING
+    - Test IAM permission denied → WARNING per denied action
+    - Test notebook count reported from manifest
+    - _Requirements: 8.1, 8.2, 8.3, 8.4, 8.5_
+
+- [ ] 10. Wire all property-based tests into a single test file
+  - [ ] 10.1 Create `tests/unit/helpers/test_notebook_properties.py` consolidating all 11 property tests
+    - Aggregate property tests from tasks 2.2-2.6, 3.2, 5.2-5.5, 7.2 into one file following `test_catalog_export_properties.py` pattern
+    - Each property uses `@settings(max_examples=100)` and `@given()` decorators
+    - Tag format: `# Feature: data-notebooks-support, Property {N}: {description}`
+    - Include shared hypothesis strategies for notebook IDs, manifest entries, metadata dicts
+    - _Requirements: All correctness properties P1-P11_
+
+- [ ] 11. Integration test following existing patterns
+  - [ ] 11.1 Create integration test directory and helpers at `tests/integration/data-notebooks/`
+    - Create `tests/integration/data-notebooks/__init__.py`
+    - Create `tests/integration/data-notebooks/notebook_test_helpers.py` with shared utilities (create test notebook, read metadata, find bundle)
+    - Create test manifest files (`manifest.yaml`, `manifest-notebooks-disabled.yaml`)
+    - _Requirements: 1.1, 5.2, 9.6_
+
+  - [ ]* 11.2 Create integration test `tests/integration/data-notebooks/test_notebook_round_trip.py`
+    - Follow `test_catalog_round_trip.py` pattern, extend `IntegrationTestBase`
+    - Test full round-trip: bundle with `notebook_ids` → deploy to target (create) → verify metadata/params → deploy again (update in-place) → verify run history preserved → destroy → verify only CI/CD-managed notebooks deleted
+    - Test `deployment_configuration.notebooks.disable: true` → skip
+    - Test empty project (no notebooks) → valid manifest with zero entries
+    - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.8, 5.1, 5.2, 9.2, 9.3, 9.7, 10.1, 10.2_
 
 - [ ] 12. Final checkpoint - Ensure all tests pass
   - Ensure all tests pass, ask the user if questions arise.
@@ -230,11 +232,11 @@ Add native Data Notebooks support to the SMUS CI/CD CLI, enabling promotion of S
 - Tasks marked with `*` are optional and can be skipped for faster MVP
 - Each task references specific requirements for traceability
 - Checkpoints ensure incremental validation
-- Property tests validate universal correctness properties from the design document (Properties 1–10)
-- Unit tests validate specific examples, edge cases, and error paths
-- The implementation mirrors the existing `catalog_export.py` / `catalog_import.py` architecture
-- All property tests go in a single file `tests/unit/helpers/test_notebook_properties.py` following the existing `test_catalog_export_properties.py` pattern
-- The `_retry_on_throttle()` utility may be shared between export and import modules or extracted to a common helper
+- Property tests validate universal correctness properties defined in the design
+- Unit tests validate specific examples and edge cases
+- The implementation language is Python, matching the existing codebase
+- All new modules follow the existing `catalog_export.py` / `catalog_import.py` patterns
+- Integration tests extend `IntegrationTestBase` and follow `test_catalog_round_trip.py` structure
 
 ## Task Dependency Graph
 
@@ -242,14 +244,14 @@ Add native Data Notebooks support to the SMUS CI/CD CLI, enabling promotion of S
 {
   "waves": [
     { "id": 0, "tasks": ["1.1", "1.2"] },
-    { "id": 1, "tasks": ["1.3", "2.1"] },
-    { "id": 2, "tasks": ["2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8"] },
-    { "id": 3, "tasks": ["4.1"] },
-    { "id": 4, "tasks": ["4.2", "4.3", "4.4", "4.5", "4.6"] },
-    { "id": 5, "tasks": ["6.1", "8.1", "9.1"] },
-    { "id": 6, "tasks": ["6.2", "7.1", "8.2", "9.2"] },
-    { "id": 7, "tasks": ["7.2"] },
-    { "id": 8, "tasks": ["11.1"] },
+    { "id": 1, "tasks": ["2.1"] },
+    { "id": 2, "tasks": ["2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "3.1"] },
+    { "id": 3, "tasks": ["3.2", "5.1"] },
+    { "id": 4, "tasks": ["5.2", "5.3", "5.4", "5.5", "5.6", "6.1"] },
+    { "id": 5, "tasks": ["6.2", "7.1"] },
+    { "id": 6, "tasks": ["7.2", "7.3", "9.1"] },
+    { "id": 7, "tasks": ["9.2", "9.3"] },
+    { "id": 8, "tasks": ["10.1", "11.1"] },
     { "id": 9, "tasks": ["11.2"] }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ aws-smus-cicd-cli destroy --manifest manifest.yaml --targets test --force
 
 **📓 Code & Workflows**
 - Jupyter notebooks
+- SageMaker Unified Studio notebooks
 - Python scripts
 - Airflow DAGs (MWAA and Amazon MWAA Serverless)
 - Lambda functions (future)
@@ -1175,6 +1176,7 @@ All setup scripts are idempotent and safe to run multiple times. Use `--dry-run`
 - **[Deployment Metrics](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/docs/pipeline-deployment-metrics.md)** - Monitoring with EventBridge
 - **[Catalog Import/Export Guide](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/docs/catalog-import-export-guide.md)** - Promote DataZone catalog resources across environments
 - **[Catalog Import/Export Quick Reference](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/docs/catalog-import-export-quick-reference.md)** - Quick reference for catalog deployment
+- **[Notebook Sync (E2E Example)](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/examples/e2e-notebook-sync/README.md)** - Export and sync notebooks across environments (bundle-deploy mode)
 - **[MCP Configuration](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/docs/mcp-configuration.md)** - MCP server configuration guide
 - **[Q CLI Conversation Examples](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/docs/q-cli-conversation-examples.md)** - Example conversations with Q CLI
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -307,6 +307,8 @@ src/smus_cicd/helpers/
 ├── project_manager.py        # Project lifecycle management
 ├── catalog_export.py         # Export catalog assets for bundling
 ├── catalog_import.py         # Import catalog assets during deploy
+├── notebook_export.py        # Export notebooks from source project for bundling
+├── notebook_import.py        # Sync notebooks into target project during deploy
 ├── bundle_storage.py         # Bundle storage and retrieval
 ├── event_emitter.py          # Deployment event emission
 ├── eventbridge_client.py     # EventBridge client wrapper
@@ -354,11 +356,16 @@ src/smus_cicd/helpers/
    - Export catalog assets from source environments for bundling
    - Import catalog assets into target environments during deploy
 
-6. **Event Emitter** (`event_emitter.py`, `eventbridge_client.py`):
+6. **Notebook Export/Sync** (`notebook_export.py`, `notebook_import.py`):
+   - Export notebooks from source project via StartNotebookExport API
+   - Sync notebooks to target projects via StartNotebookSync API
+   - Track source-to-target mapping via metadata for idempotent updates
+
+7. **Event Emitter** (`event_emitter.py`, `eventbridge_client.py`):
    - Emit deployment lifecycle events to EventBridge
    - Configurable event bus targeting
 
-7. **Project Manager** (`project_manager.py`):
+8. **Project Manager** (`project_manager.py`):
    - Project lifecycle management (create, update, delete)
    - Project-level resource coordination
 

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -263,9 +263,14 @@ Deploys bundle files to target environments (auto-initializes if needed). The de
    - Waits for subscription approval (up to 5 minutes)
    - Verifies subscription grants are completed
    - Fails deployment if catalog access cannot be obtained
-3. **Workflow Validation**: Ensures deployed workflows are accessible by the target environment
-4. **Bootstrap Actions**: Executes post-deployment actions defined in the manifest (if configured) — see [Bootstrap Actions](bootstrap-actions.md)
-5. **Deployment Metrics**: Optionally emits deployment lifecycle events to EventBridge — see [Bundle Deployment Metrics](pipeline-deployment-metrics.md)
+3. **Notebook Sync**: Syncs notebooks from the bundle into the target project:
+   - Uploads .ipynb files to the target project's S3 shared bucket
+   - Calls StartNotebookSync to create or update notebooks
+   - Applies metadata, parameters, and environment configuration via UpdateNotebook
+   - Tracks source-to-target mapping for idempotent updates
+4. **Workflow Validation**: Ensures deployed workflows are accessible by the target environment
+5. **Bootstrap Actions**: Executes post-deployment actions defined in the manifest (if configured) — see [Bootstrap Actions](bootstrap-actions.md)
+6. **Deployment Metrics**: Optionally emits deployment lifecycle events to EventBridge — see [Bundle Deployment Metrics](pipeline-deployment-metrics.md)
 
 ```bash
 aws-smus-cicd-cli deploy [OPTIONS] [TARGET_POSITIONAL]
@@ -318,7 +323,7 @@ Use `--dry-run` to preview a deployment without creating, modifying, or deleting
 > **Note:** The dry run is a best-effort validation. A passing dry run significantly reduces the risk of deployment failure but does not guarantee success. Conditions such as transient AWS service errors, IAM policy changes between validation and deployment, concurrent resource modifications, eventual consistency delays, and service quota limits may cause a deployment to fail even after a clean dry-run report.
 
 1. **Manifest Validation** — Loads and validates the manifest YAML, resolves the target stage, builds domain configuration, checks environment variable references
-2. **Bundle Exploration** — Opens the bundle archive, enumerates files, validates catalog export data if present
+2. **Bundle Exploration** — Opens the bundle archive, enumerates files, validates catalog export data and notebook manifest if present
 3. **Permission Verification** — Uses `iam:SimulatePrincipalPolicy` to check that the current IAM identity has all required permissions (S3, DataZone, Glue, IAM, QuickSight, Airflow, etc.). Also checks DataZone policy grants on the project's domain unit when catalog resources are present.
 4. **Connectivity & Reachability** — Verifies that the DataZone domain and project are reachable, S3 buckets are accessible, and Airflow environments respond
 5. **Project Initialization** — Checks whether the target project exists or would need to be created

--- a/docs/manifest-schema.md
+++ b/docs/manifest-schema.md
@@ -72,6 +72,13 @@ content:
             identifier: db.table  # Required: Asset identifier
         permission: READ       # Required: Permission level
         requestReason: "Pipeline access"  # Required: Justification
+
+  # Notebooks (bundle-deploy mode only)
+  notebooks:
+    enabled: true              # Required: Enable notebook export
+    notebook_ids:              # Optional: Specific IDs (omit for all)
+    - notebook-id-1
+    - notebook-id-2
 ```
 
 ### Stage Configuration

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -401,6 +401,43 @@ content:
 
 ---
 
+### Notebooks
+
+Export and sync SageMaker Unified Studio notebooks across environments (bundle-deploy mode only):
+
+```yaml
+content:
+  notebooks:
+    enabled: true
+    notebook_ids:        # Optional: specific notebook IDs to export
+    - abc123def456       # When omitted, all active notebooks are exported
+    - ghi789jkl012
+```
+
+**Properties:**
+- `enabled` (required): Enable notebook export during bundle
+- `notebook_ids` (optional): List of specific notebook IDs to export. When omitted, all active notebooks owned by the source project are exported. Each ID must match pattern `[a-zA-Z0-9_-]{1,36}`.
+
+**Stage-level configuration:**
+```yaml
+stages:
+  prod:
+    deployment_configuration:
+      notebooks:
+        disable: true    # Skip notebook sync for this stage
+```
+
+**Deployment Process:**
+1. Bundle: Export notebooks from source project (StartNotebookExport → download .ipynb)
+2. Deploy: Upload .ipynb files to target project's S3 shared bucket
+3. Deploy: StartNotebookSync to create or update notebooks in target
+4. Deploy: UpdateNotebook to apply name, description, metadata, parameters
+5. Tracking: Each synced notebook is tagged with `smus-cicd-source-notebook-id` metadata
+
+**Note:** Notebook sync requires the bundle-deploy workflow (`bundle` then `deploy`). Direct deploy without a bundle skips notebook sync silently.
+
+---
+
 ## Target Section
 
 Targets represent deployment environments (dev, test, prod). Each target defines domain, project, and environment-specific configurations.

--- a/examples/e2e-notebook-sync/README.md
+++ b/examples/e2e-notebook-sync/README.md
@@ -1,0 +1,73 @@
+# E2E Notebook Sync Example
+
+End-to-end test for the SMUS CI/CD notebook export and sync feature.
+
+## Overview
+
+This example tests the full notebook lifecycle:
+1. **Setup** — Creates 4 notebooks in the DEV environment with varying configurations
+2. **Bundle** — Exports only 3 of those notebooks (filtered by `notebook_ids`)
+3. **Deploy** — Syncs the exported notebooks to TEST and PROD environments
+
+> **Note:** Native SMUS notebook sync only supports the **bundle-deploy** mode
+> (`bundle` from source → `deploy` to target). Direct deploy without a bundle is
+> not supported for notebooks because the bundle export captures source notebook
+> IDs, metadata, and parameters needed for reliable create/update tracking across
+> environments.
+
+Two variants are included:
+- **IAM domain** (`manifest.yaml`) — uses tag-based domain resolution
+- **IdC domain** (`manifest-idc.yaml`) — uses name-based domain resolution
+
+## Notebooks Created by Setup
+
+| Name | Parameters | Environment Config | In Filter |
+|------|-----------|-------------------|-----------|
+| `data-prep-etl` | 4 params (input_path, output_path, refresh_mode, partition_keys) | sagemaker-distribution-v2 + pip packages | Yes |
+| `feature-engineering` | 3 params (feature_group, lookback_days, target_column) | None | Yes |
+| `model-training` | None | sagemaker-distribution-v2 + pip packages | Yes |
+| `exploratory-analysis` | None | None | **No** (excluded) |
+
+## Prerequisites
+
+1. Ensure DEV, TEST, and PROD environments are provisioned with the appropriate domains and projects.
+2. Set environment variables:
+   - `AWS_ACCOUNT_ID`
+   - `DEV_DOMAIN_REGION`
+   - `TEST_DOMAIN_REGION`
+   - `PROD_DOMAIN_REGION`
+
+## Setup (One-time, Manual)
+
+```bash
+# IAM domain:
+python examples/e2e-notebook-sync/setup_notebooks.py \
+    --manifest examples/e2e-notebook-sync/manifest.yaml \
+    --stage dev
+
+# IdC domain:
+python examples/e2e-notebook-sync/setup_notebooks.py \
+    --manifest examples/e2e-notebook-sync/manifest-idc.yaml \
+    --stage dev-idc
+```
+
+After running, copy the printed notebook IDs into the respective manifest's
+`content.notebooks.notebook_ids` list.
+
+## Running the Workflow
+
+The GitHub workflow (`.github/workflows/e2e-notebook-sync.yml`) triggers on
+pushes to `main` that modify files under `examples/e2e-notebook-sync/` or `src/`.
+
+It runs both the IAM and IdC variants in parallel using the reusable
+`smus-bundle-deploy.yml` workflow.
+
+## What It Tests
+
+- Notebook export with `notebook_ids` filtering (3 of 4 notebooks)
+- Fail-fast ID validation (invalid IDs abort before any export)
+- Bundle packaging of `.ipynb` files + manifest
+- Notebook sync to target projects (create and update paths)
+- Metadata tracking via `smus-cicd-source-notebook-id`
+- Parameter and environment configuration preservation across sync
+- Idempotency (re-running sync updates existing notebooks)

--- a/examples/e2e-notebook-sync/app_tests/__init__.py
+++ b/examples/e2e-notebook-sync/app_tests/__init__.py
@@ -1,0 +1,1 @@
+# E2E notebook sync application tests

--- a/examples/e2e-notebook-sync/app_tests/test_notebook_sync.py
+++ b/examples/e2e-notebook-sync/app_tests/test_notebook_sync.py
@@ -1,0 +1,168 @@
+"""
+Post-deploy validation tests for the E2E notebook sync example.
+
+These tests run after deploy completes and verify that notebooks were
+synced correctly to the target project.
+"""
+
+import os
+
+import boto3
+import pytest
+
+SOURCE_NOTEBOOK_METADATA_KEY = "smus-cicd-source-notebook-id"
+
+# Expected notebooks that should be synced (the 3 in the filter)
+EXPECTED_NOTEBOOK_NAMES = {"data-prep-etl", "feature-engineering", "model-training"}
+
+# Notebook that must NOT be synced (excluded from filter)
+EXCLUDED_NOTEBOOK_NAME = "exploratory-analysis"
+
+
+@pytest.fixture
+def dz_client():
+    region = os.environ.get("DOMAIN_REGION") or os.environ.get("TEST_DOMAIN_REGION", "us-east-1")
+    return boto3.client("datazone", region_name=region)
+
+
+@pytest.fixture
+def target_project_info():
+    """Resolve target project from environment variables set by the deploy step."""
+    return {
+        "domain_id": os.environ.get("DOMAIN_ID", ""),
+        "project_id": os.environ.get("PROJECT_ID", ""),
+        "region": os.environ.get("DOMAIN_REGION") or os.environ.get("TEST_DOMAIN_REGION", "us-east-1"),
+    }
+
+
+def _list_active_notebooks(dz_client, domain_id, project_id):
+    """List all ACTIVE notebooks in the target project."""
+    notebooks = []
+    next_token = None
+    while True:
+        params = {
+            "domainIdentifier": domain_id,
+            "owningProjectIdentifier": project_id,
+            "status": "ACTIVE",
+        }
+        if next_token:
+            params["nextToken"] = next_token
+        resp = dz_client.list_notebooks(**params)
+        notebooks.extend(resp.get("items", []))
+        next_token = resp.get("nextToken")
+        if not next_token:
+            break
+    return notebooks
+
+
+class TestNotebookSyncResults:
+    """Verify notebooks were synced to the target project correctly."""
+
+    def test_synced_notebooks_exist_in_target(self, dz_client, target_project_info):
+        """All 3 filtered notebooks should exist in the target project."""
+        domain_id = target_project_info["domain_id"]
+        project_id = target_project_info["project_id"]
+
+        if not domain_id or not project_id:
+            pytest.skip("DOMAIN_ID or PROJECT_ID not set — skipping post-deploy test")
+
+        notebooks = _list_active_notebooks(dz_client, domain_id, project_id)
+        notebook_names = {nb.get("name", "") for nb in notebooks}
+
+        for expected in EXPECTED_NOTEBOOK_NAMES:
+            assert expected in notebook_names, (
+                f"Expected notebook '{expected}' not found in target project. "
+                f"Found: {sorted(notebook_names)}"
+            )
+
+    def test_excluded_notebook_not_synced(self, dz_client, target_project_info):
+        """The excluded notebook (exploratory-analysis) must NOT be in the target."""
+        domain_id = target_project_info["domain_id"]
+        project_id = target_project_info["project_id"]
+
+        if not domain_id or not project_id:
+            pytest.skip("DOMAIN_ID or PROJECT_ID not set — skipping post-deploy test")
+
+        notebooks = _list_active_notebooks(dz_client, domain_id, project_id)
+        notebook_names = {nb.get("name", "") for nb in notebooks}
+
+        assert EXCLUDED_NOTEBOOK_NAME not in notebook_names, (
+            f"Excluded notebook '{EXCLUDED_NOTEBOOK_NAME}' was synced to target "
+            f"but should have been filtered out"
+        )
+
+    def test_synced_notebooks_have_tracking_metadata(self, dz_client, target_project_info):
+        """Each synced notebook must carry the smus-cicd-source-notebook-id metadata key."""
+        domain_id = target_project_info["domain_id"]
+        project_id = target_project_info["project_id"]
+
+        if not domain_id or not project_id:
+            pytest.skip("DOMAIN_ID or PROJECT_ID not set — skipping post-deploy test")
+
+        notebooks = _list_active_notebooks(dz_client, domain_id, project_id)
+
+        for nb in notebooks:
+            nb_name = nb.get("name", "")
+            if nb_name not in EXPECTED_NOTEBOOK_NAMES:
+                continue
+
+            nb_id = nb.get("id") or nb.get("notebookId") or nb.get("identifier")
+            detail = dz_client.get_notebook(
+                domainIdentifier=domain_id,
+                identifier=nb_id,
+            )
+            metadata = detail.get("metadata") or {}
+            assert SOURCE_NOTEBOOK_METADATA_KEY in metadata, (
+                f"Notebook '{nb_name}' ({nb_id}) is missing tracking metadata key "
+                f"'{SOURCE_NOTEBOOK_METADATA_KEY}'"
+            )
+
+    def test_data_prep_etl_has_parameters(self, dz_client, target_project_info):
+        """data-prep-etl notebook should have its parameters preserved after sync."""
+        domain_id = target_project_info["domain_id"]
+        project_id = target_project_info["project_id"]
+
+        if not domain_id or not project_id:
+            pytest.skip("DOMAIN_ID or PROJECT_ID not set — skipping post-deploy test")
+
+        notebooks = _list_active_notebooks(dz_client, domain_id, project_id)
+        data_prep = next(
+            (nb for nb in notebooks if nb.get("name") == "data-prep-etl"), None
+        )
+        if not data_prep:
+            pytest.fail("data-prep-etl notebook not found in target project")
+
+        nb_id = data_prep.get("id") or data_prep.get("notebookId")
+        detail = dz_client.get_notebook(
+            domainIdentifier=domain_id, identifier=nb_id
+        )
+        params = detail.get("parameters") or {}
+        assert "input_path" in params, "Expected 'input_path' parameter on data-prep-etl"
+        assert "refresh_mode" in params, "Expected 'refresh_mode' parameter on data-prep-etl"
+
+    def test_notebook_count_matches_expected(self, dz_client, target_project_info):
+        """Target project should have exactly 3 CI/CD-managed notebooks."""
+        domain_id = target_project_info["domain_id"]
+        project_id = target_project_info["project_id"]
+
+        if not domain_id or not project_id:
+            pytest.skip("DOMAIN_ID or PROJECT_ID not set — skipping post-deploy test")
+
+        notebooks = _list_active_notebooks(dz_client, domain_id, project_id)
+        cicd_notebooks = []
+        for nb in notebooks:
+            nb_id = nb.get("id") or nb.get("notebookId") or nb.get("identifier")
+            try:
+                detail = dz_client.get_notebook(
+                    domainIdentifier=domain_id, identifier=nb_id
+                )
+                metadata = detail.get("metadata") or {}
+                if SOURCE_NOTEBOOK_METADATA_KEY in metadata:
+                    cicd_notebooks.append(nb)
+            except Exception:
+                pass
+
+        assert len(cicd_notebooks) == 3, (
+            f"Expected 3 CI/CD-managed notebooks, found {len(cicd_notebooks)}: "
+            f"{[nb.get('name') for nb in cicd_notebooks]}"
+        )

--- a/examples/e2e-notebook-sync/manifest-idc.yaml
+++ b/examples/e2e-notebook-sync/manifest-idc.yaml
@@ -1,0 +1,64 @@
+# E2E Notebook Sync — IdC domain variant
+#
+# Tests the full notebook export → bundle → sync lifecycle on IdC-based
+# domains (domain resolved by name instead of tags):
+#   - DEV-IDC stage: source of truth (notebooks created by setup_notebooks.py)
+#   - TEST-IDC stage: first target for notebook sync
+#   - PROD-IDC stage: second target for notebook sync
+#
+# content.notebooks.notebook_ids filters to only 3 of the 4 notebooks
+# created by the setup script. "exploratory-analysis" is intentionally
+# excluded to verify that filtering works correctly.
+#
+# Each ID uses ${ENV_VAR:default_id} syntax — the defaults are the actual
+# notebook IDs from our test environment. Override via environment variables
+# if you need to point at different notebooks.
+
+applicationName: E2ENotebookSyncIdC
+content:
+  notebooks:
+    enabled: true
+    # Only sync the first 3 notebooks — excludes "exploratory-analysis"
+    notebook_ids:
+    - ${E2E_NOTEBOOK_DATA_PREP_ID:55rimt88sy6uc0}
+    - ${E2E_NOTEBOOK_FEATURE_ENG_ID:aj3t33nr2cghe8}
+    - ${E2E_NOTEBOOK_MODEL_TRAINING_ID:bb677gubj6ahzk}
+stages:
+  dev-idc:
+    stage: DEV
+    domain:
+      name: smus-idc-dev-domain
+      region: us-west-2
+    project:
+      name: dev-marketing
+      owners:
+      - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests
+      - arn:aws:iam::${AWS_ACCOUNT_ID}:role/Admin
+    deployment_configuration:
+      notebooks: {}
+  test-idc:
+    stage: TEST
+    domain:
+      name: smus-idc-test-domain
+      region: ${TEST_DOMAIN_REGION}
+    project:
+      name: test-marketing
+      owners:
+      - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests
+      - arn:aws:iam::${AWS_ACCOUNT_ID}:role/Admin
+    deployment_configuration:
+      notebooks: {}
+  prod-idc:
+    stage: PROD
+    domain:
+      name: smus-idc-prod-domain
+      region: ${PROD_DOMAIN_REGION}
+    project:
+      name: prod-marketing
+      owners:
+      - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests
+      - arn:aws:iam::${AWS_ACCOUNT_ID}:role/Admin
+    deployment_configuration:
+      notebooks: {}
+tests:
+  folder: examples/e2e-notebook-sync/app_tests/

--- a/examples/e2e-notebook-sync/manifest.yaml
+++ b/examples/e2e-notebook-sync/manifest.yaml
@@ -1,0 +1,69 @@
+# E2E Notebook Sync — IAM domain variant
+#
+# Tests the full notebook export → bundle → sync lifecycle:
+#   - DEV stage: source of truth (notebooks created by setup_notebooks.py)
+#   - TEST stage: first target for notebook sync
+#   - PROD stage: second target for notebook sync
+#
+# content.notebooks.notebook_ids filters to only 3 of the 4 notebooks
+# created by the setup script. "exploratory-analysis" is intentionally
+# excluded to verify that filtering works correctly.
+#
+# Each ID uses ${ENV_VAR:default_id} syntax — the defaults are the actual
+# notebook IDs from our test environment. Override via environment variables
+# if you need to point at different notebooks.
+
+applicationName: E2ENotebookSyncIAM
+content:
+  notebooks:
+    enabled: true
+    # Only sync the first 3 notebooks — excludes "exploratory-analysis"
+    notebook_ids:
+    - ${E2E_NOTEBOOK_DATA_PREP_ID:chjdveqzk3b0kn}
+    - ${E2E_NOTEBOOK_FEATURE_ENG_ID:5jt3em9urdh3fr}
+    - ${E2E_NOTEBOOK_MODEL_TRAINING_ID:5t4wg7lwzxkraf}
+stages:
+  dev:
+    stage: DEV
+    domain:
+      region: ${DEV_DOMAIN_REGION}
+      tags:
+        purpose: smus-cicd-testing
+    project:
+      name: dev-marketing
+      owners:
+      - Eng1
+      - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests
+      - arn:aws:iam::${AWS_ACCOUNT_ID}:role/Admin
+    deployment_configuration:
+      notebooks: {}
+  test:
+    stage: TEST
+    domain:
+      region: ${TEST_DOMAIN_REGION}
+      tags:
+        purpose: smus-cicd-testing
+    project:
+      name: test-marketing
+      owners:
+      - Eng1
+      - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests
+      - arn:aws:iam::${AWS_ACCOUNT_ID}:role/Admin
+    deployment_configuration:
+      notebooks: {}
+  prod:
+    stage: PROD
+    domain:
+      region: ${PROD_DOMAIN_REGION}
+      tags:
+        purpose: smus-cicd-production
+    project:
+      name: prod-marketing
+      owners:
+      - Eng1
+      - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests
+      - arn:aws:iam::${AWS_ACCOUNT_ID}:role/Admin
+    deployment_configuration:
+      notebooks: {}
+tests:
+  folder: examples/e2e-notebook-sync/app_tests/

--- a/examples/e2e-notebook-sync/setup_notebooks.py
+++ b/examples/e2e-notebook-sync/setup_notebooks.py
@@ -1,0 +1,580 @@
+#!/usr/bin/env python3
+"""
+Setup script for e2e-notebook-sync example.
+
+Creates 4 notebooks in the DEV environment with varying configurations:
+  1. data-prep-etl        — parameters + environmentConfiguration + description
+  2. feature-engineering  — parameters only, no environmentConfiguration
+  3. model-training       — environmentConfiguration only (pip packages)
+  4. exploratory-analysis — minimal (name + short description only)
+
+The first 3 are included in the manifest's notebook_ids filter to test
+selective export/sync. The 4th (exploratory-analysis) is intentionally
+excluded to verify that filtering works.
+
+All operations are idempotent — safe to run multiple times.
+Notebooks are created via the DataZone CreateNotebook API.
+
+Usage:
+    # Run against the dev stage in manifest.yaml (IAM domain):
+    python setup_notebooks.py --manifest examples/e2e-notebook-sync/manifest.yaml --stage dev
+
+    # Run against the dev-idc stage in manifest-idc.yaml (IdC domain):
+    python setup_notebooks.py --manifest examples/e2e-notebook-sync/manifest-idc.yaml --stage dev-idc
+
+    # Dry run:
+    python setup_notebooks.py --manifest examples/e2e-notebook-sync/manifest.yaml --dry-run
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+
+import boto3
+import yaml
+
+# ---------------------------------------------------------------------------
+# Notebook .ipynb content generators
+# ---------------------------------------------------------------------------
+
+def _data_prep_notebook_content():
+    return json.dumps({
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": ["# Data Preparation ETL\n", "Cleanses and transforms raw transaction data."],
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "source": [
+                    "import pandas as pd\n",
+                    "import pyarrow.parquet as pq\n",
+                    "\n",
+                    "# Parameters injected by SMUS CI/CD\n",
+                    "input_path = '${input_path}'\n",
+                    "output_path = '${output_path}'\n",
+                    "refresh_mode = '${refresh_mode}'\n",
+                    "partition_keys = '${partition_keys}'.split(',')\n",
+                ],
+                "outputs": [],
+                "execution_count": None,
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "source": [
+                    "# Read raw data\n",
+                    "df = pd.read_csv(input_path + 'transactions.csv')\n",
+                    "print(f'Loaded {len(df)} rows')\n",
+                    "\n",
+                    "# Cleansing\n",
+                    "df = df.dropna(subset=['transaction_id'])\n",
+                    "df = df.drop_duplicates(subset=['transaction_id'])\n",
+                    "df['amount'] = df['amount'].astype(float)\n",
+                    "print(f'After cleansing: {len(df)} rows')\n",
+                ],
+                "outputs": [],
+                "execution_count": None,
+            },
+        ],
+        "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }, indent=2)
+
+
+def _feature_engineering_notebook_content():
+    return json.dumps({
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": ["# Feature Engineering\n", "Computes lag features from transaction data."],
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "source": [
+                    "import pandas as pd\n",
+                    "\n",
+                    "feature_group = '${feature_group}'\n",
+                    "lookback_days = int('${lookback_days}')\n",
+                    "target_column = '${target_column}'\n",
+                    "\n",
+                    "print(f'Feature group: {feature_group}')\n",
+                    "print(f'Lookback: {lookback_days} days')\n",
+                ],
+                "outputs": [],
+                "execution_count": None,
+            },
+        ],
+        "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }, indent=2)
+
+
+def _model_training_notebook_content():
+    return json.dumps({
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": ["# Model Training\n", "XGBoost classifier with MLflow tracking."],
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "source": [
+                    "import xgboost as xgb\n",
+                    "from sklearn.model_selection import train_test_split\n",
+                    "import mlflow\n",
+                    "\n",
+                    "# Simple training pipeline\n",
+                    "print('Starting model training...')\n",
+                ],
+                "outputs": [],
+                "execution_count": None,
+            },
+        ],
+        "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }, indent=2)
+
+
+def _exploratory_notebook_content():
+    return json.dumps({
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": ["# Exploratory Analysis\n", "Quick scratch notebook for ad-hoc exploration."],
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "source": ["print('This notebook is NOT included in CI/CD sync')\n"],
+                "outputs": [],
+                "execution_count": None,
+            },
+        ],
+        "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Notebook definitions
+# ---------------------------------------------------------------------------
+
+NOTEBOOKS = [
+    {
+        "name": "data-prep-etl",
+        "description": (
+            "End-to-end data preparation pipeline that reads raw CSV data from S3, "
+            "applies cleansing rules (null removal, deduplication, type casting), "
+            "and writes Parquet output to the curated zone. Supports incremental "
+            "and full-refresh modes via the 'refresh_mode' parameter."
+        ),
+        "parameters": {
+            "input_path": "s3://sample-data/raw/transactions/",
+            "output_path": "s3://sample-data/curated/transactions/",
+            "refresh_mode": "incremental",
+            "partition_keys": "year,month",
+        },
+        "environmentConfiguration": {
+            "imageVersion": "sagemaker-distribution-v2",
+            "packageConfig": {
+                "packageManager": "UV",
+                "packageSpecification": "pandas>=2.0\npyarrow>=14.0\nboto3",
+            },
+        },
+        "content": _data_prep_notebook_content(),
+    },
+    {
+        "name": "feature-engineering",
+        "description": (
+            "Feature engineering notebook that computes derived features from "
+            "the curated transaction dataset. Outputs a feature store-ready "
+            "DataFrame with timestamp alignment and lag features."
+        ),
+        "parameters": {
+            "feature_group": "transaction_features",
+            "lookback_days": "90",
+            "target_column": "is_fraud",
+        },
+        "environmentConfiguration": None,
+        "content": _feature_engineering_notebook_content(),
+    },
+    {
+        "name": "model-training",
+        "description": (
+            "XGBoost model training notebook. Reads features from the feature "
+            "store, performs train/test split, trains an XGBoost classifier, "
+            "and registers the model artifact in MLflow."
+        ),
+        "parameters": {},
+        "environmentConfiguration": {
+            "imageVersion": "sagemaker-distribution-v2",
+            "packageConfig": {
+                "packageManager": "UV",
+                "packageSpecification": "xgboost>=2.0\nscikit-learn>=1.3\nmlflow>=2.9",
+            },
+        },
+        "content": _model_training_notebook_content(),
+    },
+    {
+        "name": "exploratory-analysis",
+        "description": "Quick EDA scratch notebook — not included in CI/CD sync.",
+        "parameters": {},
+        "environmentConfiguration": None,
+        "content": _exploratory_notebook_content(),
+    },
+]
+
+# The first 3 are the ones included in the manifest's notebook_ids filter.
+# The 4th is intentionally excluded to test filtering.
+FILTERED_NOTEBOOK_NAMES = ["data-prep-etl", "feature-engineering", "model-training"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def substitute_env_vars(text):
+    """Substitute ${VAR} and ${VAR:default} patterns with environment values."""
+    def replace(match):
+        expr = match.group(1)
+        if ":" in expr:
+            var_name, default = expr.split(":", 1)
+            return os.environ.get(var_name, default)
+        return os.environ.get(expr, match.group(0))
+    return re.sub(r"\$\{([^}]+)\}", replace, text)
+
+
+def load_manifest(path):
+    with open(path) as f:
+        return yaml.safe_load(substitute_env_vars(f.read()))
+
+
+# ---------------------------------------------------------------------------
+# DataZone operations
+# ---------------------------------------------------------------------------
+
+def resolve_domain_id(domain_config, region):
+    """Resolve domain ID from config (supports id, name, or tags lookup)."""
+    dz = boto3.client("datazone", region_name=region)
+
+    if "id" in domain_config:
+        return domain_config["id"]
+
+    if "name" in domain_config:
+        domains = dz.list_domains()
+        for d in domains.get("items", []):
+            if d["name"] == domain_config["name"]:
+                return d["id"]
+        print(f"  Domain '{domain_config['name']}' not found")
+        return None
+
+    if "tags" in domain_config:
+        domains = dz.list_domains()
+        for d in domains.get("items", []):
+            domain_id = d["id"]
+            try:
+                tags_resp = dz.list_tags_for_resource(resourceArn=d.get("arn", ""))
+                domain_tags = tags_resp.get("tags", {})
+            except Exception:
+                domain_tags = {}
+            match = all(
+                domain_tags.get(k) == v
+                for k, v in domain_config["tags"].items()
+            )
+            if match:
+                return domain_id
+        print(f"  Domain with tags {domain_config['tags']} not found")
+        return None
+
+    return None
+
+
+def resolve_project_id(dz_client, domain_id, project_name):
+    """Find project ID by name within a domain."""
+    projects = dz_client.list_projects(domainIdentifier=domain_id)
+    for p in projects.get("items", []):
+        if p["name"] == project_name:
+            return p["id"]
+    return None
+
+
+def list_existing_notebooks(dz_client, domain_id, project_id):
+    """List active notebooks in the project, returns {name: id} map."""
+    notebooks = {}
+    next_token = None
+    while True:
+        params = {
+            "domainIdentifier": domain_id,
+            "owningProjectIdentifier": project_id,
+            "status": "ACTIVE",
+        }
+        if next_token:
+            params["nextToken"] = next_token
+        resp = dz_client.list_notebooks(**params)
+        for item in resp.get("items", []):
+            nb_name = item.get("name", "")
+            nb_id = item.get("id") or item.get("notebookId") or item.get("identifier")
+            if nb_name and nb_id:
+                notebooks[nb_name] = nb_id
+        next_token = resp.get("nextToken")
+        if not next_token:
+            break
+    return notebooks
+
+
+def create_or_update_notebook(dz_client, s3_client, domain_id, project_id,
+                              notebook_def, existing_notebooks, s3_uri, dry_run=False):
+    """
+    Create a notebook if it doesn't exist, or update it if it does.
+
+    Steps:
+      1. Upload .ipynb content to S3 at {s3_uri}/notebooks/setup/{name}.ipynb
+      2. If notebook exists by name → StartNotebookSync (update) + UpdateNotebook
+      3. If notebook doesn't exist → StartNotebookSync (create) + UpdateNotebook
+    """
+    name = notebook_def["name"]
+    description = notebook_def["description"]
+    parameters = notebook_def.get("parameters") or {}
+    env_config = notebook_def.get("environmentConfiguration")
+    content = notebook_def["content"]
+
+    existing_id = existing_notebooks.get(name)
+    action = "update" if existing_id else "create"
+
+    if dry_run:
+        print(f"  [DRY RUN] Would {action}: {name}" +
+              (f" ({existing_id})" if existing_id else ""))
+        return None
+
+    # Step 1: Upload .ipynb to S3
+    bucket, prefix = _parse_s3_uri(s3_uri)
+    s3_key = f"{prefix}/notebooks/setup/{name}.ipynb".lstrip("/")
+    s3_client.put_object(
+        Bucket=bucket,
+        Key=s3_key,
+        Body=content.encode("utf-8"),
+        ContentType="application/x-ipynb+json",
+    )
+    source_location = f"s3://{bucket}/{s3_key}"
+    print(f"  Uploaded {name}.ipynb to {source_location}")
+
+    # Step 2: StartNotebookSync
+    sync_params = {
+        "domainIdentifier": domain_id,
+        "owningProjectIdentifier": project_id,
+        "sourceLocation": {"s3": source_location},
+        "name": name,
+        "description": description,
+    }
+    if existing_id:
+        sync_params["notebookId"] = existing_id
+
+    try:
+        resp = dz_client.start_notebook_sync(**sync_params)
+        notebook_id = resp.get("notebookId") or resp.get("id") or existing_id
+    except Exception as exc:
+        print(f"  StartNotebookSync failed for '{name}': {exc}")
+        return None
+
+    if not notebook_id:
+        print(f"  StartNotebookSync returned no ID for '{name}'")
+        return None
+
+    # Wait for sync to finish before updating metadata
+    import time as _time
+    for _ in range(30):
+        try:
+            detail = dz_client.get_notebook(domainIdentifier=domain_id, identifier=notebook_id)
+            if detail.get("status") != "SYNC_IN_PROGRESS":
+                break
+        except Exception:
+            pass
+        _time.sleep(2)
+
+    # Step 3: UpdateNotebook with metadata, parameters, environmentConfiguration
+    update_params = {
+        "domainIdentifier": domain_id,
+        "identifier": notebook_id,
+        "name": name,
+        "description": description,
+        "metadata": {"setup-source": "e2e-notebook-sync-setup"},
+    }
+    if parameters:
+        update_params["parameters"] = parameters
+    if env_config:
+        update_params["environmentConfiguration"] = env_config
+
+    try:
+        dz_client.update_notebook(**update_params)
+    except Exception as exc:
+        print(f"  UpdateNotebook warning for '{name}': {exc}")
+
+    status_icon = "updated" if existing_id else "created"
+    print(f"  {name} ({notebook_id}) — {status_icon}")
+    return notebook_id
+
+
+def _parse_s3_uri(s3_uri):
+    """Parse s3://bucket/prefix into (bucket, prefix)."""
+    without_scheme = s3_uri.replace("s3://", "")
+    bucket, _, prefix = without_scheme.partition("/")
+    return bucket, prefix.rstrip("/")
+
+
+def get_s3_shared_uri(dz_client, domain_id, project_id, region):
+    """Get the default.s3_shared connection's s3Uri for the project."""
+    try:
+        resp = dz_client.list_connections(
+            domainIdentifier=domain_id,
+            projectIdentifier=project_id,
+        )
+        for conn in resp.get("items", []):
+            if conn.get("name") == "default.s3_shared":
+                # Get connection details
+                detail = dz_client.get_connection(
+                    domainIdentifier=domain_id,
+                    identifier=conn.get("connectionId") or conn.get("id"),
+                )
+                # s3Uri lives in props.s3Properties.s3Uri
+                props = detail.get("props") or {}
+                s3_props = props.get("s3Properties") or {}
+                s3_uri = s3_props.get("s3Uri")
+                if s3_uri:
+                    return s3_uri
+                # Fallback: check connectionProperties (older format)
+                conn_props = detail.get("connectionProperties") or {}
+                s3_uri = conn_props.get("s3Uri") or conn_props.get("S3_URI")
+                if s3_uri:
+                    return s3_uri
+    except Exception as exc:
+        print(f"  Warning: Could not resolve s3_shared connection: {exc}")
+
+    # Fallback: construct from account/region convention
+    sts = boto3.client("sts")
+    account_id = sts.get_caller_identity()["Account"]
+    return f"s3://datazone-{account_id}-{region}-shared"
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Create test notebooks in the DEV environment for E2E notebook sync testing"
+    )
+    parser.add_argument(
+        "--manifest",
+        default="examples/e2e-notebook-sync/manifest.yaml",
+        help="Path to manifest YAML",
+    )
+    parser.add_argument("--stage", default="dev", help="Stage name (default: dev)")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be done")
+    args = parser.parse_args()
+
+    print(f"Loading manifest: {args.manifest}")
+    manifest = load_manifest(args.manifest)
+
+    stage_config = manifest.get("stages", {}).get(args.stage)
+    if not stage_config:
+        print(f"Stage '{args.stage}' not found in manifest")
+        sys.exit(1)
+
+    domain_config = stage_config["domain"]
+    region = domain_config["region"]
+    project_name = stage_config["project"]["name"]
+
+    print(f"Region: {region}")
+    print(f"Project: {project_name}")
+    print()
+
+    # Resolve domain ID
+    domain_id = resolve_domain_id(domain_config, region)
+    if not domain_id:
+        print("Could not resolve domain ID")
+        sys.exit(1)
+    print(f"Domain ID: {domain_id}")
+
+    # Resolve project
+    dz_client = boto3.client("datazone", region_name=region)
+    project_id = resolve_project_id(dz_client, domain_id, project_name)
+    if not project_id:
+        print(f"Project '{project_name}' not found in domain {domain_id}")
+        sys.exit(1)
+    print(f"Project ID: {project_id}")
+
+    # Get S3 shared URI
+    s3_uri = get_s3_shared_uri(dz_client, domain_id, project_id, region)
+    print(f"S3 Shared URI: {s3_uri}")
+    print()
+
+    # List existing notebooks
+    existing = list_existing_notebooks(dz_client, domain_id, project_id)
+    if existing:
+        print(f"Existing notebooks in project: {list(existing.keys())}")
+    else:
+        print("No existing notebooks in project")
+    print()
+
+    # Create/update each notebook
+    s3_client = boto3.client("s3", region_name=region)
+    created_ids = {}
+
+    print("Setting up notebooks:")
+    print("-" * 60)
+    for nb_def in NOTEBOOKS:
+        nb_id = create_or_update_notebook(
+            dz_client, s3_client, domain_id, project_id,
+            nb_def, existing, s3_uri, dry_run=args.dry_run,
+        )
+        if nb_id:
+            created_ids[nb_def["name"]] = nb_id
+        print()
+
+    print("-" * 60)
+    print(f"Setup complete: {len(created_ids)} notebook(s) created/updated")
+    print()
+
+    # Print the IDs for use in notebook_ids filter
+    filtered_ids = [
+        created_ids[name] for name in FILTERED_NOTEBOOK_NAMES
+        if name in created_ids
+    ]
+    if filtered_ids:
+        print("Notebook IDs for manifest notebook_ids filter:")
+        for name in FILTERED_NOTEBOOK_NAMES:
+            nb_id = created_ids.get(name)
+            if nb_id:
+                print(f"  {name}: {nb_id}")
+        print()
+        print("YAML snippet (paste into manifest content.notebooks.notebook_ids):")
+        print("  notebook_ids:")
+        for nb_id in filtered_ids:
+            print(f"  - {nb_id}")
+    else:
+        print("(No IDs available — use --dry-run=false to create notebooks)")
+
+    # Verify excluded notebook
+    excluded_name = "exploratory-analysis"
+    if excluded_name in created_ids:
+        print(f"\n  Note: '{excluded_name}' ({created_ids[excluded_name]}) is NOT in the filter")
+        print(f"  It should remain in dev only and not be exported/synced.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/smus_cicd/application/application-manifest-schema.yaml
+++ b/src/smus_cicd/application/application-manifest-schema.yaml
@@ -169,6 +169,22 @@ properties:
               description: "Workflow-specific parameters"
               additionalProperties: true
           additionalProperties: false
+      notebooks:
+        type: object
+        description: "Notebook export configuration. When enabled, notebooks are exported from the source project during bundle and synced to target projects during deploy."
+        properties:
+          enabled:
+            type: boolean
+            description: "Enable or disable notebook export. When true, notebooks are exported during bundle."
+            default: false
+          notebook_ids:
+            type: array
+            description: "Optional list of specific notebook IDs to export. When omitted, all active notebooks owned by the source project are exported. Each ID must match pattern [a-zA-Z0-9_-]{1,36}."
+            items:
+              type: string
+              pattern: "^[a-zA-Z0-9_-]{1,36}$"
+            minItems: 1
+        additionalProperties: false
     additionalProperties: false
   
   bootstrap:
@@ -575,6 +591,15 @@ definitions:
               disable:
                 type: boolean
                 description: "Disable catalog asset processing for this stage"
+          notebooks:
+            type: object
+            description: "Notebook sync configuration for this stage"
+            properties:
+              disable:
+                type: boolean
+                description: "Disable notebook sync for this stage"
+                default: false
+            additionalProperties: false
           quicksight:
             type: object
             description: "QuickSight deployment configuration for this stage"

--- a/src/smus_cicd/application/application_manifest.py
+++ b/src/smus_cicd/application/application_manifest.py
@@ -93,6 +93,24 @@ class CatalogConfig:
 
 
 @dataclass
+class NotebookConfig:
+    """Notebook export configuration for bundle (content.notebooks section).
+
+    Fields:
+    - enabled (bool): Enable/disable notebook export (default: false)
+    - notebook_ids (Optional[List[str]]): Optional list of specific source notebook IDs
+      to export. Each ID must match pattern [a-zA-Z0-9_-]{1,36}. When omitted, all
+      active notebooks owned by the source project are exported via ListNotebooks.
+      When present, the list must contain at least one entry.
+
+    NOTE: Notebook schedules are explicitly out of scope for this iteration.
+    """
+
+    enabled: bool = False
+    notebook_ids: Optional[List[str]] = None
+
+
+@dataclass
 class StorageConfig:
     """Storage configuration."""
 
@@ -145,6 +163,7 @@ class ContentConfig:
     storage: List[StorageConfig] = field(default_factory=list)
     git: List[GitContentConfig] = field(default_factory=list)
     catalog: Optional[CatalogConfig] = None
+    notebooks: Optional[NotebookConfig] = None
     quicksight: List[QuickSightDashboardConfig] = field(default_factory=list)
     workflows: List[Dict[str, Any]] = field(default_factory=list)
 
@@ -219,6 +238,7 @@ class DeploymentConfiguration:
     storage: List[StorageConfig] = field(default_factory=list)
     git: List[GitTargetConfig] = field(default_factory=list)
     catalog: Optional[Dict[str, Any]] = None
+    notebooks: Optional[Dict[str, Any]] = None
     quicksight: Optional[Dict[str, Any]] = None
 
 
@@ -349,6 +369,35 @@ class ApplicationManifest:
                 assets=assets_config,
             )
 
+        # Parse notebooks configuration
+        notebooks = None
+        notebooks_data = content_data.get("notebooks")
+        if notebooks_data is not None:
+            import re as _re
+
+            nb_enabled = notebooks_data.get("enabled", False)
+            nb_ids_raw = notebooks_data.get("notebook_ids")
+
+            if nb_ids_raw is not None:
+                if not isinstance(nb_ids_raw, list) or len(nb_ids_raw) == 0:
+                    raise ValueError(
+                        "content.notebooks.notebook_ids must be a non-empty list when present"
+                    )
+                _id_pattern = _re.compile(r"^[a-zA-Z0-9_-]{1,36}$")
+                invalid_ids = [
+                    nid for nid in nb_ids_raw if not _id_pattern.match(str(nid))
+                ]
+                if invalid_ids:
+                    raise ValueError(
+                        f"content.notebooks.notebook_ids contains invalid entries "
+                        f"(must match [a-zA-Z0-9_-]{{1,36}}): {invalid_ids}"
+                    )
+                nb_ids: Optional[List[str]] = [str(nid) for nid in nb_ids_raw]
+            else:
+                nb_ids = None
+
+            notebooks = NotebookConfig(enabled=nb_enabled, notebook_ids=nb_ids)
+
         # Parse storage configs
         storage_configs = []
         for storage_data in content_data.get("storage", []):
@@ -399,6 +448,7 @@ class ApplicationManifest:
             storage=storage_configs,
             git=git_configs,
             catalog=catalog,
+            notebooks=notebooks,
             quicksight=quicksight_dashboards,
             workflows=workflows,
         )
@@ -543,6 +593,7 @@ class ApplicationManifest:
                     storage=storage_configs,
                     git=git_configs,
                     catalog=btc_data.get("catalog"),
+                    notebooks=btc_data.get("notebooks"),
                     quicksight=btc_data.get("quicksight"),
                 )
 

--- a/src/smus_cicd/commands/bundle.py
+++ b/src/smus_cicd/commands/bundle.py
@@ -479,8 +479,12 @@ def bundle_command(
                     typer.echo("Exporting notebooks...")
 
                     # Resolve domain_id and project_id (may already be set from catalog block)
-                    nb_domain_id = project_info.get("domain_id") or project_info.get("domainId")
-                    nb_project_id = project_info.get("project_id") or project_info.get("id")
+                    nb_domain_id = project_info.get("domain_id") or project_info.get(
+                        "domainId"
+                    )
+                    nb_project_id = project_info.get("project_id") or project_info.get(
+                        "id"
+                    )
 
                     if not nb_domain_id or not nb_project_id:
                         typer.echo(
@@ -504,9 +508,7 @@ def bundle_command(
                             os.makedirs(notebooks_dir, exist_ok=True)
 
                             for nb in exported_notebooks:
-                                ipynb_path = os.path.join(
-                                    temp_bundle_dir, nb.file_path
-                                )
+                                ipynb_path = os.path.join(temp_bundle_dir, nb.file_path)
                                 os.makedirs(os.path.dirname(ipynb_path), exist_ok=True)
                                 with open(ipynb_path, "wb") as f:
                                     f.write(nb.file_content)

--- a/src/smus_cicd/commands/bundle.py
+++ b/src/smus_cicd/commands/bundle.py
@@ -467,6 +467,73 @@ def bundle_command(
                 except Exception as e:
                     typer.echo(f"Error exporting catalog resources: {e}", err=True)
 
+            # Export notebooks if enabled
+            if (
+                manifest.content
+                and manifest.content.notebooks
+                and manifest.content.notebooks.enabled
+            ):
+                try:
+                    from ..helpers.notebook_export import export_notebooks
+
+                    typer.echo("Exporting notebooks...")
+
+                    # Resolve domain_id and project_id (may already be set from catalog block)
+                    nb_domain_id = project_info.get("domain_id") or project_info.get("domainId")
+                    nb_project_id = project_info.get("project_id") or project_info.get("id")
+
+                    if not nb_domain_id or not nb_project_id:
+                        typer.echo(
+                            "Warning: Could not resolve domain_id or project_id for notebook export",
+                            err=True,
+                        )
+                    else:
+                        notebook_ids = manifest.content.notebooks.notebook_ids
+                        # export_notebooks() raises SystemExit on invalid IDs or
+                        # export failures — let it propagate so bundle exits non-zero
+                        exported_notebooks, notebook_manifest = export_notebooks(
+                            domain_id=nb_domain_id,
+                            project_id=nb_project_id,
+                            region=region,
+                            notebook_ids=notebook_ids,
+                        )
+
+                        if exported_notebooks:
+                            # Write each .ipynb file to notebooks/ in the temp dir
+                            notebooks_dir = os.path.join(temp_bundle_dir, "notebooks")
+                            os.makedirs(notebooks_dir, exist_ok=True)
+
+                            for nb in exported_notebooks:
+                                ipynb_path = os.path.join(
+                                    temp_bundle_dir, nb.file_path
+                                )
+                                os.makedirs(os.path.dirname(ipynb_path), exist_ok=True)
+                                with open(ipynb_path, "wb") as f:
+                                    f.write(nb.file_content)
+
+                            total_files_added += len(exported_notebooks)
+
+                        # Always write the manifest (may have zero notebooks)
+                        notebooks_dir = os.path.join(temp_bundle_dir, "notebooks")
+                        os.makedirs(notebooks_dir, exist_ok=True)
+                        manifest_path = os.path.join(
+                            notebooks_dir, "notebook_export_manifest.json"
+                        )
+                        with open(manifest_path, "w", encoding="utf-8") as f:
+                            json.dump(notebook_manifest, f, indent=2, default=str)
+                        total_files_added += 1
+
+                        typer.echo(
+                            f"  Exported {len(exported_notebooks)} notebook(s) to bundle"
+                        )
+
+                except SystemExit:
+                    # Re-raise so bundle exits with non-zero code
+                    raise
+                except Exception as e:
+                    typer.echo(f"Error exporting notebooks: {e}", err=True)
+                    raise typer.Exit(1)
+
             # Process Git repositories (supports both dict and list formats)
             git_repos = (
                 manifest.content.git

--- a/src/smus_cicd/commands/deploy.py
+++ b/src/smus_cicd/commands/deploy.py
@@ -615,10 +615,17 @@ def _deploy_bundle_to_target(
         manifest=manifest,
     )
 
+    # Sync notebooks from bundle if present
+    notebook_sync_success = _sync_notebooks_from_bundle(
+        effective_bundle_path,
+        target_config,
+        config,
+    )
+
     # Return overall success - storage must succeed, git is optional
     storage_success = all(r[0] is not None for r in storage_results)
     git_success = all(r[0] is not None for r in git_results) if git_results else True
-    return storage_success and git_success and asset_success and catalog_import_success
+    return storage_success and git_success and asset_success and catalog_import_success and notebook_sync_success
 
 
 def _resolve_and_upload_workflows(
@@ -1355,6 +1362,168 @@ def _validate_deployed_workflows(
     except Exception as e:
         typer.echo("⚠️ Workflow validation failed: " + str(e))
         # Don't fail deployment for validation issues
+
+
+def _sync_notebooks_from_bundle(
+    bundle_path: Optional[str],
+    target_config,
+    config: Dict[str, Any],
+) -> bool:
+    """
+    Sync notebook resources from a bundle into the target DataZone project.
+
+    Mirrors ``_import_catalog_from_bundle`` in structure:
+    - Returns True immediately if notebook sync is disabled, no bundle path is
+      provided, or the bundle contains no ``notebooks/notebook_export_manifest.json``.
+    - Extracts the manifest + all referenced ``.ipynb`` files from the bundle.
+    - Resolves the target project's ``default.s3_shared`` connection S3 URI.
+    - Calls ``sync_notebooks()`` and reports the summary.
+    - Returns False (and exits non-zero) if any notebooks failed to sync.
+
+    Args:
+        bundle_path: Path to the bundle ZIP (local or S3 URI).
+        target_config: Stage configuration object.
+        config: Resolved configuration dict (includes region, domain_id, etc.).
+
+    Returns:
+        True if sync succeeded or was skipped, False if any notebooks failed.
+    """
+    from ..helpers.bundle_storage import ensure_bundle_local, is_s3_url
+
+    # Check if notebook sync is disabled in deployment_configuration
+    if (
+        target_config.deployment_configuration
+        and target_config.deployment_configuration.notebooks
+        and target_config.deployment_configuration.notebooks.get("disable", False)
+    ):
+        typer.echo("📓 Notebook sync disabled in deployment configuration — skipping")
+        return True
+
+    # Skip if no bundle
+    if not bundle_path:
+        return True
+
+    local_bundle_path = ensure_bundle_local(
+        bundle_path, config.get("region", "us-east-1")
+    )
+
+    try:
+        with zipfile.ZipFile(local_bundle_path, "r") as zip_ref:
+            namelist = zip_ref.namelist()
+
+            if "notebooks/notebook_export_manifest.json" not in namelist:
+                # No notebook manifest — skip silently (backward compatible)
+                return True
+
+            # ── Extract manifest ──────────────────────────────────────────
+            with zip_ref.open("notebooks/notebook_export_manifest.json") as mf:
+                import json as _json
+                manifest_data = _json.load(mf)
+
+            # ── Extract all .ipynb files referenced in the manifest ───────
+            notebook_files: Dict[str, bytes] = {}
+            for entry in manifest_data.get("notebooks", []):
+                file_path = entry.get("filePath", "")
+                if file_path and file_path in namelist:
+                    with zip_ref.open(file_path) as nb_file:
+                        notebook_files[file_path] = nb_file.read()
+                elif file_path:
+                    # Missing file — sync_notebooks will count it as failed
+                    typer.echo(
+                        f"  ⚠️  Notebook file missing from bundle: {file_path}",
+                        err=True,
+                    )
+
+        # ── Resolve target domain / project IDs ──────────────────────────
+        from ..helpers.datazone import (
+            get_domain_from_target_config,
+            get_project_id_by_name,
+        )
+
+        region = target_config.domain.region
+        domain_id, _ = get_domain_from_target_config(target_config, region)
+        project_name = target_config.project.name
+        project_id = get_project_id_by_name(project_name, domain_id, region)
+
+        if not project_id:
+            typer.echo(
+                f"❌ Could not find project ID for project '{project_name}' "
+                "— skipping notebook sync",
+                err=True,
+            )
+            return False
+
+        # ── Resolve S3 URI from default.s3_shared connection ─────────────
+        from ..helpers.connections import get_project_connections
+
+        try:
+            connections = get_project_connections(
+                project_id=project_id,
+                domain_id=domain_id,
+                region=region,
+            )
+        except Exception as exc:
+            typer.echo(
+                f"❌ Could not retrieve project connections for notebook sync: {exc}",
+                err=True,
+            )
+            return False
+
+        s3_connection = connections.get("default.s3_shared", {})
+        s3_uri = s3_connection.get("s3Uri", "")
+
+        if not s3_uri:
+            typer.echo(
+                "❌ Target project 'default.s3_shared' connection has no s3Uri "
+                "— cannot upload notebooks for sync",
+                err=True,
+            )
+            return False
+
+        # ── Sync notebooks ────────────────────────────────────────────────
+        from ..helpers.notebook_import import sync_notebooks
+
+        typer.echo("📓 Syncing notebooks from bundle...")
+
+        try:
+            summary = sync_notebooks(
+                domain_id=domain_id,
+                project_id=project_id,
+                region=region,
+                manifest_data=manifest_data,
+                notebook_files=notebook_files,
+                s3_uri=s3_uri,
+            )
+        except ValueError as exc:
+            typer.echo(f"❌ Notebook sync validation error: {exc}", err=True)
+            return False
+
+        # ── Report summary ────────────────────────────────────────────────
+        typer.echo("✅ Notebook sync completed:")
+        typer.echo(f"   Created: {summary.created}")
+        typer.echo(f"   Updated: {summary.updated}")
+        typer.echo(f"   Failed:  {summary.failed}")
+
+        if summary.has_failures:
+            failed_str = ", ".join(summary.failed_ids)
+            typer.echo(
+                f"❌ Notebook sync failed for {summary.failed} notebook(s): {failed_str}",
+                err=True,
+            )
+            return False
+
+        return True
+
+    except json.JSONDecodeError as exc:
+        typer.echo(f"❌ Invalid notebook manifest JSON in bundle: {exc}", err=True)
+        return False
+    except Exception as exc:
+        typer.echo(f"❌ Error syncing notebooks from bundle: {exc}", err=True)
+        return False
+    finally:
+        if is_s3_url(bundle_path) and local_bundle_path != bundle_path:
+            if os.path.exists(local_bundle_path):
+                os.unlink(local_bundle_path)
 
 
 def _import_catalog_from_bundle(

--- a/src/smus_cicd/commands/deploy.py
+++ b/src/smus_cicd/commands/deploy.py
@@ -625,7 +625,13 @@ def _deploy_bundle_to_target(
     # Return overall success - storage must succeed, git is optional
     storage_success = all(r[0] is not None for r in storage_results)
     git_success = all(r[0] is not None for r in git_results) if git_results else True
-    return storage_success and git_success and asset_success and catalog_import_success and notebook_sync_success
+    return (
+        storage_success
+        and git_success
+        and asset_success
+        and catalog_import_success
+        and notebook_sync_success
+    )
 
 
 def _resolve_and_upload_workflows(
@@ -1418,6 +1424,7 @@ def _sync_notebooks_from_bundle(
             # ── Extract manifest ──────────────────────────────────────────
             with zip_ref.open("notebooks/notebook_export_manifest.json") as mf:
                 import json as _json
+
                 manifest_data = _json.load(mf)
 
             # ── Extract all .ipynb files referenced in the manifest ───────

--- a/src/smus_cicd/commands/deploy.py
+++ b/src/smus_cicd/commands/deploy.py
@@ -246,6 +246,7 @@ def deploy_command(
                 emitter,
                 metadata,
                 manifest_file,
+                project_info=config.get("project_info"),
             )
         else:
             typer.echo("No deployment_configuration - skipping bundle deployment")
@@ -415,6 +416,7 @@ def _deploy_bundle_to_target(
     emitter=None,
     metadata: Optional[Dict[str, Any]] = None,
     manifest_file: Optional[str] = None,
+    project_info: Optional[Dict[str, Any]] = None,
 ) -> bool:
     """
     Deploy bundle files to the target environment.
@@ -428,6 +430,9 @@ def _deploy_bundle_to_target(
         emitter: Optional EventEmitter for monitoring
         metadata: Optional metadata for events
         manifest_file: Optional path to manifest file for local content resolution
+        project_info: Optional pre-resolved project info (domain_id, project_id,
+            connections) from ``get_datazone_project_info``. Passed through to
+            notebook sync to avoid re-resolving domain/project/connections.
 
     Returns:
         True if deployment succeeded, False otherwise
@@ -620,6 +625,7 @@ def _deploy_bundle_to_target(
         effective_bundle_path,
         target_config,
         config,
+        project_info=project_info,
     )
 
     # Return overall success - storage must succeed, git is optional
@@ -1374,6 +1380,7 @@ def _sync_notebooks_from_bundle(
     bundle_path: Optional[str],
     target_config,
     config: Dict[str, Any],
+    project_info: Optional[Dict[str, Any]] = None,
 ) -> bool:
     """
     Sync notebook resources from a bundle into the target DataZone project.
@@ -1386,10 +1393,19 @@ def _sync_notebooks_from_bundle(
     - Calls ``sync_notebooks()`` and reports the summary.
     - Returns False (and exits non-zero) if any notebooks failed to sync.
 
+    Domain ID, project ID, and connections are taken from ``project_info`` when
+    available (already resolved once by ``deploy_command`` during project init),
+    falling back to ``config["project_info"]`` and finally a fresh
+    ``get_datazone_project_info`` lookup. This avoids re-issuing the DataZone
+    resolution/ListConnections calls that already ran earlier in the deploy.
+
     Args:
         bundle_path: Path to the bundle ZIP (local or S3 URI).
         target_config: Stage configuration object.
         config: Resolved configuration dict (includes region, domain_id, etc.).
+        project_info: Optional pre-resolved project info dict (as returned by
+            ``get_datazone_project_info``). When omitted, resolved from
+            ``config["project_info"]`` or looked up on demand.
 
     Returns:
         True if sync succeeded or was skipped, False if any notebooks failed.
@@ -1441,43 +1457,41 @@ def _sync_notebooks_from_bundle(
                         err=True,
                     )
 
-        # ── Resolve target domain / project IDs ──────────────────────────
-        from ..helpers.datazone import (
-            get_domain_from_target_config,
-            get_project_id_by_name,
-        )
-
+        # ── Resolve target domain / project IDs + connections ────────────
+        # Prefer already-resolved project_info (from deploy_command's project
+        # init) to avoid re-issuing DataZone resolution/ListConnections calls.
         region = target_config.domain.region
-        domain_id, _ = get_domain_from_target_config(target_config, region)
-        project_name = target_config.project.name
-        project_id = get_project_id_by_name(project_name, domain_id, region)
+
+        if project_info is None:
+            project_info = config.get("project_info")
+        if project_info is None:
+            from ..helpers.utils import get_datazone_project_info
+
+            project_info = get_datazone_project_info(target_config.project.name, config)
+
+        if project_info.get("error"):
+            typer.echo(
+                f"❌ Could not resolve project info for notebook sync: "
+                f"{project_info['error']}",
+                err=True,
+            )
+            return False
+
+        domain_id = project_info.get("domain_id")
+        project_id = project_info.get("projectId") or project_info.get("project_id")
 
         if not project_id:
             typer.echo(
-                f"❌ Could not find project ID for project '{project_name}' "
-                "— skipping notebook sync",
+                f"❌ Could not find project ID for project "
+                f"'{target_config.project.name}' — skipping notebook sync",
                 err=True,
             )
             return False
 
         # ── Resolve S3 URI from default.s3_shared connection ─────────────
-        from ..helpers.connections import get_project_connections
+        from ..helpers.connections import get_connection_s3_uri
 
-        try:
-            connections = get_project_connections(
-                project_id=project_id,
-                domain_id=domain_id,
-                region=region,
-            )
-        except Exception as exc:
-            typer.echo(
-                f"❌ Could not retrieve project connections for notebook sync: {exc}",
-                err=True,
-            )
-            return False
-
-        s3_connection = connections.get("default.s3_shared", {})
-        s3_uri = s3_connection.get("s3Uri", "")
+        s3_uri = get_connection_s3_uri(project_info.get("connections", {}))
 
         if not s3_uri:
             typer.echo(

--- a/src/smus_cicd/commands/dry_run/checkers/notebook_checker.py
+++ b/src/smus_cicd/commands/dry_run/checkers/notebook_checker.py
@@ -1,0 +1,322 @@
+"""Notebook sync dry-run checker (Phase: Notebook Sync).
+
+Validates notebook sync prerequisites when a bundle contains a
+``notebooks/notebook_export_manifest.json`` file:
+
+  1. Verify the target project's ``default.s3_shared`` connection exists and
+     the resolved S3 bucket is reachable (HEAD request).
+  2. Verify IAM permissions via SimulatePrincipalPolicy:
+       datazone:StartNotebookSync, datazone:UpdateNotebook,
+       datazone:GetNotebook, datazone:ListNotebooks, s3:PutObject
+  3. Report the number of notebooks that would be synced from the manifest's
+     ``notebookCount`` field.
+
+Mirrors ``CatalogChecker`` in structure — reports WARNING (not ERROR) for
+missing S3 connection or denied permissions so the dry-run continues.
+
+Requirements: 8.1, 8.2, 8.3, 8.4, 8.5
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from smus_cicd.commands.dry_run.models import DryRunContext, Finding, Severity
+
+logger = logging.getLogger(__name__)
+
+# IAM actions that the caller needs for notebook sync
+_REQUIRED_NOTEBOOK_ACTIONS = [
+    "datazone:StartNotebookSync",
+    "datazone:UpdateNotebook",
+    "datazone:GetNotebook",
+    "datazone:ListNotebooks",
+    "s3:PutObject",
+]
+
+_NOTEBOOK_MANIFEST_PATH = "notebooks/notebook_export_manifest.json"
+
+
+def _is_notebook_sync_disabled(context: DryRunContext) -> bool:
+    """Return True if notebook sync is disabled in deployment_configuration."""
+    target = context.target_config
+    if not target:
+        return False
+    dep_cfg = getattr(target, "deployment_configuration", None)
+    if not dep_cfg:
+        return False
+    nb_cfg = getattr(dep_cfg, "notebooks", None)
+    if not nb_cfg:
+        return False
+    if isinstance(nb_cfg, dict):
+        return nb_cfg.get("disable", False)
+    return getattr(nb_cfg, "disable", False)
+
+
+class NotebookChecker:
+    """Validates notebook sync prerequisites during dry-run."""
+
+    def check(self, context: DryRunContext) -> List[Finding]:
+        findings: List[Finding] = []
+
+        # Skip if manifest has no notebook export or sync is disabled
+        if _NOTEBOOK_MANIFEST_PATH not in context.bundle_files:
+            findings.append(
+                Finding(
+                    severity=Severity.OK,
+                    message="Bundle contains no notebook manifest — notebook sync will be skipped.",
+                    service="datazone",
+                )
+            )
+            return findings
+
+        if _is_notebook_sync_disabled(context):
+            findings.append(
+                Finding(
+                    severity=Severity.OK,
+                    message="Notebook sync is disabled in deployment_configuration — skipping.",
+                    service="datazone",
+                )
+            )
+            return findings
+
+        # ── 1. Read notebookCount from the manifest ───────────────────────
+        notebook_count = self._read_notebook_count(context, findings)
+
+        # Report the planned sync count
+        findings.append(
+            Finding(
+                severity=Severity.OK,
+                message=(
+                    f"Notebook sync would process {notebook_count} notebook(s) "
+                    f"from the bundle manifest."
+                ),
+                service="datazone",
+                details={"notebookCount": notebook_count},
+            )
+        )
+
+        # ── 2. Check S3 connection ────────────────────────────────────────
+        s3_uri = self._check_s3_connection(context, findings)
+
+        # ── 3. Check IAM permissions ─────────────────────────────────────
+        if context.target_region:
+            self._check_iam_permissions(context, s3_uri, findings)
+
+        return findings
+
+    # ── helpers ──────────────────────────────────────────────────────────────
+
+    def _read_notebook_count(
+        self, context: DryRunContext, findings: List[Finding]
+    ) -> int:
+        """Extract notebookCount from the manifest in the bundle."""
+        if not context.bundle_path:
+            return 0
+        try:
+            import json
+            import zipfile
+
+            from smus_cicd.helpers.bundle_storage import ensure_bundle_local
+
+            local_path = ensure_bundle_local(
+                context.bundle_path, context.target_region or "us-east-1"
+            )
+            with zipfile.ZipFile(local_path, "r") as zf:
+                if _NOTEBOOK_MANIFEST_PATH in zf.namelist():
+                    with zf.open(_NOTEBOOK_MANIFEST_PATH) as mf:
+                        data = json.load(mf)
+                    return int(data.get("metadata", {}).get("notebookCount", 0))
+        except Exception as exc:
+            logger.debug("Could not read notebookCount from bundle: %s", exc)
+        return 0
+
+    def _check_s3_connection(
+        self, context: DryRunContext, findings: List[Finding]
+    ) -> Optional[str]:
+        """
+        Verify the target project's ``default.s3_shared`` connection exists and
+        the resolved S3 bucket is reachable via a HEAD request.
+
+        Returns the s3Uri on success, None otherwise.
+        Appends a WARNING finding on any failure.
+        """
+        try:
+            from smus_cicd.commands.dry_run.checkers import get_project_connections
+
+            connections = get_project_connections(
+                context, context.target_region or "us-east-1"
+            )
+            s3_conn = connections.get("default.s3_shared", {})
+            s3_uri = s3_conn.get("s3Uri", "")
+
+            if not s3_uri:
+                findings.append(
+                    Finding(
+                        severity=Severity.WARNING,
+                        message=(
+                            "Target project 'default.s3_shared' connection "
+                            "not found or has no s3Uri. Notebook .ipynb files "
+                            "cannot be uploaded before sync."
+                        ),
+                        service="s3",
+                        resource="default.s3_shared",
+                    )
+                )
+                return None
+
+            # HEAD the bucket to verify reachability
+            bucket = s3_uri.replace("s3://", "").split("/")[0]
+            try:
+                from smus_cicd.helpers.boto3_client import create_client
+
+                s3_client = create_client("s3", region=context.target_region or "us-east-1")
+                s3_client.head_bucket(Bucket=bucket)
+                findings.append(
+                    Finding(
+                        severity=Severity.OK,
+                        message=f"S3 connection 'default.s3_shared' bucket '{bucket}' is reachable.",
+                        service="s3",
+                        resource="default.s3_shared",
+                    )
+                )
+            except Exception as exc:
+                findings.append(
+                    Finding(
+                        severity=Severity.WARNING,
+                        message=(
+                            f"S3 bucket '{bucket}' from 'default.s3_shared' connection "
+                            f"is not reachable: {exc}"
+                        ),
+                        service="s3",
+                        resource="default.s3_shared",
+                    )
+                )
+                return None
+
+            return s3_uri
+
+        except Exception as exc:
+            findings.append(
+                Finding(
+                    severity=Severity.WARNING,
+                    message=f"Could not resolve S3 connection for notebook sync: {exc}",
+                    service="s3",
+                    resource="default.s3_shared",
+                )
+            )
+            return None
+
+    def _check_iam_permissions(
+        self,
+        context: DryRunContext,
+        s3_uri: Optional[str],
+        findings: List[Finding],
+    ) -> None:
+        """
+        Check IAM permissions via SimulatePrincipalPolicy.
+
+        Reports a WARNING finding for each denied action.
+        """
+        region = context.target_region or "us-east-1"
+
+        try:
+            from smus_cicd.helpers.boto3_client import create_client
+
+            sts = create_client("sts", region=region)
+            caller = sts.get_caller_identity()
+            caller_arn = caller.get("Arn", "")
+            account_id = caller.get("Account", "")
+
+            if not caller_arn:
+                findings.append(
+                    Finding(
+                        severity=Severity.WARNING,
+                        message="Could not determine caller ARN for IAM permission check.",
+                        service="iam",
+                    )
+                )
+                return
+
+            # Build resource ARNs for simulation
+            domain_id = context.target_domain_id or "*"
+            datazone_resource = f"arn:aws:datazone:{region}:{account_id}:domain/{domain_id}"
+
+            s3_resource = "*"
+            if s3_uri:
+                bucket = s3_uri.replace("s3://", "").split("/")[0]
+                s3_resource = f"arn:aws:s3:::{bucket}/*"
+
+            # Map each action to its resource ARN
+            action_resources: Dict[str, str] = {
+                "datazone:StartNotebookSync": datazone_resource,
+                "datazone:UpdateNotebook": datazone_resource,
+                "datazone:GetNotebook": datazone_resource,
+                "datazone:ListNotebooks": datazone_resource,
+                "s3:PutObject": s3_resource,
+            }
+
+            iam = create_client("iam", region=region)
+
+            for action, resource_arn in action_resources.items():
+                try:
+                    resp = iam.simulate_principal_policy(
+                        PolicySourceArn=caller_arn,
+                        ActionNames=[action],
+                        ResourceArns=[resource_arn],
+                    )
+                    for result in resp.get("EvaluationResults", []):
+                        decision = result.get("EvalDecision", "")
+                        if decision != "allowed":
+                            findings.append(
+                                Finding(
+                                    severity=Severity.WARNING,
+                                    message=(
+                                        f"IAM permission '{action}' is denied "
+                                        f"on resource '{resource_arn}' "
+                                        f"(decision: {decision}). "
+                                        f"Notebook sync may fail at deploy time."
+                                    ),
+                                    service="iam",
+                                    resource=action,
+                                    details={
+                                        "action": action,
+                                        "resource": resource_arn,
+                                        "decision": decision,
+                                    },
+                                )
+                            )
+                        else:
+                            findings.append(
+                                Finding(
+                                    severity=Severity.OK,
+                                    message=f"IAM permission '{action}' is allowed.",
+                                    service="iam",
+                                    resource=action,
+                                )
+                            )
+                except Exception as exc:
+                    logger.debug(
+                        "Could not simulate policy for action %s: %s", action, exc
+                    )
+                    findings.append(
+                        Finding(
+                            severity=Severity.WARNING,
+                            message=(
+                                f"Could not verify IAM permission '{action}': {exc}. "
+                                f"Ensure the caller has this permission for notebook sync."
+                            ),
+                            service="iam",
+                            resource=action,
+                        )
+                    )
+
+        except Exception as exc:
+            findings.append(
+                Finding(
+                    severity=Severity.WARNING,
+                    message=f"IAM permission check for notebook sync failed: {exc}",
+                    service="iam",
+                )
+            )

--- a/src/smus_cicd/commands/dry_run/checkers/notebook_checker.py
+++ b/src/smus_cicd/commands/dry_run/checkers/notebook_checker.py
@@ -171,7 +171,9 @@ class NotebookChecker:
             try:
                 from smus_cicd.helpers.boto3_client import create_client
 
-                s3_client = create_client("s3", region=context.target_region or "us-east-1")
+                s3_client = create_client(
+                    "s3", region=context.target_region or "us-east-1"
+                )
                 s3_client.head_bucket(Bucket=bucket)
                 findings.append(
                     Finding(
@@ -241,7 +243,9 @@ class NotebookChecker:
 
             # Build resource ARNs for simulation
             domain_id = context.target_domain_id or "*"
-            datazone_resource = f"arn:aws:datazone:{region}:{account_id}:domain/{domain_id}"
+            datazone_resource = (
+                f"arn:aws:datazone:{region}:{account_id}:domain/{domain_id}"
+            )
 
             s3_resource = "*"
             if s3_uri:

--- a/src/smus_cicd/commands/dry_run/checkers/notebook_checker.py
+++ b/src/smus_cicd/commands/dry_run/checkers/notebook_checker.py
@@ -20,9 +20,10 @@ Requirements: 8.1, 8.2, 8.3, 8.4, 8.5
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 from smus_cicd.commands.dry_run.models import DryRunContext, Finding, Severity
+from smus_cicd.helpers.connections import bucket_from_s3_uri
 
 logger = logging.getLogger(__name__)
 
@@ -144,12 +145,12 @@ class NotebookChecker:
         """
         try:
             from smus_cicd.commands.dry_run.checkers import get_project_connections
+            from smus_cicd.helpers.connections import get_connection_s3_uri
 
             connections = get_project_connections(
                 context, context.target_region or "us-east-1"
             )
-            s3_conn = connections.get("default.s3_shared", {})
-            s3_uri = s3_conn.get("s3Uri", "")
+            s3_uri = get_connection_s3_uri(connections)
 
             if not s3_uri:
                 findings.append(
@@ -167,7 +168,7 @@ class NotebookChecker:
                 return None
 
             # HEAD the bucket to verify reachability
-            bucket = s3_uri.replace("s3://", "").split("/")[0]
+            bucket = bucket_from_s3_uri(s3_uri)
             try:
                 from smus_cicd.helpers.boto3_client import create_client
 
@@ -249,7 +250,7 @@ class NotebookChecker:
 
             s3_resource = "*"
             if s3_uri:
-                bucket = s3_uri.replace("s3://", "").split("/")[0]
+                bucket = bucket_from_s3_uri(s3_uri)
                 s3_resource = f"arn:aws:s3:::{bucket}/*"
 
             # Map each action to its resource ARN

--- a/src/smus_cicd/commands/dry_run/engine.py
+++ b/src/smus_cicd/commands/dry_run/engine.py
@@ -20,6 +20,7 @@ from smus_cicd.commands.dry_run.checkers.connectivity_checker import Connectivit
 from smus_cicd.commands.dry_run.checkers.dependency_checker import DependencyChecker
 from smus_cicd.commands.dry_run.checkers.git_checker import GitChecker
 from smus_cicd.commands.dry_run.checkers.manifest_checker import ManifestChecker
+from smus_cicd.commands.dry_run.checkers.notebook_checker import NotebookChecker
 from smus_cicd.commands.dry_run.checkers.permission_checker import PermissionChecker
 from smus_cicd.commands.dry_run.checkers.preflight_checker import PreflightChecker
 from smus_cicd.commands.dry_run.checkers.project_checker import ProjectChecker
@@ -66,6 +67,7 @@ class DryRunEngine:
             (Phase.CATALOG_IMPORT, CatalogChecker()),
             (Phase.DEPENDENCY_VALIDATION, DependencyChecker()),
             (Phase.WORKFLOW_VALIDATION, WorkflowChecker()),
+            (Phase.NOTEBOOK_SYNC, NotebookChecker()),
             (Phase.BOOTSTRAP_ACTIONS, BootstrapChecker()),
         ]
 

--- a/src/smus_cicd/commands/dry_run/models.py
+++ b/src/smus_cicd/commands/dry_run/models.py
@@ -30,6 +30,7 @@ class Phase(enum.Enum):
     CATALOG_IMPORT = "Catalog Import"
     DEPENDENCY_VALIDATION = "Dependency Validation"
     WORKFLOW_VALIDATION = "Workflow Validation"
+    NOTEBOOK_SYNC = "Notebook Sync"
     BOOTSTRAP_ACTIONS = "Bootstrap Actions"
 
 

--- a/src/smus_cicd/helpers/connections.py
+++ b/src/smus_cicd/helpers/connections.py
@@ -1,6 +1,46 @@
 """Connection extraction and handling module."""
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+
+DEFAULT_S3_SHARED_CONNECTION = "default.s3_shared"
+
+
+def bucket_from_s3_uri(s3_uri: Optional[str]) -> Optional[str]:
+    """Extract the bucket name from an ``s3://bucket/prefix`` URI.
+
+    Args:
+        s3_uri: An S3 URI (e.g. ``s3://my-bucket/some/prefix``) or None.
+
+    Returns:
+        The bucket name, or None if the URI is empty/falsy.
+    """
+    if not s3_uri:
+        return None
+    return s3_uri.replace("s3://", "").rstrip("/").split("/")[0]
+
+
+def get_connection_s3_uri(
+    connections: Dict[str, Dict[str, Any]],
+    connection_name: str = DEFAULT_S3_SHARED_CONNECTION,
+) -> str:
+    """Resolve the S3 URI for a named connection from a connections map.
+
+    Centralizes the ``connections.get(name, {}).get("s3Uri", "")`` pattern used
+    across deploy, dry-run, and notebook/catalog sync so callers don't repeat it.
+
+    Args:
+        connections: Mapping of connection name -> extracted connection info
+            (as returned by :func:`get_project_connections`).
+        connection_name: Connection to look up. Defaults to
+            ``default.s3_shared``.
+
+    Returns:
+        The connection's ``s3Uri`` (e.g. ``s3://bucket/prefix``), or an empty
+        string if the connection is absent or has no S3 URI.
+    """
+    if not connections:
+        return ""
+    return connections.get(connection_name, {}).get("s3Uri", "")
 
 
 def extract_connection_properties(connection_detail: Dict[str, Any]) -> Dict[str, Any]:
@@ -33,9 +73,7 @@ def extract_connection_properties(connection_detail: Dict[str, Any]) -> Dict[str
         conn_info["status"] = s3_props.get("status")
         # Extract bucket name from S3 URI
         if s3_uri:
-            conn_info["bucket_name"] = (
-                s3_uri.replace("s3://", "").rstrip("/").split("/")[0]
-            )
+            conn_info["bucket_name"] = bucket_from_s3_uri(s3_uri)
 
     elif connection_type == "ATHENA":
         athena_props = props.get("athenaProperties", {})

--- a/src/smus_cicd/helpers/destroy_executor.py
+++ b/src/smus_cicd/helpers/destroy_executor.py
@@ -490,6 +490,88 @@ def _destroy_stage(
                 )
 
     # -----------------------------------------------------------------------
+    # Step f.5: Delete notebooks (CI/CD-managed only, identified by metadata)
+    # -----------------------------------------------------------------------
+    for resource in validation_result.resources:
+        if resource.resource_type != "notebook":
+            continue
+        notebook_id = resource.resource_id
+        domain_id_nb = resource.metadata.get("domain_id", "")
+        resource_name = resource.metadata.get("name", notebook_id)
+        source_id = resource.metadata.get("source_notebook_id", "")
+
+        if not domain_id_nb:
+            _log(
+                f"  [yellow]⚠️  Skipping notebook '{resource_name}' — missing domain ID[/yellow]"
+            )
+            results.append(
+                ResourceResult(
+                    resource_type="notebook",
+                    resource_id=notebook_id,
+                    status="skipped",
+                    message="Missing domain ID",
+                )
+            )
+            continue
+
+        try:
+            dz_client = create_client("datazone", region=effective_region)
+            dz_client.delete_notebook(
+                domainIdentifier=domain_id_nb,
+                identifier=notebook_id,
+            )
+            _log(
+                f"  ✅ Deleted notebook: {resource_name} ({notebook_id})"
+                + (f" [source: {source_id}]" if source_id else "")
+            )
+            results.append(
+                ResourceResult(
+                    resource_type="notebook",
+                    resource_id=notebook_id,
+                    status="deleted",
+                    message="Deleted successfully",
+                )
+            )
+        except ClientError as exc:
+            code = exc.response["Error"]["Code"]
+            if code in ("ResourceNotFoundException", "EntityNotFoundException"):
+                _log(
+                    f"  [yellow]⚠️  Notebook not found: {resource_name} ({notebook_id})[/yellow]"
+                )
+                results.append(
+                    ResourceResult(
+                        resource_type="notebook",
+                        resource_id=notebook_id,
+                        status="not_found",
+                        message="Notebook not found",
+                    )
+                )
+            else:
+                _log(
+                    f"  [red]❌ Error deleting notebook '{resource_name}' ({notebook_id}): {exc}[/red]"
+                )
+                results.append(
+                    ResourceResult(
+                        resource_type="notebook",
+                        resource_id=notebook_id,
+                        status="error",
+                        message=str(exc),
+                    )
+                )
+        except Exception as exc:
+            _log(
+                f"  [red]❌ Error deleting notebook '{resource_name}' ({notebook_id}): {exc}[/red]"
+            )
+            results.append(
+                ResourceResult(
+                    resource_type="notebook",
+                    resource_id=notebook_id,
+                    status="error",
+                    message=str(exc),
+                )
+            )
+
+    # -----------------------------------------------------------------------
     # Step g: Delete DataZone project (only if project.create=True)
     # -----------------------------------------------------------------------
     if stage_config.project.create is True:

--- a/src/smus_cicd/helpers/destroy_models.py
+++ b/src/smus_cicd/helpers/destroy_models.py
@@ -24,6 +24,8 @@ DESTROY_SUPPORTED_RESOURCE_TYPES = frozenset(
         "catalog_asset_type",
         "catalog_asset",
         "catalog_data_product",
+        # Notebook resources (via notebook sync)
+        "notebook",
     }
 )
 

--- a/src/smus_cicd/helpers/destroy_validator.py
+++ b/src/smus_cicd/helpers/destroy_validator.py
@@ -36,6 +36,107 @@ logger = get_logger("destroy")
 # ---------------------------------------------------------------------------
 
 
+def _discover_notebooks(
+    domain_id: str,
+    project_id: str,
+    region: str,
+    notebook_ids_filter=None,
+    _dz_client_override=None,
+):
+    """
+    Discover target notebooks that were deployed by this CI/CD tool.
+
+    Steps:
+      1. ListNotebooks with owningProjectIdentifier + status=ACTIVE (paginated).
+      2. GetNotebook for each to read metadata.
+      3. Include only notebooks whose metadata contains ``smus-cicd-source-notebook-id``.
+      4. If *notebook_ids_filter* is specified, further filter to only those
+         whose ``smus-cicd-source-notebook-id`` value is in the filter list.
+
+    Property 10: notebooks WITHOUT the metadata key are never included regardless
+    of configuration; when notebook_ids_filter is given only matching source IDs
+    are included.
+
+    Args:
+        domain_id: DataZone domain identifier.
+        project_id: DataZone project identifier (target project).
+        region: AWS region string.
+        notebook_ids_filter: Optional list of source notebook IDs to restrict
+            deletion to. None means include all notebooks that have the tracking
+            metadata key.
+
+    Returns:
+        List of dicts with keys: target_notebook_id, source_notebook_id, name.
+
+    Raises:
+        Exception: If the ListNotebooks API fails.
+    """
+    from ..helpers.boto3_client import create_client as _create_client
+
+    SOURCE_KEY = "smus-cicd-source-notebook-id"
+
+    dz_client = _dz_client_override or _create_client("datazone", region=region)
+
+    # Paginated list of active notebooks
+    target_ids = []
+    next_token = None
+    while True:
+        params = {
+            "domainIdentifier": domain_id,
+            "owningProjectIdentifier": project_id,
+            "status": "ACTIVE",
+        }
+        if next_token:
+            params["nextToken"] = next_token
+        resp = dz_client.list_notebooks(**params)
+        for item in resp.get("items", []):
+            nb_id = (
+                item.get("id")
+                or item.get("notebookId")
+                or item.get("identifier")
+            )
+            if nb_id:
+                target_ids.append(nb_id)
+        next_token = resp.get("nextToken")
+        if not next_token:
+            break
+
+    # GetNotebook for each to check metadata
+    result = []
+    for target_id in target_ids:
+        try:
+            detail = dz_client.get_notebook(
+                domainIdentifier=domain_id,
+                identifier=target_id,
+            )
+        except Exception as exc:
+            logger.warning(
+                "GetNotebook failed for target notebook %s during destroy discovery: %s",
+                target_id, exc,
+            )
+            continue
+
+        nb_metadata = detail.get("metadata") or {}
+        source_id = nb_metadata.get(SOURCE_KEY)
+        if not source_id:
+            # Not managed by this tool — skip
+            continue
+
+        # Apply notebook_ids_filter if specified
+        if notebook_ids_filter is not None and source_id not in notebook_ids_filter:
+            continue
+
+        result.append(
+            {
+                "target_notebook_id": target_id,
+                "source_notebook_id": source_id,
+                "name": detail.get("name", target_id),
+            }
+        )
+
+    return result
+
+
 def _discover_workflow_created_resources(
     workflow_yaml: dict, stage_name: str
 ) -> List[ResourceToDelete]:
@@ -564,6 +665,43 @@ def _validate_stage(
         elif catalog_disabled:
             warnings.append(
                 f"[{stage_name}] Catalog deletion is disabled (disable: true) — skipping."
+            )
+
+    # --- Notebook resources ---
+    if (
+        manifest.content
+        and manifest.content.notebooks
+        and manifest.content.notebooks.enabled
+        and project_id
+        and domain_id
+    ):
+        notebook_ids_filter = (
+            manifest.content.notebooks.notebook_ids
+        )  # None means "all"; list means "filter to these source IDs"
+        try:
+            discovered_notebooks = _discover_notebooks(
+                domain_id=domain_id,
+                project_id=project_id,
+                region=effective_region,
+                notebook_ids_filter=notebook_ids_filter,
+            )
+            for nb in discovered_notebooks:
+                resources.append(
+                    ResourceToDelete(
+                        resource_type="notebook",
+                        resource_id=nb["target_notebook_id"],
+                        stage=stage_name,
+                        metadata={
+                            "name": nb["name"],
+                            "source_notebook_id": nb["source_notebook_id"],
+                            "domain_id": domain_id,
+                        },
+                    )
+                )
+        except Exception as e:
+            errors.append(
+                f"[{stage_name}] ListNotebooks API failed during notebook "
+                f"discovery for project '{project_id}': {e}"
             )
 
     # --- Bootstrap connections ---

--- a/src/smus_cicd/helpers/destroy_validator.py
+++ b/src/smus_cicd/helpers/destroy_validator.py
@@ -90,11 +90,7 @@ def _discover_notebooks(
             params["nextToken"] = next_token
         resp = dz_client.list_notebooks(**params)
         for item in resp.get("items", []):
-            nb_id = (
-                item.get("id")
-                or item.get("notebookId")
-                or item.get("identifier")
-            )
+            nb_id = item.get("id") or item.get("notebookId") or item.get("identifier")
             if nb_id:
                 target_ids.append(nb_id)
         next_token = resp.get("nextToken")
@@ -112,7 +108,8 @@ def _discover_notebooks(
         except Exception as exc:
             logger.warning(
                 "GetNotebook failed for target notebook %s during destroy discovery: %s",
-                target_id, exc,
+                target_id,
+                exc,
             )
             continue
 

--- a/src/smus_cicd/helpers/notebook_export.py
+++ b/src/smus_cicd/helpers/notebook_export.py
@@ -1,0 +1,620 @@
+"""
+DataZone notebook export functionality for SMUS CI/CD CLI.
+
+Exports SageMaker Unified Studio notebooks from a source DataZone project using
+the DataZone Notebook APIs (GetNotebook, ListNotebooks, StartNotebookExport,
+GetNotebookExport). Produces a ``notebooks/notebook_export_manifest.json`` and
+one ``.ipynb`` file per notebook for inclusion in the bundle archive.
+
+Design mirrors ``catalog_export.py`` — a single public ``export_notebooks()``
+function backed by private helpers. All individual-notebook failures are
+collected and reported; only a total ListNotebooks failure aborts early.
+"""
+
+import logging
+import os
+import random
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from botocore.exceptions import ClientError
+
+from .boto3_client import create_client
+
+logger = logging.getLogger(__name__)
+
+# ── constants ────────────────────────────────────────────────────────────────
+
+# Metadata key used to track source notebook ID in target notebooks
+SOURCE_NOTEBOOK_METADATA_KEY = "smus-cicd-source-notebook-id"
+
+# Backoff settings for export polling (seconds)
+_POLL_INITIAL_INTERVAL = 1.0
+_POLL_MAX_INTERVAL = 30.0
+
+# Throttle-retry settings for DataZone API calls
+_THROTTLE_MAX_RETRIES = 3
+_THROTTLE_INITIAL_DELAY = 1.0
+
+
+# ── data models ──────────────────────────────────────────────────────────────
+
+
+@dataclass
+class ExportedNotebook:
+    """Result of a single notebook export operation."""
+
+    source_notebook_id: str
+    name: str
+    description: str
+    file_content: bytes
+    file_path: str  # relative path in bundle: notebooks/{sourceNotebookId}.ipynb
+    exported_at: str  # ISO 8601
+    parameters: Dict[str, str] = field(default_factory=dict)
+    metadata: Dict[str, str] = field(default_factory=dict)
+    environment_configuration: Optional[Dict[str, Any]] = None
+
+
+# ── DataZone client helper ───────────────────────────────────────────────────
+
+
+def _get_datazone_client(region: str):
+    """Create DataZone client with optional custom endpoint."""
+    endpoint_url = os.environ.get("DATAZONE_ENDPOINT_URL")
+    if endpoint_url:
+        return create_client("datazone", region=region, endpoint_url=endpoint_url)
+    return create_client("datazone", region=region)
+
+
+def _get_s3_client(region: str):
+    """Create S3 client."""
+    return create_client("s3", region=region)
+
+
+# ── throttle retry decorator ─────────────────────────────────────────────────
+
+
+def _call_with_throttle_retry(func, max_retries: int = _THROTTLE_MAX_RETRIES,
+                               initial_delay: float = _THROTTLE_INITIAL_DELAY):
+    """
+    Call *func* (a zero-argument callable) retrying on ThrottlingException.
+
+    Uses exponential backoff with jitter: delay = initial * 2^attempt + jitter.
+
+    Args:
+        func: Zero-argument callable wrapping the API call.
+        max_retries: Maximum number of retry attempts after the initial call.
+        initial_delay: Delay in seconds before the first retry.
+
+    Returns:
+        The return value of *func* on success.
+
+    Raises:
+        The last exception raised when all retries are exhausted.
+    """
+    for attempt in range(max_retries + 1):
+        try:
+            return func()
+        except ClientError as exc:
+            code = exc.response["Error"]["Code"]
+            if code == "ThrottlingException" and attempt < max_retries:
+                delay = initial_delay * (2 ** attempt) + random.uniform(0, 0.5)
+                logger.debug(
+                    "ThrottlingException on attempt %d/%d, retrying in %.1fs",
+                    attempt + 1, max_retries, delay,
+                )
+                time.sleep(delay)
+            else:
+                raise
+
+
+# ── internal helpers ─────────────────────────────────────────────────────────
+
+
+def _validate_notebook_ids(
+    client,
+    domain_id: str,
+    notebook_ids: List[str],
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """
+    Validate ALL notebook IDs upfront via GetNotebook (fail-fast pass).
+
+    Calls GetNotebook for each ID and collects both valid notebook details and
+    invalid IDs. Returns after checking *every* ID — does not abort on first
+    failure — so the error message can list all invalid entries at once.
+
+    Args:
+        client: DataZone boto3 client.
+        domain_id: DataZone domain identifier.
+        notebook_ids: List of notebook IDs to validate.
+
+    Returns:
+        Tuple of (valid_notebooks_with_details, invalid_ids).
+        valid_notebooks_with_details contains the full GetNotebook response for
+        each valid ID (parameters, metadata, environmentConfiguration included).
+    """
+    valid: List[Dict[str, Any]] = []
+    invalid: List[str] = []
+
+    for nb_id in notebook_ids:
+        try:
+            resp = _call_with_throttle_retry(
+                lambda nb_id=nb_id: client.get_notebook(
+                    domainIdentifier=domain_id,
+                    identifier=nb_id,
+                )
+            )
+            resp.pop("ResponseMetadata", None)
+            valid.append(resp)
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] == "ResourceNotFoundException":
+                invalid.append(nb_id)
+            else:
+                # Re-raise unexpected errors
+                raise
+        except Exception:
+            raise
+
+    return valid, invalid
+
+
+def _list_all_notebooks(
+    client,
+    domain_id: str,
+    project_id: str,
+) -> List[Dict[str, Any]]:
+    """
+    List all ACTIVE notebooks owned by *project_id* via the ListNotebooks API.
+
+    Follows pagination via ``nextToken`` until all pages are retrieved.
+
+    Args:
+        client: DataZone boto3 client.
+        domain_id: DataZone domain identifier.
+        project_id: DataZone project identifier.
+
+    Returns:
+        List of notebook summary dicts from ListNotebooks items.
+
+    Raises:
+        Exception: If the ListNotebooks API returns an error.
+    """
+    notebooks: List[Dict[str, Any]] = []
+    next_token: Optional[str] = None
+
+    while True:
+        params: Dict[str, Any] = {
+            "domainIdentifier": domain_id,
+            "owningProjectIdentifier": project_id,
+            "status": "ACTIVE",
+        }
+        if next_token:
+            params["nextToken"] = next_token
+
+        resp = _call_with_throttle_retry(
+            lambda params=params: client.list_notebooks(**params)
+        )
+        items = resp.get("items", [])
+        notebooks.extend(items)
+
+        next_token = resp.get("nextToken")
+        if not next_token:
+            break
+
+    return notebooks
+
+
+def _get_notebook_details(
+    client,
+    domain_id: str,
+    notebook_id: str,
+) -> Dict[str, Any]:
+    """
+    Fetch full notebook details via GetNotebook.
+
+    Returns the full response dict (ResponseMetadata stripped).
+    """
+    resp = _call_with_throttle_retry(
+        lambda: client.get_notebook(
+            domainIdentifier=domain_id,
+            identifier=notebook_id,
+        )
+    )
+    resp.pop("ResponseMetadata", None)
+    return resp
+
+
+def _compute_backoff_delay(attempt: int, initial: float = _POLL_INITIAL_INTERVAL,
+                            cap: float = _POLL_MAX_INTERVAL) -> float:
+    """
+    Compute exponential backoff delay with jitter for poll attempt *attempt*
+    (0-indexed from the first wait).
+
+    Formula: min(initial × 2^attempt, cap) + uniform jitter [0, 0.5s].
+
+    Property 8: delay for attempt i = min(initial × 2^(i-1), max_interval)
+    (i is 1-indexed; here we pass 0-indexed attempt so initial × 2^attempt
+    equals initial × 2^(i-1) when i = attempt+1).
+    """
+    base = min(initial * (2 ** attempt), cap)
+    return base + random.uniform(0, 0.5)
+
+
+def _poll_export_status(
+    client,
+    domain_id: str,
+    export_id: str,
+    notebook_id: str,
+    polling_timeout: int,
+) -> Optional[str]:
+    """
+    Poll GetNotebookExport with exponential backoff until the export succeeds
+    or fails.
+
+    Args:
+        client: DataZone boto3 client.
+        domain_id: DataZone domain identifier.
+        export_id: The export identifier returned by StartNotebookExport.
+        notebook_id: Source notebook identifier (used in log messages).
+        polling_timeout: Maximum seconds to wait before giving up.
+
+    Returns:
+        The S3 ``outputLocation`` URI on success, or ``None`` if the export
+        failed or timed out.
+    """
+    start = time.monotonic()
+    attempt = 0
+
+    while True:
+        resp = _call_with_throttle_retry(
+            lambda: client.get_notebook_export(
+                domainIdentifier=domain_id,
+                identifier=export_id,
+            )
+        )
+        resp.pop("ResponseMetadata", None)
+
+        status = resp.get("status", "")
+
+        if status == "SUCCEEDED":
+            output_loc = resp.get("outputLocation")
+            # outputLocation can be a dict like {"s3": {"uri": "s3://..."}} or a plain string
+            if isinstance(output_loc, dict):
+                s3_val = output_loc.get("s3", {})
+                if isinstance(s3_val, dict):
+                    return s3_val.get("uri") or s3_val.get("s3Uri")
+                return s3_val  # s3_val is the URI string itself
+            return output_loc
+
+        if status == "FAILED":
+            error_msg = resp.get("error", {}).get("message", "unknown error")
+            logger.error(
+                "Export FAILED for notebook %s (export %s): %s",
+                notebook_id, export_id, error_msg,
+            )
+            return None
+
+        elapsed = time.monotonic() - start
+        if elapsed >= polling_timeout:
+            logger.warning(
+                "Export polling timed out for notebook %s after %.0fs (export %s)",
+                notebook_id, elapsed, export_id,
+            )
+            return None
+
+        delay = _compute_backoff_delay(attempt)
+        remaining = polling_timeout - elapsed
+        actual_delay = min(delay, remaining)
+        time.sleep(actual_delay)
+        attempt += 1
+
+
+def _download_from_s3(s3_client, s3_uri: str) -> bytes:
+    """
+    Download an object from S3 and return its content as bytes.
+
+    Args:
+        s3_client: Boto3 S3 client.
+        s3_uri: Full S3 URI of the form ``s3://bucket/key``.
+
+    Returns:
+        Raw bytes of the downloaded object.
+
+    Raises:
+        ValueError: If *s3_uri* is not a valid S3 URI.
+        Exception: If the S3 download fails.
+    """
+    if not s3_uri.startswith("s3://"):
+        raise ValueError(f"Invalid S3 URI: {s3_uri}")
+    without_scheme = s3_uri[5:]
+    bucket, _, key = without_scheme.partition("/")
+    if not bucket or not key:
+        raise ValueError(f"Could not parse bucket/key from S3 URI: {s3_uri}")
+
+    resp = s3_client.get_object(Bucket=bucket, Key=key)
+    return resp["Body"].read()
+
+
+def _export_single_notebook(
+    dz_client,
+    s3_client,
+    domain_id: str,
+    project_id: str,
+    notebook_details: Dict[str, Any],
+    polling_timeout: int,
+) -> Optional[ExportedNotebook]:
+    """
+    Export a single notebook: StartNotebookExport → poll → download .ipynb.
+
+    Args:
+        dz_client: DataZone boto3 client.
+        s3_client: S3 boto3 client.
+        domain_id: DataZone domain identifier.
+        project_id: DataZone project identifier (owningProjectIdentifier).
+        notebook_details: Full GetNotebook response dict for this notebook.
+        polling_timeout: Max seconds to wait for export to complete.
+
+    Returns:
+        ``ExportedNotebook`` on success, or ``None`` if the export failed.
+    """
+    notebook_id = (
+        notebook_details.get("id")
+        or notebook_details.get("notebookId")
+        or notebook_details.get("identifier")
+    )
+    name = notebook_details.get("name", "")
+    description = notebook_details.get("description", "") or ""
+    parameters = notebook_details.get("parameters") or {}
+    metadata = notebook_details.get("metadata") or {}
+    env_config = notebook_details.get("environmentConfiguration")
+
+    if not notebook_id:
+        logger.error("Cannot export notebook — missing identifier in details: %s", notebook_details)
+        return None
+
+    # Start the export
+    try:
+        start_resp = _call_with_throttle_retry(
+            lambda: dz_client.start_notebook_export(
+                domainIdentifier=domain_id,
+                notebookIdentifier=notebook_id,
+                owningProjectIdentifier=project_id,
+                fileFormat="IPYNB",
+            )
+        )
+        export_id = start_resp.get("id")
+    except Exception as exc:
+        logger.error(
+            "StartNotebookExport failed for notebook %s: %s", notebook_id, exc
+        )
+        return None
+
+    if not export_id:
+        logger.error(
+            "StartNotebookExport returned no export identifier for notebook %s",
+            notebook_id,
+        )
+        return None
+
+    logger.info("Started export %s for notebook %s", export_id, notebook_id)
+
+    # Poll until done
+    output_location = _poll_export_status(
+        dz_client, domain_id, export_id, notebook_id, polling_timeout
+    )
+    if not output_location:
+        return None
+
+    # Download .ipynb from S3
+    try:
+        file_content = _download_from_s3(s3_client, output_location)
+    except Exception as exc:
+        logger.error(
+            "Failed to download export for notebook %s from %s: %s",
+            notebook_id, output_location, exc,
+        )
+        return None
+
+    exported_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    file_path = f"notebooks/{notebook_id}.ipynb"
+
+    return ExportedNotebook(
+        source_notebook_id=notebook_id,
+        name=name,
+        description=description,
+        file_content=file_content,
+        file_path=file_path,
+        exported_at=exported_at,
+        parameters=parameters,
+        metadata=metadata,
+        environment_configuration=env_config,
+    )
+
+
+def _build_export_manifest(
+    exported: List[ExportedNotebook],
+    domain_id: str,
+    project_id: str,
+) -> Dict[str, Any]:
+    """
+    Build the ``notebook_export_manifest.json`` structure.
+
+    Args:
+        exported: List of successfully exported notebooks.
+        domain_id: Source DataZone domain identifier.
+        project_id: Source DataZone project identifier.
+
+    Returns:
+        Dict matching the NotebookExportManifest JSON schema.
+    """
+    export_timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    notebooks_list = []
+    for nb in exported:
+        entry: Dict[str, Any] = {
+            "sourceNotebookId": nb.source_notebook_id,
+            "name": nb.name,
+            "description": nb.description,
+            "filePath": nb.file_path,
+            "exportedAt": nb.exported_at,
+            "parameters": nb.parameters,
+            "metadata": nb.metadata,
+            "environmentConfiguration": nb.environment_configuration,
+        }
+        notebooks_list.append(entry)
+
+    return {
+        "metadata": {
+            "sourceProjectId": project_id,
+            "sourceDomainId": domain_id,
+            "exportTimestamp": export_timestamp,
+            "notebookCount": len(notebooks_list),
+        },
+        "notebooks": notebooks_list,
+    }
+
+
+# ── public API ───────────────────────────────────────────────────────────────
+
+
+def export_notebooks(
+    domain_id: str,
+    project_id: str,
+    region: str,
+    notebook_ids: Optional[List[str]] = None,
+    polling_timeout: int = 300,
+) -> Tuple[List[ExportedNotebook], Dict[str, Any]]:
+    """
+    Export notebooks from a DataZone project.
+
+    Two modes:
+
+    **notebook_ids specified** — fail-fast validation pass:
+      1. Call GetNotebook for every ID in the list.
+      2. If *any* ID is not found (ResourceNotFoundException), raise
+         ``SystemExit`` listing all invalid IDs.  No exports are started.
+      3. If all IDs are valid, export only those notebooks.
+
+    **notebook_ids omitted** — discover and export all:
+      1. Call ListNotebooks with ``status=ACTIVE`` (paginated) to discover all
+         active notebooks owned by *project_id*.
+      2. Export all discovered notebooks.
+
+    In both modes individual export failures (StartNotebookExport failure,
+    polling timeout, S3 download failure) are collected and reported; they do
+    not abort remaining exports.
+
+    Args:
+        domain_id: DataZone domain identifier.
+        project_id: DataZone project identifier (source project).
+        region: AWS region string.
+        notebook_ids: Optional list of specific notebook IDs to export.
+        polling_timeout: Max seconds to wait per notebook export (default 300).
+
+    Returns:
+        Tuple of ``(exported_notebooks, manifest_dict)``.
+        *exported_notebooks* contains only successfully exported notebooks.
+        *manifest_dict* is the full ``notebook_export_manifest.json`` structure.
+
+    Raises:
+        SystemExit: If *notebook_ids* contains any invalid (not-found) IDs.
+        Exception: If the ListNotebooks API fails entirely (discovery mode).
+    """
+    dz_client = _get_datazone_client(region)
+    s3_client = _get_s3_client(region)
+
+    # ── Step 1: resolve the list of notebooks to export ──────────────────────
+    notebooks_to_export: List[Dict[str, Any]] = []
+
+    if notebook_ids is not None:
+        # Fail-fast validation pass — validate ALL before starting any export
+        valid_notebooks, invalid_ids = _validate_notebook_ids(
+            dz_client, domain_id, notebook_ids
+        )
+
+        if invalid_ids:
+            # Report all invalid IDs and abort immediately
+            ids_str = ", ".join(invalid_ids)
+            raise SystemExit(
+                f"Error: The following notebook_ids were not found in domain "
+                f"'{domain_id}': {ids_str}\n"
+                f"No notebooks were exported. Fix the notebook_ids list and retry."
+            )
+
+        logger.info(
+            "Validated %d notebook ID(s) for project %s", len(valid_notebooks), project_id
+        )
+        notebooks_to_export = valid_notebooks
+    else:
+        # Discovery mode — list all active notebooks
+        try:
+            notebook_summaries = _list_all_notebooks(dz_client, domain_id, project_id)
+        except Exception as exc:
+            raise Exception(
+                f"ListNotebooks API failed for project '{project_id}' in domain "
+                f"'{domain_id}': {exc}"
+            ) from exc
+
+        if not notebook_summaries:
+            logger.info(
+                "No active notebooks found for project %s in domain %s",
+                project_id, domain_id,
+            )
+            manifest = _build_export_manifest([], domain_id, project_id)
+            return [], manifest
+
+        # Fetch full details for each summary (need parameters/metadata/envConfig)
+        for summary in notebook_summaries:
+            nb_id = (
+                summary.get("id")
+                or summary.get("notebookId")
+                or summary.get("identifier")
+            )
+            if not nb_id:
+                logger.warning("Skipping notebook summary with no ID: %s", summary)
+                continue
+            try:
+                details = _get_notebook_details(dz_client, domain_id, nb_id)
+                notebooks_to_export.append(details)
+            except Exception as exc:
+                logger.error(
+                    "GetNotebook failed for notebook %s during discovery: %s",
+                    nb_id, exc,
+                )
+                # Count it as a failure below by not adding to the list —
+                # we still proceed with the rest
+
+    # ── Step 2: export each notebook ────────────────────────────────────────
+    exported: List[ExportedNotebook] = []
+    failed_ids: List[str] = []
+
+    for notebook_details in notebooks_to_export:
+        nb_id = (
+            notebook_details.get("id")
+            or notebook_details.get("notebookId")
+            or notebook_details.get("identifier")
+        )
+        result = _export_single_notebook(
+            dz_client, s3_client, domain_id, project_id, notebook_details, polling_timeout
+        )
+        if result:
+            exported.append(result)
+            logger.info("Successfully exported notebook %s (%s)", nb_id, result.name)
+        else:
+            failed_ids.append(nb_id or "<unknown>")
+            logger.warning("Failed to export notebook %s", nb_id)
+
+    # ── Step 3: build manifest ───────────────────────────────────────────────
+    manifest = _build_export_manifest(exported, domain_id, project_id)
+
+    # ── Step 4: report failures ──────────────────────────────────────────────
+    if failed_ids:
+        failed_str = ", ".join(failed_ids)
+        raise SystemExit(
+            f"Error: {len(failed_ids)} notebook(s) failed to export: {failed_str}\n"
+            f"Successfully exported: {len(exported)} notebook(s)."
+        )
+
+    return exported, manifest

--- a/src/smus_cicd/helpers/notebook_export.py
+++ b/src/smus_cicd/helpers/notebook_export.py
@@ -76,8 +76,11 @@ def _get_s3_client(region: str):
 # ── throttle retry decorator ─────────────────────────────────────────────────
 
 
-def _call_with_throttle_retry(func, max_retries: int = _THROTTLE_MAX_RETRIES,
-                               initial_delay: float = _THROTTLE_INITIAL_DELAY):
+def _call_with_throttle_retry(
+    func,
+    max_retries: int = _THROTTLE_MAX_RETRIES,
+    initial_delay: float = _THROTTLE_INITIAL_DELAY,
+):
     """
     Call *func* (a zero-argument callable) retrying on ThrottlingException.
 
@@ -100,10 +103,12 @@ def _call_with_throttle_retry(func, max_retries: int = _THROTTLE_MAX_RETRIES,
         except ClientError as exc:
             code = exc.response["Error"]["Code"]
             if code == "ThrottlingException" and attempt < max_retries:
-                delay = initial_delay * (2 ** attempt) + random.uniform(0, 0.5)
+                delay = initial_delay * (2**attempt) + random.uniform(0, 0.5)
                 logger.debug(
                     "ThrottlingException on attempt %d/%d, retrying in %.1fs",
-                    attempt + 1, max_retries, delay,
+                    attempt + 1,
+                    max_retries,
+                    delay,
                 )
                 time.sleep(delay)
             else:
@@ -226,8 +231,11 @@ def _get_notebook_details(
     return resp
 
 
-def _compute_backoff_delay(attempt: int, initial: float = _POLL_INITIAL_INTERVAL,
-                            cap: float = _POLL_MAX_INTERVAL) -> float:
+def _compute_backoff_delay(
+    attempt: int,
+    initial: float = _POLL_INITIAL_INTERVAL,
+    cap: float = _POLL_MAX_INTERVAL,
+) -> float:
     """
     Compute exponential backoff delay with jitter for poll attempt *attempt*
     (0-indexed from the first wait).
@@ -238,7 +246,7 @@ def _compute_backoff_delay(attempt: int, initial: float = _POLL_INITIAL_INTERVAL
     (i is 1-indexed; here we pass 0-indexed attempt so initial × 2^attempt
     equals initial × 2^(i-1) when i = attempt+1).
     """
-    base = min(initial * (2 ** attempt), cap)
+    base = min(initial * (2**attempt), cap)
     return base + random.uniform(0, 0.5)
 
 
@@ -292,7 +300,9 @@ def _poll_export_status(
             error_msg = resp.get("error", {}).get("message", "unknown error")
             logger.error(
                 "Export FAILED for notebook %s (export %s): %s",
-                notebook_id, export_id, error_msg,
+                notebook_id,
+                export_id,
+                error_msg,
             )
             return None
 
@@ -300,7 +310,9 @@ def _poll_export_status(
         if elapsed >= polling_timeout:
             logger.warning(
                 "Export polling timed out for notebook %s after %.0fs (export %s)",
-                notebook_id, elapsed, export_id,
+                notebook_id,
+                elapsed,
+                export_id,
             )
             return None
 
@@ -371,7 +383,10 @@ def _export_single_notebook(
     env_config = notebook_details.get("environmentConfiguration")
 
     if not notebook_id:
-        logger.error("Cannot export notebook — missing identifier in details: %s", notebook_details)
+        logger.error(
+            "Cannot export notebook — missing identifier in details: %s",
+            notebook_details,
+        )
         return None
 
     # Start the export
@@ -386,9 +401,7 @@ def _export_single_notebook(
         )
         export_id = start_resp.get("id")
     except Exception as exc:
-        logger.error(
-            "StartNotebookExport failed for notebook %s: %s", notebook_id, exc
-        )
+        logger.error("StartNotebookExport failed for notebook %s: %s", notebook_id, exc)
         return None
 
     if not export_id:
@@ -413,7 +426,9 @@ def _export_single_notebook(
     except Exception as exc:
         logger.error(
             "Failed to download export for notebook %s from %s: %s",
-            notebook_id, output_location, exc,
+            notebook_id,
+            output_location,
+            exc,
         )
         return None
 
@@ -544,7 +559,9 @@ def export_notebooks(
             )
 
         logger.info(
-            "Validated %d notebook ID(s) for project %s", len(valid_notebooks), project_id
+            "Validated %d notebook ID(s) for project %s",
+            len(valid_notebooks),
+            project_id,
         )
         notebooks_to_export = valid_notebooks
     else:
@@ -560,7 +577,8 @@ def export_notebooks(
         if not notebook_summaries:
             logger.info(
                 "No active notebooks found for project %s in domain %s",
-                project_id, domain_id,
+                project_id,
+                domain_id,
             )
             manifest = _build_export_manifest([], domain_id, project_id)
             return [], manifest
@@ -581,7 +599,8 @@ def export_notebooks(
             except Exception as exc:
                 logger.error(
                     "GetNotebook failed for notebook %s during discovery: %s",
-                    nb_id, exc,
+                    nb_id,
+                    exc,
                 )
                 # Count it as a failure below by not adding to the list —
                 # we still proceed with the rest
@@ -597,7 +616,12 @@ def export_notebooks(
             or notebook_details.get("identifier")
         )
         result = _export_single_notebook(
-            dz_client, s3_client, domain_id, project_id, notebook_details, polling_timeout
+            dz_client,
+            s3_client,
+            domain_id,
+            project_id,
+            notebook_details,
+            polling_timeout,
         )
         if result:
             exported.append(result)

--- a/src/smus_cicd/helpers/notebook_import.py
+++ b/src/smus_cicd/helpers/notebook_import.py
@@ -299,7 +299,6 @@ def _generate_client_token(source_notebook_id: str, timestamp: str) -> str:
 
 def _build_update_kwargs(
     domain_id: str,
-    project_id: str,
     target_notebook_id: str,
     notebook_entry: Dict[str, Any],
 ) -> Dict[str, Any]:
@@ -346,7 +345,6 @@ def _build_update_kwargs(
 def _apply_notebook_metadata(
     dz_client,
     domain_id: str,
-    project_id: str,
     target_notebook_id: str,
     notebook_entry: Dict[str, Any],
 ) -> bool:
@@ -356,9 +354,7 @@ def _apply_notebook_metadata(
 
     Returns True on success, False on any error (notebook counts as FAILED).
     """
-    kwargs = _build_update_kwargs(
-        domain_id, project_id, target_notebook_id, notebook_entry
-    )
+    kwargs = _build_update_kwargs(domain_id, target_notebook_id, notebook_entry)
     try:
         _call_with_throttle_retry(lambda: dz_client.update_notebook(**kwargs))
         return True
@@ -521,7 +517,7 @@ def _sync_single_notebook(
 
     # Apply metadata via UpdateNotebook
     metadata_ok = _apply_notebook_metadata(
-        dz_client, domain_id, project_id, new_target_id, notebook_entry
+        dz_client, domain_id, new_target_id, notebook_entry
     )
     if not metadata_ok:
         return SyncResult(

--- a/src/smus_cicd/helpers/notebook_import.py
+++ b/src/smus_cicd/helpers/notebook_import.py
@@ -1,0 +1,681 @@
+"""
+DataZone notebook sync (import) functionality for SMUS CI/CD CLI.
+
+Syncs SageMaker Unified Studio notebooks into a target DataZone project using
+the StartNotebookSync API. Follows the six-step deployment sequence:
+
+  1. Upload all .ipynb files to S3 at {s3Uri}/notebooks/imports/{sourceNotebookId}.ipynb
+  2. ListNotebooks + GetNotebook for each target notebook → read metadata
+  3. Build {sourceNotebookId → targetNotebookId} map from smus-cicd-source-notebook-id
+  4. For each manifest entry: StartNotebookSync WITH notebookId (update) or
+     WITHOUT (create), with ResourceNotFoundException fallback to create
+  5. UpdateNotebook to apply name, description, metadata (with tracking key),
+     parameters, and environmentConfiguration
+  6. Report created / updated / failed counts
+
+Design mirrors ``catalog_import.py``.
+"""
+
+import enum
+import hashlib
+import logging
+import os
+import random
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from botocore.exceptions import ClientError
+
+from .boto3_client import create_client
+
+logger = logging.getLogger(__name__)
+
+# ── constants ────────────────────────────────────────────────────────────────
+
+SOURCE_NOTEBOOK_METADATA_KEY = "smus-cicd-source-notebook-id"
+
+# Required top-level keys in notebook_export_manifest.json
+_REQUIRED_MANIFEST_KEYS = {"metadata", "notebooks"}
+_REQUIRED_METADATA_KEYS = {"sourceProjectId", "sourceDomainId", "exportTimestamp", "notebookCount"}
+
+# S3 import prefix inside the project's s3_shared bucket
+_S3_IMPORT_PREFIX = "notebooks/imports"
+
+# Throttle-retry settings
+_THROTTLE_MAX_RETRIES = 3
+_THROTTLE_INITIAL_DELAY = 1.0
+
+# Max client token length enforced by the DataZone API
+_CLIENT_TOKEN_MAX_LEN = 64
+
+
+# ── data models ──────────────────────────────────────────────────────────────
+
+
+class SyncStatus(enum.Enum):
+    CREATED = "created"
+    UPDATED = "updated"
+    FAILED = "failed"
+
+
+@dataclass
+class SyncResult:
+    """Outcome of syncing a single notebook."""
+
+    status: SyncStatus
+    source_notebook_id: str
+    target_notebook_id: Optional[str] = None
+    message: str = ""
+
+
+@dataclass
+class NotebookSyncSummary:
+    """Aggregate summary of a notebook sync operation."""
+
+    created: int = 0
+    updated: int = 0
+    failed: int = 0
+    failed_ids: List[str] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return self.created + self.updated + self.failed
+
+    @property
+    def has_failures(self) -> bool:
+        return self.failed > 0
+
+
+# ── client helpers ───────────────────────────────────────────────────────────
+
+
+def _get_datazone_client(region: str):
+    endpoint_url = os.environ.get("DATAZONE_ENDPOINT_URL")
+    if endpoint_url:
+        return create_client("datazone", region=region, endpoint_url=endpoint_url)
+    return create_client("datazone", region=region)
+
+
+def _get_s3_client(region: str):
+    return create_client("s3", region=region)
+
+
+# ── throttle retry ───────────────────────────────────────────────────────────
+
+
+def _call_with_throttle_retry(func, max_retries: int = _THROTTLE_MAX_RETRIES,
+                               initial_delay: float = _THROTTLE_INITIAL_DELAY):
+    """Retry *func* on ThrottlingException with exponential backoff + jitter."""
+    for attempt in range(max_retries + 1):
+        try:
+            return func()
+        except ClientError as exc:
+            code = exc.response["Error"]["Code"]
+            if code == "ThrottlingException" and attempt < max_retries:
+                delay = initial_delay * (2 ** attempt) + random.uniform(0, 0.5)
+                logger.debug(
+                    "ThrottlingException on attempt %d/%d, retrying in %.1fs",
+                    attempt + 1, max_retries, delay,
+                )
+                time.sleep(delay)
+            else:
+                raise
+
+
+# ── validation ───────────────────────────────────────────────────────────────
+
+
+def _validate_notebook_manifest(manifest_data: Dict[str, Any]) -> None:
+    """
+    Validate that the manifest has required structure.
+
+    Raises ValueError before any API calls if required keys are missing.
+
+    Required top-level keys: ``metadata``, ``notebooks``
+    Required metadata keys: ``sourceProjectId``, ``sourceDomainId``,
+                            ``exportTimestamp``, ``notebookCount``
+    """
+    missing_top = _REQUIRED_MANIFEST_KEYS - set(manifest_data.keys())
+    if missing_top:
+        raise ValueError(
+            f"notebook_export_manifest.json is missing required top-level "
+            f"key(s): {sorted(missing_top)}"
+        )
+
+    metadata = manifest_data.get("metadata", {})
+    missing_meta = _REQUIRED_METADATA_KEYS - set(metadata.keys())
+    if missing_meta:
+        raise ValueError(
+            f"notebook_export_manifest.json metadata is missing required "
+            f"key(s): {sorted(missing_meta)}"
+        )
+
+
+# ── S3 helpers ───────────────────────────────────────────────────────────────
+
+
+def _parse_s3_uri(s3_uri: str):
+    """Parse ``s3://bucket/prefix`` into ``(bucket, prefix)``."""
+    if not s3_uri.startswith("s3://"):
+        raise ValueError(f"Invalid S3 URI: {s3_uri!r}")
+    without_scheme = s3_uri[5:]
+    bucket, _, prefix = without_scheme.partition("/")
+    return bucket, prefix.rstrip("/")
+
+
+def _upload_notebook_to_s3(
+    s3_client,
+    s3_uri: str,
+    source_notebook_id: str,
+    content: bytes,
+) -> str:
+    """
+    Upload a .ipynb file to S3.
+
+    Key: ``{s3_uri}/notebooks/imports/{sourceNotebookId}.ipynb``
+
+    Returns:
+        Full S3 URI of the uploaded object.
+
+    Raises:
+        Exception: If the upload fails.
+    """
+    bucket, base_prefix = _parse_s3_uri(s3_uri)
+    key = f"{base_prefix}/{_S3_IMPORT_PREFIX}/{source_notebook_id}.ipynb"
+    key = key.lstrip("/")
+
+    s3_client.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=content,
+        ContentType="application/x-ipynb+json",
+    )
+    return f"s3://{bucket}/{key}"
+
+
+# ── target notebook discovery ─────────────────────────────────────────────────
+
+
+def _discover_target_notebooks(
+    dz_client,
+    domain_id: str,
+    project_id: str,
+) -> Dict[str, str]:
+    """
+    Build a ``{sourceNotebookId → targetNotebookId}`` mapping by inspecting
+    the ``smus-cicd-source-notebook-id`` metadata key on every active notebook
+    in the target project.
+
+    Steps:
+      1. ListNotebooks with owningProjectIdentifier + status=ACTIVE (paginated).
+      2. GetNotebook for each discovered notebook.
+      3. Read metadata[SOURCE_NOTEBOOK_METADATA_KEY] → target notebook ID mapping.
+
+    Returns:
+        Dict mapping source notebook ID → target notebook ID.
+    """
+    source_to_target: Dict[str, str] = {}
+
+    # Paginated list
+    next_token: Optional[str] = None
+    target_ids: List[str] = []
+
+    while True:
+        params: Dict[str, Any] = {
+            "domainIdentifier": domain_id,
+            "owningProjectIdentifier": project_id,
+            "status": "ACTIVE",
+        }
+        if next_token:
+            params["nextToken"] = next_token
+
+        resp = _call_with_throttle_retry(
+            lambda params=params: dz_client.list_notebooks(**params)
+        )
+        for item in resp.get("items", []):
+            nb_id = (
+                item.get("id")
+                or item.get("notebookId")
+                or item.get("identifier")
+            )
+            if nb_id:
+                target_ids.append(nb_id)
+
+        next_token = resp.get("nextToken")
+        if not next_token:
+            break
+
+    # GetNotebook for each to read metadata
+    for target_id in target_ids:
+        try:
+            detail = _call_with_throttle_retry(
+                lambda tid=target_id: dz_client.get_notebook(
+                    domainIdentifier=domain_id,
+                    identifier=tid,
+                )
+            )
+            nb_metadata = detail.get("metadata") or {}
+            source_id = nb_metadata.get(SOURCE_NOTEBOOK_METADATA_KEY)
+            if source_id:
+                source_to_target[source_id] = target_id
+        except Exception as exc:
+            logger.warning(
+                "Could not GetNotebook for target notebook %s during discovery: %s",
+                target_id, exc,
+            )
+
+    return source_to_target
+
+
+# ── client token ─────────────────────────────────────────────────────────────
+
+
+def _generate_client_token(source_notebook_id: str, timestamp: str) -> str:
+    """
+    Generate a deterministic, idempotent client token for StartNotebookSync.
+
+    Derived from source notebook ID + deployment timestamp, truncated to
+    _CLIENT_TOKEN_MAX_LEN characters.
+
+    Property 5: same inputs → same output; distinct pairs → distinct tokens;
+    len ≤ 64.
+    """
+    raw = f"{source_notebook_id}:{timestamp}"
+    # Use SHA-256 hex digest (64 chars) which is exactly the limit
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+    return digest[:_CLIENT_TOKEN_MAX_LEN]
+
+
+# ── UpdateNotebook kwargs builder ─────────────────────────────────────────────
+
+
+def _build_update_kwargs(
+    domain_id: str,
+    project_id: str,
+    target_notebook_id: str,
+    notebook_entry: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Build the UpdateNotebook API kwargs from a manifest notebook entry.
+
+    Rules (Property 7):
+    - Always include ``name`` and ``description``.
+    - Always include ``metadata`` with ``smus-cicd-source-notebook-id`` set,
+      merged with any existing metadata from the manifest (even if empty dict).
+    - Omit ``parameters`` when the entry's parameters is an empty dict.
+    - Omit ``environmentConfiguration`` when the entry's value is None.
+    """
+    source_id = notebook_entry["sourceNotebookId"]
+
+    # Build metadata: merge manifest metadata + tracking key
+    manifest_metadata = dict(notebook_entry.get("metadata") or {})
+    manifest_metadata[SOURCE_NOTEBOOK_METADATA_KEY] = source_id
+
+    kwargs: Dict[str, Any] = {
+        "domainIdentifier": domain_id,
+        "identifier": target_notebook_id,
+        "name": notebook_entry.get("name", ""),
+        "description": notebook_entry.get("description", ""),
+        "metadata": manifest_metadata,
+    }
+
+    # Omit parameters when empty
+    parameters = notebook_entry.get("parameters") or {}
+    if parameters:
+        kwargs["parameters"] = parameters
+
+    # Omit environmentConfiguration when None
+    env_config = notebook_entry.get("environmentConfiguration")
+    if env_config is not None:
+        kwargs["environmentConfiguration"] = env_config
+
+    return kwargs
+
+
+# ── per-notebook sync ─────────────────────────────────────────────────────────
+
+
+def _apply_notebook_metadata(
+    dz_client,
+    domain_id: str,
+    project_id: str,
+    target_notebook_id: str,
+    notebook_entry: Dict[str, Any],
+) -> bool:
+    """
+    Call UpdateNotebook to apply name, description, metadata (with tracking
+    key), parameters, and environmentConfiguration from the manifest entry.
+
+    Returns True on success, False on any error (notebook counts as FAILED).
+    """
+    kwargs = _build_update_kwargs(domain_id, project_id, target_notebook_id, notebook_entry)
+    try:
+        _call_with_throttle_retry(
+            lambda: dz_client.update_notebook(**kwargs)
+        )
+        return True
+    except Exception as exc:
+        logger.error(
+            "UpdateNotebook failed for notebook %s (target %s): %s",
+            notebook_entry.get("sourceNotebookId"), target_notebook_id, exc,
+        )
+        return False
+
+
+def _wait_for_sync_complete(
+    dz_client,
+    domain_id: str,
+    notebook_id: str,
+    source_id: str,
+    timeout: int = 120,
+    poll_interval: float = 2.0,
+) -> bool:
+    """
+    Poll GetNotebook until the notebook leaves SYNC_IN_PROGRESS status.
+
+    Returns True if sync completed (status is ACTIVE or SYNC_FAILED),
+    False if timed out.
+    """
+    import time as _time
+
+    start = _time.monotonic()
+    while True:
+        try:
+            resp = _call_with_throttle_retry(
+                lambda: dz_client.get_notebook(
+                    domainIdentifier=domain_id,
+                    identifier=notebook_id,
+                )
+            )
+            status = resp.get("status", "")
+            if status != "SYNC_IN_PROGRESS":
+                return True
+        except Exception as exc:
+            logger.debug(
+                "GetNotebook failed while waiting for sync on %s: %s",
+                notebook_id, exc,
+            )
+
+        elapsed = _time.monotonic() - start
+        if elapsed >= timeout:
+            logger.warning(
+                "Timed out waiting for notebook %s (source %s) to leave SYNC_IN_PROGRESS after %.0fs",
+                notebook_id, source_id, elapsed,
+            )
+            return False
+
+        _time.sleep(poll_interval)
+
+
+def _sync_single_notebook(
+    dz_client,
+    domain_id: str,
+    project_id: str,
+    notebook_entry: Dict[str, Any],
+    s3_location: str,
+    target_notebook_id: Optional[str],
+    deployment_timestamp: str,
+) -> SyncResult:
+    """
+    Sync a single notebook via StartNotebookSync then UpdateNotebook.
+
+    Logic:
+    - If target_notebook_id is set → call StartNotebookSync WITH notebookId (update).
+      If ResourceNotFoundException → log warning, retry WITHOUT notebookId (create).
+    - If target_notebook_id is None → call StartNotebookSync WITHOUT notebookId (create).
+    - On success → call UpdateNotebook to apply metadata/config.
+    - Any non-ResourceNotFoundException error from StartNotebookSync → FAILED.
+    - Any UpdateNotebook error → FAILED.
+
+    Returns a SyncResult with the appropriate status.
+    """
+    source_id = notebook_entry.get("sourceNotebookId", "")
+    client_token = _generate_client_token(source_id, deployment_timestamp)
+
+    def _do_sync(with_nb_id: Optional[str]) -> Dict[str, Any]:
+        params: Dict[str, Any] = {
+            "domainIdentifier": domain_id,
+            "owningProjectIdentifier": project_id,
+            "sourceLocation": {"s3": s3_location},
+            "clientToken": client_token,
+        }
+        # Optional fields supported by StartNotebookSync
+        if notebook_entry.get("name"):
+            params["name"] = notebook_entry["name"]
+        if notebook_entry.get("description"):
+            params["description"] = notebook_entry["description"]
+        if with_nb_id:
+            params["notebookId"] = with_nb_id
+        return _call_with_throttle_retry(lambda: dz_client.start_notebook_sync(**params))
+
+    intended_update = target_notebook_id is not None
+    synced_as_update = False
+
+    # Attempt sync
+    try:
+        if target_notebook_id:
+            try:
+                sync_resp = _do_sync(target_notebook_id)
+                synced_as_update = True
+            except ClientError as exc:
+                if exc.response["Error"]["Code"] == "ResourceNotFoundException":
+                    logger.warning(
+                        "Target notebook %s not found (may have been manually deleted) "
+                        "for source %s — creating new notebook instead.",
+                        target_notebook_id, source_id,
+                    )
+                    sync_resp = _do_sync(None)
+                    synced_as_update = False
+                else:
+                    raise
+        else:
+            sync_resp = _do_sync(None)
+            synced_as_update = False
+
+    except Exception as exc:
+        logger.error(
+            "StartNotebookSync failed for source notebook %s: %s", source_id, exc
+        )
+        return SyncResult(
+            status=SyncStatus.FAILED,
+            source_notebook_id=source_id,
+            message=str(exc),
+        )
+
+    # Extract the resulting target notebook ID
+    new_target_id = (
+        sync_resp.get("notebookId")
+        or sync_resp.get("id")
+        or sync_resp.get("identifier")
+        or target_notebook_id  # fallback for in-place update
+    )
+
+    if not new_target_id:
+        logger.error(
+            "StartNotebookSync returned no notebook identifier for source %s", source_id
+        )
+        return SyncResult(
+            status=SyncStatus.FAILED,
+            source_notebook_id=source_id,
+            message="StartNotebookSync returned no notebook identifier",
+        )
+
+    # Wait for the notebook to leave SYNC_IN_PROGRESS before updating metadata
+    _wait_for_sync_complete(dz_client, domain_id, new_target_id, source_id)
+
+    # Apply metadata via UpdateNotebook
+    metadata_ok = _apply_notebook_metadata(
+        dz_client, domain_id, project_id, new_target_id, notebook_entry
+    )
+    if not metadata_ok:
+        return SyncResult(
+            status=SyncStatus.FAILED,
+            source_notebook_id=source_id,
+            target_notebook_id=new_target_id,
+            message="UpdateNotebook failed — see logs for details",
+        )
+
+    final_status = SyncStatus.UPDATED if (intended_update or synced_as_update) else SyncStatus.CREATED
+    return SyncResult(
+        status=final_status,
+        source_notebook_id=source_id,
+        target_notebook_id=new_target_id,
+    )
+
+
+# ── public API ────────────────────────────────────────────────────────────────
+
+
+def sync_notebooks(
+    domain_id: str,
+    project_id: str,
+    region: str,
+    manifest_data: Dict[str, Any],
+    notebook_files: Dict[str, bytes],
+    s3_uri: str,
+) -> NotebookSyncSummary:
+    """
+    Sync notebooks into a target DataZone project using StartNotebookSync.
+
+    Six-step deployment sequence (strict order):
+
+      Step 1: Upload all .ipynb files to S3 at
+              ``{s3Uri}/notebooks/imports/{sourceNotebookId}.ipynb``
+      Step 2: ListNotebooks + GetNotebook for each target notebook → read
+              metadata
+      Step 3: Build ``{sourceNotebookId → targetNotebookId}`` map from
+              ``smus-cicd-source-notebook-id`` metadata key
+      Step 4: For each manifest entry: StartNotebookSync WITH notebookId
+              (update) or WITHOUT (create); ResourceNotFoundException on
+              update → retry as create
+      Step 5: UpdateNotebook — name, description, metadata (with tracking
+              key), parameters, environmentConfiguration
+      Step 6: Report created / updated / failed counts
+
+    Args:
+        domain_id: Target domain identifier.
+        project_id: Target project identifier.
+        region: AWS region string.
+        manifest_data: Parsed ``notebook_export_manifest.json`` dict.
+        notebook_files: Mapping of ``filePath`` (as in the manifest) to raw
+            ``.ipynb`` bytes.
+        s3_uri: S3 URI from the target project's ``default.s3_shared``
+            connection (e.g. ``s3://bucket/prefix``).
+
+    Returns:
+        ``NotebookSyncSummary`` with counts of created, updated, and failed.
+
+    Raises:
+        ValueError: If the manifest is structurally invalid (before any API
+            calls).
+        ValueError: If *s3_uri* is missing or empty.
+    """
+    # ── pre-flight validation ────────────────────────────────────────────────
+    _validate_notebook_manifest(manifest_data)
+
+    if not s3_uri:
+        raise ValueError(
+            "Target project 'default.s3_shared' connection is missing or has "
+            "no s3Uri. Cannot upload notebook files for sync."
+        )
+
+    dz_client = _get_datazone_client(region)
+    s3_client = _get_s3_client(region)
+    summary = NotebookSyncSummary()
+
+    notebook_entries: List[Dict[str, Any]] = manifest_data.get("notebooks", [])
+    if not notebook_entries:
+        logger.info(
+            "Notebook export manifest contains no notebooks — nothing to sync."
+        )
+        return summary
+
+    deployment_timestamp = str(int(time.time()))
+
+    # ── Step 1: upload all .ipynb files to S3 ───────────────────────────────
+    # Map sourceNotebookId → uploaded S3 URI (only successfully uploaded ones)
+    uploaded_locations: Dict[str, str] = {}
+
+    for entry in notebook_entries:
+        source_id = entry.get("sourceNotebookId", "")
+        file_path = entry.get("filePath", "")
+
+        if file_path not in notebook_files:
+            logger.error(
+                "Notebook file missing from bundle for source %s (filePath=%s) — skipping",
+                source_id, file_path,
+            )
+            summary.failed += 1
+            summary.failed_ids.append(source_id)
+            continue
+
+        content = notebook_files[file_path]
+        try:
+            uploaded_uri = _upload_notebook_to_s3(s3_client, s3_uri, source_id, content)
+            uploaded_locations[source_id] = uploaded_uri
+            logger.info("Uploaded notebook %s to %s", source_id, uploaded_uri)
+        except Exception as exc:
+            logger.error(
+                "S3 upload failed for notebook %s to %s: %s",
+                source_id,
+                f"{s3_uri}/{_S3_IMPORT_PREFIX}/{source_id}.ipynb",
+                exc,
+            )
+            summary.failed += 1
+            summary.failed_ids.append(source_id)
+
+    # ── Steps 2–3: discover existing target notebooks and build source→target map ──
+    source_to_target = _discover_target_notebooks(dz_client, domain_id, project_id)
+    logger.info(
+        "Found %d existing target notebook(s) with source tracking metadata",
+        len(source_to_target),
+    )
+
+    # ── Steps 4–5: sync each notebook ────────────────────────────────────────
+    for entry in notebook_entries:
+        source_id = entry.get("sourceNotebookId", "")
+
+        # Skip notebooks that failed upload
+        if source_id not in uploaded_locations:
+            continue
+
+        s3_location = uploaded_locations[source_id]
+        target_notebook_id = source_to_target.get(source_id)
+
+        result = _sync_single_notebook(
+            dz_client=dz_client,
+            domain_id=domain_id,
+            project_id=project_id,
+            notebook_entry=entry,
+            s3_location=s3_location,
+            target_notebook_id=target_notebook_id,
+            deployment_timestamp=deployment_timestamp,
+        )
+
+        if result.status == SyncStatus.CREATED:
+            summary.created += 1
+            logger.info(
+                "Created target notebook %s from source %s",
+                result.target_notebook_id, source_id,
+            )
+        elif result.status == SyncStatus.UPDATED:
+            summary.updated += 1
+            logger.info(
+                "Updated target notebook %s from source %s",
+                result.target_notebook_id, source_id,
+            )
+        else:
+            summary.failed += 1
+            summary.failed_ids.append(source_id)
+            logger.error(
+                "Failed to sync source notebook %s: %s",
+                source_id, result.message,
+            )
+
+    # ── Step 6: report ───────────────────────────────────────────────────────
+    logger.info(
+        "Notebook sync complete: %d created, %d updated, %d failed",
+        summary.created, summary.updated, summary.failed,
+    )
+    return summary

--- a/src/smus_cicd/helpers/notebook_import.py
+++ b/src/smus_cicd/helpers/notebook_import.py
@@ -37,7 +37,12 @@ SOURCE_NOTEBOOK_METADATA_KEY = "smus-cicd-source-notebook-id"
 
 # Required top-level keys in notebook_export_manifest.json
 _REQUIRED_MANIFEST_KEYS = {"metadata", "notebooks"}
-_REQUIRED_METADATA_KEYS = {"sourceProjectId", "sourceDomainId", "exportTimestamp", "notebookCount"}
+_REQUIRED_METADATA_KEYS = {
+    "sourceProjectId",
+    "sourceDomainId",
+    "exportTimestamp",
+    "notebookCount",
+}
 
 # S3 import prefix inside the project's s3_shared bucket
 _S3_IMPORT_PREFIX = "notebooks/imports"
@@ -104,8 +109,11 @@ def _get_s3_client(region: str):
 # ── throttle retry ───────────────────────────────────────────────────────────
 
 
-def _call_with_throttle_retry(func, max_retries: int = _THROTTLE_MAX_RETRIES,
-                               initial_delay: float = _THROTTLE_INITIAL_DELAY):
+def _call_with_throttle_retry(
+    func,
+    max_retries: int = _THROTTLE_MAX_RETRIES,
+    initial_delay: float = _THROTTLE_INITIAL_DELAY,
+):
     """Retry *func* on ThrottlingException with exponential backoff + jitter."""
     for attempt in range(max_retries + 1):
         try:
@@ -113,10 +121,12 @@ def _call_with_throttle_retry(func, max_retries: int = _THROTTLE_MAX_RETRIES,
         except ClientError as exc:
             code = exc.response["Error"]["Code"]
             if code == "ThrottlingException" and attempt < max_retries:
-                delay = initial_delay * (2 ** attempt) + random.uniform(0, 0.5)
+                delay = initial_delay * (2**attempt) + random.uniform(0, 0.5)
                 logger.debug(
                     "ThrottlingException on attempt %d/%d, retrying in %.1fs",
-                    attempt + 1, max_retries, delay,
+                    attempt + 1,
+                    max_retries,
+                    delay,
                 )
                 time.sleep(delay)
             else:
@@ -234,11 +244,7 @@ def _discover_target_notebooks(
             lambda params=params: dz_client.list_notebooks(**params)
         )
         for item in resp.get("items", []):
-            nb_id = (
-                item.get("id")
-                or item.get("notebookId")
-                or item.get("identifier")
-            )
+            nb_id = item.get("id") or item.get("notebookId") or item.get("identifier")
             if nb_id:
                 target_ids.append(nb_id)
 
@@ -262,7 +268,8 @@ def _discover_target_notebooks(
         except Exception as exc:
             logger.warning(
                 "Could not GetNotebook for target notebook %s during discovery: %s",
-                target_id, exc,
+                target_id,
+                exc,
             )
 
     return source_to_target
@@ -349,16 +356,18 @@ def _apply_notebook_metadata(
 
     Returns True on success, False on any error (notebook counts as FAILED).
     """
-    kwargs = _build_update_kwargs(domain_id, project_id, target_notebook_id, notebook_entry)
+    kwargs = _build_update_kwargs(
+        domain_id, project_id, target_notebook_id, notebook_entry
+    )
     try:
-        _call_with_throttle_retry(
-            lambda: dz_client.update_notebook(**kwargs)
-        )
+        _call_with_throttle_retry(lambda: dz_client.update_notebook(**kwargs))
         return True
     except Exception as exc:
         logger.error(
             "UpdateNotebook failed for notebook %s (target %s): %s",
-            notebook_entry.get("sourceNotebookId"), target_notebook_id, exc,
+            notebook_entry.get("sourceNotebookId"),
+            target_notebook_id,
+            exc,
         )
         return False
 
@@ -394,14 +403,17 @@ def _wait_for_sync_complete(
         except Exception as exc:
             logger.debug(
                 "GetNotebook failed while waiting for sync on %s: %s",
-                notebook_id, exc,
+                notebook_id,
+                exc,
             )
 
         elapsed = _time.monotonic() - start
         if elapsed >= timeout:
             logger.warning(
                 "Timed out waiting for notebook %s (source %s) to leave SYNC_IN_PROGRESS after %.0fs",
-                notebook_id, source_id, elapsed,
+                notebook_id,
+                source_id,
+                elapsed,
             )
             return False
 
@@ -447,7 +459,9 @@ def _sync_single_notebook(
             params["description"] = notebook_entry["description"]
         if with_nb_id:
             params["notebookId"] = with_nb_id
-        return _call_with_throttle_retry(lambda: dz_client.start_notebook_sync(**params))
+        return _call_with_throttle_retry(
+            lambda: dz_client.start_notebook_sync(**params)
+        )
 
     intended_update = target_notebook_id is not None
     synced_as_update = False
@@ -463,7 +477,8 @@ def _sync_single_notebook(
                     logger.warning(
                         "Target notebook %s not found (may have been manually deleted) "
                         "for source %s — creating new notebook instead.",
-                        target_notebook_id, source_id,
+                        target_notebook_id,
+                        source_id,
                     )
                     sync_resp = _do_sync(None)
                     synced_as_update = False
@@ -516,7 +531,11 @@ def _sync_single_notebook(
             message="UpdateNotebook failed — see logs for details",
         )
 
-    final_status = SyncStatus.UPDATED if (intended_update or synced_as_update) else SyncStatus.CREATED
+    final_status = (
+        SyncStatus.UPDATED
+        if (intended_update or synced_as_update)
+        else SyncStatus.CREATED
+    )
     return SyncResult(
         status=final_status,
         source_notebook_id=source_id,
@@ -586,9 +605,7 @@ def sync_notebooks(
 
     notebook_entries: List[Dict[str, Any]] = manifest_data.get("notebooks", [])
     if not notebook_entries:
-        logger.info(
-            "Notebook export manifest contains no notebooks — nothing to sync."
-        )
+        logger.info("Notebook export manifest contains no notebooks — nothing to sync.")
         return summary
 
     deployment_timestamp = str(int(time.time()))
@@ -604,7 +621,8 @@ def sync_notebooks(
         if file_path not in notebook_files:
             logger.error(
                 "Notebook file missing from bundle for source %s (filePath=%s) — skipping",
-                source_id, file_path,
+                source_id,
+                file_path,
             )
             summary.failed += 1
             summary.failed_ids.append(source_id)
@@ -657,25 +675,30 @@ def sync_notebooks(
             summary.created += 1
             logger.info(
                 "Created target notebook %s from source %s",
-                result.target_notebook_id, source_id,
+                result.target_notebook_id,
+                source_id,
             )
         elif result.status == SyncStatus.UPDATED:
             summary.updated += 1
             logger.info(
                 "Updated target notebook %s from source %s",
-                result.target_notebook_id, source_id,
+                result.target_notebook_id,
+                source_id,
             )
         else:
             summary.failed += 1
             summary.failed_ids.append(source_id)
             logger.error(
                 "Failed to sync source notebook %s: %s",
-                source_id, result.message,
+                source_id,
+                result.message,
             )
 
     # ── Step 6: report ───────────────────────────────────────────────────────
     logger.info(
         "Notebook sync complete: %d created, %d updated, %d failed",
-        summary.created, summary.updated, summary.failed,
+        summary.created,
+        summary.updated,
+        summary.failed,
     )
     return summary

--- a/src/smus_cicd/resource_types.py
+++ b/src/smus_cicd/resource_types.py
@@ -39,5 +39,7 @@ DEPLOY_RESOURCE_TYPES = frozenset(
         "catalog_asset_type",
         "catalog_asset",
         "catalog_data_product",
+        # Notebook resources (via notebook sync)
+        "notebook",
     }
 )

--- a/tests/unit/commands/dry_run/test_engine.py
+++ b/tests/unit/commands/dry_run/test_engine.py
@@ -34,10 +34,10 @@ PHASE_ORDER = list(Phase)
 
 
 class TestPhaseOrdering:
-    """Verify all 12 phases run in the correct order."""
+    """Verify all phases run in the correct order."""
 
     def test_all_phases_run_in_order(self):
-        """When manifest validation passes, all 12 phases should execute in order."""
+        """When manifest validation passes, all phases should execute in order."""
         engine = DryRunEngine(
             manifest_file="manifest.yaml",
             stage_name="dev",
@@ -63,7 +63,7 @@ class TestPhaseOrdering:
         report = engine.run()
 
         assert call_order == PHASE_ORDER
-        assert len(report.findings_by_phase) == 13
+        assert len(report.findings_by_phase) == len(PHASE_ORDER)
         for phase in PHASE_ORDER:
             assert phase in report.findings_by_phase
 

--- a/tests/unit/commands/test_deploy_notebook_sync.py
+++ b/tests/unit/commands/test_deploy_notebook_sync.py
@@ -1,0 +1,297 @@
+"""Unit tests for notebook sync integration in deploy.py.
+
+Covers _sync_notebooks_from_bundle:
+  - Missing bundle → skip silently (True)
+  - Bundle without notebook manifest → skip silently (True)
+  - Notebook sync disabled in deployment_configuration → skip (True)
+  - Happy path: manifest present → sync invoked → created/updated/failed reported
+  - S3 connection missing → return False
+  - Project not found → return False
+  - Sync failures → return False
+  - Missing .ipynb files in bundle handled gracefully
+"""
+
+import json
+import os
+import tempfile
+import zipfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from smus_cicd.commands.deploy import _sync_notebooks_from_bundle
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_target_config():
+    config = MagicMock()
+    config.deployment_configuration = MagicMock()
+    config.deployment_configuration.notebooks = None  # not disabled
+    config.domain = MagicMock()
+    config.domain.region = "us-east-1"
+    config.project = MagicMock()
+    config.project.name = "target-project"
+    return config
+
+
+@pytest.fixture
+def mock_config():
+    return {"region": "us-east-1"}
+
+
+def _make_manifest_data(notebooks=None):
+    notebooks = notebooks or []
+    return {
+        "metadata": {
+            "sourceProjectId": "src-proj",
+            "sourceDomainId": "dom-1",
+            "exportTimestamp": "2024-01-01T00:00:00Z",
+            "notebookCount": len(notebooks),
+        },
+        "notebooks": notebooks,
+    }
+
+
+def _make_notebook_entry(nb_id="nb-1"):
+    return {
+        "sourceNotebookId": nb_id,
+        "name": "Test NB",
+        "description": "",
+        "filePath": f"notebooks/{nb_id}.ipynb",
+        "exportedAt": "2024-01-01T00:00:00Z",
+        "parameters": {},
+        "metadata": {},
+        "environmentConfiguration": None,
+    }
+
+
+def _create_bundle(manifest_data=None, ipynb_files=None):
+    """Create a temporary bundle ZIP and return its path + temp dir."""
+    temp_dir = tempfile.mkdtemp()
+    bundle_path = os.path.join(temp_dir, "test-bundle.zip")
+
+    with zipfile.ZipFile(bundle_path, "w") as zf:
+        if manifest_data is not None:
+            zf.writestr(
+                "notebooks/notebook_export_manifest.json",
+                json.dumps(manifest_data),
+            )
+        for path, content in (ipynb_files or {}).items():
+            zf.writestr(path, content)
+
+    return bundle_path, temp_dir
+
+
+def _cleanup(temp_dir):
+    import shutil
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+PATCH_DOMAIN = "smus_cicd.helpers.datazone.get_domain_from_target_config"
+PATCH_PROJECT_ID = "smus_cicd.helpers.datazone.get_project_id_by_name"
+PATCH_CONNECTIONS = "smus_cicd.helpers.connections.get_project_connections"
+PATCH_SYNC = "smus_cicd.helpers.notebook_import.sync_notebooks"
+
+
+# ---------------------------------------------------------------------------
+# Tests: skip conditions
+# ---------------------------------------------------------------------------
+
+class TestSyncNotebooksSkipConditions:
+
+    def test_no_bundle_path_returns_true(self, mock_target_config, mock_config):
+        result = _sync_notebooks_from_bundle(None, mock_target_config, mock_config)
+        assert result is True
+
+    def test_bundle_without_manifest_returns_true(self, mock_target_config, mock_config):
+        bundle_path, temp_dir = _create_bundle()  # no manifest
+        try:
+            result = _sync_notebooks_from_bundle(bundle_path, mock_target_config, mock_config)
+            assert result is True
+        finally:
+            _cleanup(temp_dir)
+
+    def test_notebook_sync_disabled_returns_true(self, mock_target_config, mock_config):
+        mock_target_config.deployment_configuration.notebooks = {"disable": True}
+        bundle_path, temp_dir = _create_bundle(
+            manifest_data=_make_manifest_data([_make_notebook_entry()])
+        )
+        try:
+            result = _sync_notebooks_from_bundle(bundle_path, mock_target_config, mock_config)
+            assert result is True
+        finally:
+            _cleanup(temp_dir)
+
+    def test_disable_false_does_not_skip(self, mock_target_config, mock_config):
+        """disable=False must NOT skip — sync should proceed."""
+        mock_target_config.deployment_configuration.notebooks = {"disable": False}
+        bundle_path, temp_dir = _create_bundle(
+            manifest_data=_make_manifest_data([_make_notebook_entry()]),
+            ipynb_files={"notebooks/nb-1.ipynb": b'{"cells":[]}'},
+        )
+        try:
+            with patch(PATCH_DOMAIN, return_value=("dom-1", "test-domain")), \
+                 patch(PATCH_PROJECT_ID, return_value="proj-target"), \
+                 patch(PATCH_CONNECTIONS,
+                       return_value={"default.s3_shared": {"s3Uri": "s3://bucket/shared"}}), \
+                 patch(PATCH_SYNC) as mock_sync:
+                from smus_cicd.helpers.notebook_import import NotebookSyncSummary
+                mock_sync.return_value = NotebookSyncSummary(created=1)
+                result = _sync_notebooks_from_bundle(bundle_path, mock_target_config, mock_config)
+                # sync_notebooks must have been called
+                mock_sync.assert_called_once()
+                assert result is True
+        finally:
+            _cleanup(temp_dir)
+
+
+# ---------------------------------------------------------------------------
+# Tests: happy path
+# ---------------------------------------------------------------------------
+
+class TestSyncNotebooksHappyPath:
+
+    @patch(PATCH_DOMAIN, return_value=("dom-1", "test-domain"))
+    @patch(PATCH_PROJECT_ID, return_value="proj-target")
+    def test_creates_summary_reported_in_output(
+        self, mock_project, mock_domain, mock_target_config, mock_config, capsys
+    ):
+        bundle_path, temp_dir = _create_bundle(
+            manifest_data=_make_manifest_data([_make_notebook_entry()]),
+            ipynb_files={"notebooks/nb-1.ipynb": b'{"cells":[]}'},
+        )
+        try:
+            with patch(PATCH_CONNECTIONS,
+                       return_value={"default.s3_shared": {"s3Uri": "s3://b/shared"}}), \
+                 patch(PATCH_SYNC) as mock_sync:
+                from smus_cicd.helpers.notebook_import import NotebookSyncSummary
+                mock_sync.return_value = NotebookSyncSummary(created=1, updated=0, failed=0)
+                result = _sync_notebooks_from_bundle(bundle_path, mock_target_config, mock_config)
+
+            assert result is True
+            captured = capsys.readouterr()
+            assert "Created: 1" in captured.out
+            assert "Updated: 0" in captured.out
+            assert "Failed:  0" in captured.out
+        finally:
+            _cleanup(temp_dir)
+
+    @patch(PATCH_DOMAIN, return_value=("dom-1", "test-domain"))
+    @patch(PATCH_PROJECT_ID, return_value="proj-target")
+    def test_sync_notebooks_receives_correct_arguments(
+        self, mock_project, mock_domain, mock_target_config, mock_config
+    ):
+        entry = _make_notebook_entry("nb-abc")
+        bundle_path, temp_dir = _create_bundle(
+            manifest_data=_make_manifest_data([entry]),
+            ipynb_files={"notebooks/nb-abc.ipynb": b'{"cells":[]}'},
+        )
+        try:
+            with patch(PATCH_CONNECTIONS,
+                       return_value={"default.s3_shared": {"s3Uri": "s3://bucket/data"}}), \
+                 patch(PATCH_SYNC) as mock_sync:
+                from smus_cicd.helpers.notebook_import import NotebookSyncSummary
+                mock_sync.return_value = NotebookSyncSummary(created=1)
+                _sync_notebooks_from_bundle(bundle_path, mock_target_config, mock_config)
+
+            call_kwargs = mock_sync.call_args[1] if mock_sync.call_args.kwargs else {}
+            call_args = mock_sync.call_args
+            # Verify domain_id, project_id, region, s3_uri
+            assert "dom-1" in str(call_args)
+            assert "proj-target" in str(call_args)
+            assert "s3://bucket/data" in str(call_args)
+            # Verify ipynb bytes were extracted from bundle
+            assert b'{"cells":[]}' in str(call_args).encode() or True  # content in notebook_files
+        finally:
+            _cleanup(temp_dir)
+
+
+# ---------------------------------------------------------------------------
+# Tests: failure paths
+# ---------------------------------------------------------------------------
+
+class TestSyncNotebooksFailurePaths:
+
+    @patch(PATCH_DOMAIN, return_value=("dom-1", "test-domain"))
+    @patch(PATCH_PROJECT_ID, return_value="proj-target")
+    def test_missing_s3_connection_returns_false(
+        self, mock_project, mock_domain, mock_target_config, mock_config
+    ):
+        bundle_path, temp_dir = _create_bundle(
+            manifest_data=_make_manifest_data([_make_notebook_entry()])
+        )
+        try:
+            with patch(PATCH_CONNECTIONS,
+                       return_value={"default.s3_shared": {"s3Uri": ""}}):
+                result = _sync_notebooks_from_bundle(bundle_path, mock_target_config, mock_config)
+            assert result is False
+        finally:
+            _cleanup(temp_dir)
+
+    @patch(PATCH_DOMAIN, return_value=("dom-1", "test-domain"))
+    @patch(PATCH_PROJECT_ID, return_value=None)  # project not found
+    def test_project_not_found_returns_false(
+        self, mock_project, mock_domain, mock_target_config, mock_config
+    ):
+        bundle_path, temp_dir = _create_bundle(
+            manifest_data=_make_manifest_data([_make_notebook_entry()])
+        )
+        try:
+            result = _sync_notebooks_from_bundle(bundle_path, mock_target_config, mock_config)
+            assert result is False
+        finally:
+            _cleanup(temp_dir)
+
+    @patch(PATCH_DOMAIN, return_value=("dom-1", "test-domain"))
+    @patch(PATCH_PROJECT_ID, return_value="proj-target")
+    def test_sync_failures_returns_false(
+        self, mock_project, mock_domain, mock_target_config, mock_config
+    ):
+        bundle_path, temp_dir = _create_bundle(
+            manifest_data=_make_manifest_data([_make_notebook_entry()]),
+            ipynb_files={"notebooks/nb-1.ipynb": b'{"cells":[]}'},
+        )
+        try:
+            with patch(PATCH_CONNECTIONS,
+                       return_value={"default.s3_shared": {"s3Uri": "s3://b/shared"}}), \
+                 patch(PATCH_SYNC) as mock_sync:
+                from smus_cicd.helpers.notebook_import import NotebookSyncSummary
+                mock_sync.return_value = NotebookSyncSummary(created=0, updated=0, failed=1,
+                                                              failed_ids=["nb-1"])
+                result = _sync_notebooks_from_bundle(bundle_path, mock_target_config, mock_config)
+            assert result is False
+        finally:
+            _cleanup(temp_dir)
+
+    @patch(PATCH_DOMAIN, return_value=("dom-1", "test-domain"))
+    @patch(PATCH_PROJECT_ID, return_value="proj-target")
+    def test_connection_api_error_returns_false(
+        self, mock_project, mock_domain, mock_target_config, mock_config
+    ):
+        bundle_path, temp_dir = _create_bundle(
+            manifest_data=_make_manifest_data([_make_notebook_entry()])
+        )
+        try:
+            with patch(PATCH_CONNECTIONS,
+                       side_effect=Exception("ConnectionError")):
+                result = _sync_notebooks_from_bundle(bundle_path, mock_target_config, mock_config)
+            assert result is False
+        finally:
+            _cleanup(temp_dir)
+
+    def test_malformed_manifest_json_returns_false(
+        self, mock_target_config, mock_config
+    ):
+        temp_dir = tempfile.mkdtemp()
+        bundle_path = os.path.join(temp_dir, "bundle.zip")
+        try:
+            with zipfile.ZipFile(bundle_path, "w") as zf:
+                zf.writestr("notebooks/notebook_export_manifest.json", "{ invalid json }")
+            result = _sync_notebooks_from_bundle(bundle_path, mock_target_config, mock_config)
+            assert result is False
+        finally:
+            _cleanup(temp_dir)

--- a/tests/unit/commands/test_deploy_notebook_sync.py
+++ b/tests/unit/commands/test_deploy_notebook_sync.py
@@ -9,6 +9,11 @@ Covers _sync_notebooks_from_bundle:
   - Project not found → return False
   - Sync failures → return False
   - Missing .ipynb files in bundle handled gracefully
+
+Resolution note: domain/project/connections are resolved once via
+``get_datazone_project_info`` (or reused from a pre-resolved ``project_info``
+passed in by ``deploy_command``). These tests inject ``project_info`` directly
+or patch ``get_datazone_project_info`` at its source module.
 """
 
 import json
@@ -21,10 +26,10 @@ import pytest
 
 from smus_cicd.commands.deploy import _sync_notebooks_from_bundle
 
-
 # ---------------------------------------------------------------------------
 # Fixtures and helpers
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def mock_target_config():
@@ -41,6 +46,19 @@ def mock_target_config():
 @pytest.fixture
 def mock_config():
     return {"region": "us-east-1"}
+
+
+def _make_project_info(s3_uri="s3://bucket/shared", project_id="proj-target"):
+    """Build a resolved project_info dict as returned by get_datazone_project_info."""
+    return {
+        "projectId": project_id,
+        "project_id": project_id,
+        "domain_id": "dom-1",
+        "status": "ACTIVE",
+        "owners": [],
+        "contributors": [],
+        "connections": {"default.s3_shared": {"s3Uri": s3_uri}},
+    }
 
 
 def _make_manifest_data(notebooks=None):
@@ -88,12 +106,13 @@ def _create_bundle(manifest_data=None, ipynb_files=None):
 
 def _cleanup(temp_dir):
     import shutil
+
     shutil.rmtree(temp_dir, ignore_errors=True)
 
 
-PATCH_DOMAIN = "smus_cicd.helpers.datazone.get_domain_from_target_config"
-PATCH_PROJECT_ID = "smus_cicd.helpers.datazone.get_project_id_by_name"
-PATCH_CONNECTIONS = "smus_cicd.helpers.connections.get_project_connections"
+# Resolution now goes through get_datazone_project_info (source module) and
+# sync_notebooks. The connection s3Uri is read from the resolved project_info.
+PATCH_PROJECT_INFO = "smus_cicd.helpers.utils.get_datazone_project_info"
 PATCH_SYNC = "smus_cicd.helpers.notebook_import.sync_notebooks"
 
 
@@ -101,16 +120,21 @@ PATCH_SYNC = "smus_cicd.helpers.notebook_import.sync_notebooks"
 # Tests: skip conditions
 # ---------------------------------------------------------------------------
 
+
 class TestSyncNotebooksSkipConditions:
 
     def test_no_bundle_path_returns_true(self, mock_target_config, mock_config):
         result = _sync_notebooks_from_bundle(None, mock_target_config, mock_config)
         assert result is True
 
-    def test_bundle_without_manifest_returns_true(self, mock_target_config, mock_config):
+    def test_bundle_without_manifest_returns_true(
+        self, mock_target_config, mock_config
+    ):
         bundle_path, temp_dir = _create_bundle()  # no manifest
         try:
-            result = _sync_notebooks_from_bundle(bundle_path, mock_target_config, mock_config)
+            result = _sync_notebooks_from_bundle(
+                bundle_path, mock_target_config, mock_config
+            )
             assert result is True
         finally:
             _cleanup(temp_dir)
@@ -121,7 +145,9 @@ class TestSyncNotebooksSkipConditions:
             manifest_data=_make_manifest_data([_make_notebook_entry()])
         )
         try:
-            result = _sync_notebooks_from_bundle(bundle_path, mock_target_config, mock_config)
+            result = _sync_notebooks_from_bundle(
+                bundle_path, mock_target_config, mock_config
+            )
             assert result is True
         finally:
             _cleanup(temp_dir)
@@ -134,14 +160,16 @@ class TestSyncNotebooksSkipConditions:
             ipynb_files={"notebooks/nb-1.ipynb": b'{"cells":[]}'},
         )
         try:
-            with patch(PATCH_DOMAIN, return_value=("dom-1", "test-domain")), \
-                 patch(PATCH_PROJECT_ID, return_value="proj-target"), \
-                 patch(PATCH_CONNECTIONS,
-                       return_value={"default.s3_shared": {"s3Uri": "s3://bucket/shared"}}), \
-                 patch(PATCH_SYNC) as mock_sync:
+            with patch(PATCH_SYNC) as mock_sync:
                 from smus_cicd.helpers.notebook_import import NotebookSyncSummary
+
                 mock_sync.return_value = NotebookSyncSummary(created=1)
-                result = _sync_notebooks_from_bundle(bundle_path, mock_target_config, mock_config)
+                result = _sync_notebooks_from_bundle(
+                    bundle_path,
+                    mock_target_config,
+                    mock_config,
+                    project_info=_make_project_info(),
+                )
                 # sync_notebooks must have been called
                 mock_sync.assert_called_once()
                 assert result is True
@@ -150,27 +178,109 @@ class TestSyncNotebooksSkipConditions:
 
 
 # ---------------------------------------------------------------------------
+# Tests: project_info reuse (no re-resolution)
+# ---------------------------------------------------------------------------
+
+
+class TestProjectInfoReuse:
+
+    def test_passed_project_info_avoids_lookup(self, mock_target_config, mock_config):
+        """When project_info is passed in, get_datazone_project_info is NOT called."""
+        bundle_path, temp_dir = _create_bundle(
+            manifest_data=_make_manifest_data([_make_notebook_entry()]),
+            ipynb_files={"notebooks/nb-1.ipynb": b'{"cells":[]}'},
+        )
+        try:
+            with patch(PATCH_PROJECT_INFO) as mock_lookup, patch(
+                PATCH_SYNC
+            ) as mock_sync:
+                from smus_cicd.helpers.notebook_import import NotebookSyncSummary
+
+                mock_sync.return_value = NotebookSyncSummary(created=1)
+                result = _sync_notebooks_from_bundle(
+                    bundle_path,
+                    mock_target_config,
+                    mock_config,
+                    project_info=_make_project_info(),
+                )
+            assert result is True
+            mock_lookup.assert_not_called()
+        finally:
+            _cleanup(temp_dir)
+
+    def test_config_project_info_reused(self, mock_target_config, mock_config):
+        """When config carries project_info, it is reused without a lookup."""
+        mock_config["project_info"] = _make_project_info()
+        bundle_path, temp_dir = _create_bundle(
+            manifest_data=_make_manifest_data([_make_notebook_entry()]),
+            ipynb_files={"notebooks/nb-1.ipynb": b'{"cells":[]}'},
+        )
+        try:
+            with patch(PATCH_PROJECT_INFO) as mock_lookup, patch(
+                PATCH_SYNC
+            ) as mock_sync:
+                from smus_cicd.helpers.notebook_import import NotebookSyncSummary
+
+                mock_sync.return_value = NotebookSyncSummary(created=1)
+                result = _sync_notebooks_from_bundle(
+                    bundle_path, mock_target_config, mock_config
+                )
+            assert result is True
+            mock_lookup.assert_not_called()
+        finally:
+            _cleanup(temp_dir)
+
+    def test_falls_back_to_lookup_when_no_project_info(
+        self, mock_target_config, mock_config
+    ):
+        """With no project_info anywhere, falls back to get_datazone_project_info."""
+        bundle_path, temp_dir = _create_bundle(
+            manifest_data=_make_manifest_data([_make_notebook_entry()]),
+            ipynb_files={"notebooks/nb-1.ipynb": b'{"cells":[]}'},
+        )
+        try:
+            with patch(
+                PATCH_PROJECT_INFO, return_value=_make_project_info()
+            ) as mock_lookup, patch(PATCH_SYNC) as mock_sync:
+                from smus_cicd.helpers.notebook_import import NotebookSyncSummary
+
+                mock_sync.return_value = NotebookSyncSummary(created=1)
+                result = _sync_notebooks_from_bundle(
+                    bundle_path, mock_target_config, mock_config
+                )
+            assert result is True
+            mock_lookup.assert_called_once()
+        finally:
+            _cleanup(temp_dir)
+
+
+# ---------------------------------------------------------------------------
 # Tests: happy path
 # ---------------------------------------------------------------------------
 
+
 class TestSyncNotebooksHappyPath:
 
-    @patch(PATCH_DOMAIN, return_value=("dom-1", "test-domain"))
-    @patch(PATCH_PROJECT_ID, return_value="proj-target")
     def test_creates_summary_reported_in_output(
-        self, mock_project, mock_domain, mock_target_config, mock_config, capsys
+        self, mock_target_config, mock_config, capsys
     ):
         bundle_path, temp_dir = _create_bundle(
             manifest_data=_make_manifest_data([_make_notebook_entry()]),
             ipynb_files={"notebooks/nb-1.ipynb": b'{"cells":[]}'},
         )
         try:
-            with patch(PATCH_CONNECTIONS,
-                       return_value={"default.s3_shared": {"s3Uri": "s3://b/shared"}}), \
-                 patch(PATCH_SYNC) as mock_sync:
+            with patch(PATCH_SYNC) as mock_sync:
                 from smus_cicd.helpers.notebook_import import NotebookSyncSummary
-                mock_sync.return_value = NotebookSyncSummary(created=1, updated=0, failed=0)
-                result = _sync_notebooks_from_bundle(bundle_path, mock_target_config, mock_config)
+
+                mock_sync.return_value = NotebookSyncSummary(
+                    created=1, updated=0, failed=0
+                )
+                result = _sync_notebooks_from_bundle(
+                    bundle_path,
+                    mock_target_config,
+                    mock_config,
+                    project_info=_make_project_info(s3_uri="s3://b/shared"),
+                )
 
             assert result is True
             captured = capsys.readouterr()
@@ -180,10 +290,8 @@ class TestSyncNotebooksHappyPath:
         finally:
             _cleanup(temp_dir)
 
-    @patch(PATCH_DOMAIN, return_value=("dom-1", "test-domain"))
-    @patch(PATCH_PROJECT_ID, return_value="proj-target")
     def test_sync_notebooks_receives_correct_arguments(
-        self, mock_project, mock_domain, mock_target_config, mock_config
+        self, mock_target_config, mock_config
     ):
         entry = _make_notebook_entry("nb-abc")
         bundle_path, temp_dir = _create_bundle(
@@ -191,21 +299,22 @@ class TestSyncNotebooksHappyPath:
             ipynb_files={"notebooks/nb-abc.ipynb": b'{"cells":[]}'},
         )
         try:
-            with patch(PATCH_CONNECTIONS,
-                       return_value={"default.s3_shared": {"s3Uri": "s3://bucket/data"}}), \
-                 patch(PATCH_SYNC) as mock_sync:
+            with patch(PATCH_SYNC) as mock_sync:
                 from smus_cicd.helpers.notebook_import import NotebookSyncSummary
-                mock_sync.return_value = NotebookSyncSummary(created=1)
-                _sync_notebooks_from_bundle(bundle_path, mock_target_config, mock_config)
 
-            call_kwargs = mock_sync.call_args[1] if mock_sync.call_args.kwargs else {}
+                mock_sync.return_value = NotebookSyncSummary(created=1)
+                _sync_notebooks_from_bundle(
+                    bundle_path,
+                    mock_target_config,
+                    mock_config,
+                    project_info=_make_project_info(s3_uri="s3://bucket/data"),
+                )
+
             call_args = mock_sync.call_args
-            # Verify domain_id, project_id, region, s3_uri
+            # Verify domain_id, project_id, region, s3_uri threaded through
             assert "dom-1" in str(call_args)
             assert "proj-target" in str(call_args)
             assert "s3://bucket/data" in str(call_args)
-            # Verify ipynb bytes were extracted from bundle
-            assert b'{"cells":[]}' in str(call_args).encode() or True  # content in notebook_files
         finally:
             _cleanup(temp_dir)
 
@@ -214,71 +323,75 @@ class TestSyncNotebooksHappyPath:
 # Tests: failure paths
 # ---------------------------------------------------------------------------
 
+
 class TestSyncNotebooksFailurePaths:
 
-    @patch(PATCH_DOMAIN, return_value=("dom-1", "test-domain"))
-    @patch(PATCH_PROJECT_ID, return_value="proj-target")
-    def test_missing_s3_connection_returns_false(
-        self, mock_project, mock_domain, mock_target_config, mock_config
-    ):
+    def test_missing_s3_connection_returns_false(self, mock_target_config, mock_config):
         bundle_path, temp_dir = _create_bundle(
             manifest_data=_make_manifest_data([_make_notebook_entry()])
         )
         try:
-            with patch(PATCH_CONNECTIONS,
-                       return_value={"default.s3_shared": {"s3Uri": ""}}):
-                result = _sync_notebooks_from_bundle(bundle_path, mock_target_config, mock_config)
+            result = _sync_notebooks_from_bundle(
+                bundle_path,
+                mock_target_config,
+                mock_config,
+                project_info=_make_project_info(s3_uri=""),
+            )
             assert result is False
         finally:
             _cleanup(temp_dir)
 
-    @patch(PATCH_DOMAIN, return_value=("dom-1", "test-domain"))
-    @patch(PATCH_PROJECT_ID, return_value=None)  # project not found
-    def test_project_not_found_returns_false(
-        self, mock_project, mock_domain, mock_target_config, mock_config
-    ):
+    def test_project_not_found_returns_false(self, mock_target_config, mock_config):
         bundle_path, temp_dir = _create_bundle(
             manifest_data=_make_manifest_data([_make_notebook_entry()])
         )
         try:
-            result = _sync_notebooks_from_bundle(bundle_path, mock_target_config, mock_config)
+            project_info = _make_project_info()
+            project_info["projectId"] = None
+            project_info["project_id"] = None
+            result = _sync_notebooks_from_bundle(
+                bundle_path,
+                mock_target_config,
+                mock_config,
+                project_info=project_info,
+            )
             assert result is False
         finally:
             _cleanup(temp_dir)
 
-    @patch(PATCH_DOMAIN, return_value=("dom-1", "test-domain"))
-    @patch(PATCH_PROJECT_ID, return_value="proj-target")
-    def test_sync_failures_returns_false(
-        self, mock_project, mock_domain, mock_target_config, mock_config
-    ):
+    def test_project_info_error_returns_false(self, mock_target_config, mock_config):
+        bundle_path, temp_dir = _create_bundle(
+            manifest_data=_make_manifest_data([_make_notebook_entry()])
+        )
+        try:
+            result = _sync_notebooks_from_bundle(
+                bundle_path,
+                mock_target_config,
+                mock_config,
+                project_info={"error": "Domain not found"},
+            )
+            assert result is False
+        finally:
+            _cleanup(temp_dir)
+
+    def test_sync_failures_returns_false(self, mock_target_config, mock_config):
         bundle_path, temp_dir = _create_bundle(
             manifest_data=_make_manifest_data([_make_notebook_entry()]),
             ipynb_files={"notebooks/nb-1.ipynb": b'{"cells":[]}'},
         )
         try:
-            with patch(PATCH_CONNECTIONS,
-                       return_value={"default.s3_shared": {"s3Uri": "s3://b/shared"}}), \
-                 patch(PATCH_SYNC) as mock_sync:
+            with patch(PATCH_SYNC) as mock_sync:
                 from smus_cicd.helpers.notebook_import import NotebookSyncSummary
-                mock_sync.return_value = NotebookSyncSummary(created=0, updated=0, failed=1,
-                                                              failed_ids=["nb-1"])
-                result = _sync_notebooks_from_bundle(bundle_path, mock_target_config, mock_config)
-            assert result is False
-        finally:
-            _cleanup(temp_dir)
 
-    @patch(PATCH_DOMAIN, return_value=("dom-1", "test-domain"))
-    @patch(PATCH_PROJECT_ID, return_value="proj-target")
-    def test_connection_api_error_returns_false(
-        self, mock_project, mock_domain, mock_target_config, mock_config
-    ):
-        bundle_path, temp_dir = _create_bundle(
-            manifest_data=_make_manifest_data([_make_notebook_entry()])
-        )
-        try:
-            with patch(PATCH_CONNECTIONS,
-                       side_effect=Exception("ConnectionError")):
-                result = _sync_notebooks_from_bundle(bundle_path, mock_target_config, mock_config)
+                mock_sync.return_value = NotebookSyncSummary(
+                    created=0, updated=0, failed=1, failed_ids=["nb-1"]
+                )
+                result = _sync_notebooks_from_bundle(
+                    bundle_path,
+                    mock_target_config,
+                    mock_config,
+                    project_info=_make_project_info(s3_uri="s3://b/shared"),
+                )
             assert result is False
         finally:
             _cleanup(temp_dir)
@@ -290,8 +403,15 @@ class TestSyncNotebooksFailurePaths:
         bundle_path = os.path.join(temp_dir, "bundle.zip")
         try:
             with zipfile.ZipFile(bundle_path, "w") as zf:
-                zf.writestr("notebooks/notebook_export_manifest.json", "{ invalid json }")
-            result = _sync_notebooks_from_bundle(bundle_path, mock_target_config, mock_config)
+                zf.writestr(
+                    "notebooks/notebook_export_manifest.json", "{ invalid json }"
+                )
+            result = _sync_notebooks_from_bundle(
+                bundle_path,
+                mock_target_config,
+                mock_config,
+                project_info=_make_project_info(),
+            )
             assert result is False
         finally:
             _cleanup(temp_dir)

--- a/tests/unit/commands/test_destroy_notebooks.py
+++ b/tests/unit/commands/test_destroy_notebooks.py
@@ -20,7 +20,10 @@ from smus_cicd.application.application_manifest import (
     StageConfig,
 )
 from smus_cicd.helpers.destroy_executor import _destroy_stage
-from smus_cicd.helpers.destroy_models import ResourceResult, ResourceToDelete, ValidationResult
+from smus_cicd.helpers.destroy_models import (
+    ResourceToDelete,
+    ValidationResult,
+)
 from smus_cicd.helpers.destroy_validator import _discover_notebooks
 
 SOURCE_KEY = "smus-cicd-source-notebook-id"
@@ -29,6 +32,7 @@ SOURCE_KEY = "smus-cicd-source-notebook-id"
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _client_error(code, message="error"):
     return ClientError({"Error": {"Code": code, "Message": message}}, "Op")
@@ -43,10 +47,10 @@ def _make_dz_client(notebook_map):
     ids = list(notebook_map.keys())
     client.list_notebooks.return_value = {"items": [{"id": nb_id} for nb_id in ids]}
 
-    def get_notebook(domainIdentifier, notebookIdentifier):
-        source_id = notebook_map.get(notebookIdentifier)
+    def get_notebook(domainIdentifier, identifier):
+        source_id = notebook_map.get(identifier)
         metadata = {SOURCE_KEY: source_id} if source_id else {}
-        return {"id": notebookIdentifier, "name": f"NB-{notebookIdentifier}", "metadata": metadata}
+        return {"id": identifier, "name": f"NB-{identifier}", "metadata": metadata}
 
     client.get_notebook.side_effect = get_notebook
     return client
@@ -63,6 +67,7 @@ def _make_vr(resources=None):
 
 def _simple_manifest():
     from smus_cicd.application.application_manifest import ApplicationManifest
+
     return ApplicationManifest(
         application_name="App",
         content=ContentConfig(),
@@ -83,37 +88,56 @@ def _make_stage_config():
 # _discover_notebooks
 # ---------------------------------------------------------------------------
 
+
 class TestDiscoverNotebooks(unittest.TestCase):
 
     def test_notebooks_with_tracking_metadata_included(self):
-        dz = _make_dz_client({
-            "tgt-1": "src-1",
-            "tgt-2": "src-2",
-        })
-        result = _discover_notebooks("dom-1", "proj-1", "us-east-1", notebook_ids_filter=None,
-                                     _dz_client_override=dz)
+        dz = _make_dz_client(
+            {
+                "tgt-1": "src-1",
+                "tgt-2": "src-2",
+            }
+        )
+        result = _discover_notebooks(
+            "dom-1",
+            "proj-1",
+            "us-east-1",
+            notebook_ids_filter=None,
+            _dz_client_override=dz,
+        )
         self.assertEqual(len(result), 2)
         source_ids = {r["source_notebook_id"] for r in result}
         self.assertEqual(source_ids, {"src-1", "src-2"})
 
     def test_notebooks_without_tracking_metadata_excluded(self):
-        dz = _make_dz_client({
-            "tgt-cicd": "src-1",
-            "tgt-manual": None,  # no tracking key
-        })
-        result = _discover_notebooks("dom-1", "proj-1", "us-east-1", notebook_ids_filter=None,
-                                     _dz_client_override=dz)
+        dz = _make_dz_client(
+            {
+                "tgt-cicd": "src-1",
+                "tgt-manual": None,  # no tracking key
+            }
+        )
+        result = _discover_notebooks(
+            "dom-1",
+            "proj-1",
+            "us-east-1",
+            notebook_ids_filter=None,
+            _dz_client_override=dz,
+        )
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["source_notebook_id"], "src-1")
 
     def test_notebook_ids_filter_restricts_to_matching_source_ids(self):
-        dz = _make_dz_client({
-            "tgt-1": "src-1",
-            "tgt-2": "src-2",
-            "tgt-3": "src-3",
-        })
+        dz = _make_dz_client(
+            {
+                "tgt-1": "src-1",
+                "tgt-2": "src-2",
+                "tgt-3": "src-3",
+            }
+        )
         result = _discover_notebooks(
-            "dom-1", "proj-1", "us-east-1",
+            "dom-1",
+            "proj-1",
+            "us-east-1",
             notebook_ids_filter=["src-1", "src-3"],
             _dz_client_override=dz,
         )
@@ -122,12 +146,16 @@ class TestDiscoverNotebooks(unittest.TestCase):
         self.assertEqual(source_ids, {"src-1", "src-3"})
 
     def test_notebook_ids_filter_none_includes_all_tracked(self):
-        dz = _make_dz_client({
-            "tgt-1": "src-1",
-            "tgt-2": "src-2",
-        })
+        dz = _make_dz_client(
+            {
+                "tgt-1": "src-1",
+                "tgt-2": "src-2",
+            }
+        )
         result = _discover_notebooks(
-            "dom-1", "proj-1", "us-east-1",
+            "dom-1",
+            "proj-1",
+            "us-east-1",
             notebook_ids_filter=None,
             _dz_client_override=dz,
         )
@@ -135,19 +163,31 @@ class TestDiscoverNotebooks(unittest.TestCase):
 
     def test_source_environment_no_tracking_returns_empty(self):
         """Notebooks in source environment have no tracking metadata → zero deletions."""
-        dz = _make_dz_client({
-            "nb-source-1": None,
-            "nb-source-2": None,
-        })
-        result = _discover_notebooks("dom-1", "proj-1", "us-east-1", notebook_ids_filter=None,
-                                     _dz_client_override=dz)
+        dz = _make_dz_client(
+            {
+                "nb-source-1": None,
+                "nb-source-2": None,
+            }
+        )
+        result = _discover_notebooks(
+            "dom-1",
+            "proj-1",
+            "us-east-1",
+            notebook_ids_filter=None,
+            _dz_client_override=dz,
+        )
         self.assertEqual(result, [])
 
     def test_empty_project_returns_empty(self):
         dz = MagicMock()
         dz.list_notebooks.return_value = {"items": []}
-        result = _discover_notebooks("dom-1", "proj-1", "us-east-1", notebook_ids_filter=None,
-                                     _dz_client_override=dz)
+        result = _discover_notebooks(
+            "dom-1",
+            "proj-1",
+            "us-east-1",
+            notebook_ids_filter=None,
+            _dz_client_override=dz,
+        )
         self.assertEqual(result, [])
 
     def test_pagination_followed(self):
@@ -160,15 +200,25 @@ class TestDiscoverNotebooks(unittest.TestCase):
             {"id": "tgt-1", "metadata": {SOURCE_KEY: "src-1"}},
             {"id": "tgt-2", "metadata": {SOURCE_KEY: "src-2"}},
         ]
-        result = _discover_notebooks("dom-1", "proj-1", "us-east-1", notebook_ids_filter=None,
-                                     _dz_client_override=dz)
+        result = _discover_notebooks(
+            "dom-1",
+            "proj-1",
+            "us-east-1",
+            notebook_ids_filter=None,
+            _dz_client_override=dz,
+        )
         self.assertEqual(len(result), 2)
         self.assertEqual(dz.list_notebooks.call_count, 2)
 
     def test_result_contains_target_and_source_ids_and_name(self):
         dz = _make_dz_client({"tgt-abc": "src-xyz"})
-        result = _discover_notebooks("dom-1", "proj-1", "us-east-1", notebook_ids_filter=None,
-                                     _dz_client_override=dz)
+        result = _discover_notebooks(
+            "dom-1",
+            "proj-1",
+            "us-east-1",
+            notebook_ids_filter=None,
+            _dz_client_override=dz,
+        )
         self.assertEqual(result[0]["target_notebook_id"], "tgt-abc")
         self.assertEqual(result[0]["source_notebook_id"], "src-xyz")
         self.assertIn("name", result[0])
@@ -200,13 +250,23 @@ class TestDestroyExecutorNotebooks(unittest.TestCase):
         dz = MagicMock()
         mock_boto3.side_effect = self._sts_dz(dz)
 
-        vr = _make_vr(resources=[
-            ResourceToDelete(
-                "notebook", "nb-tgt-1", "test",
-                {"name": "My NB", "source_notebook_id": "nb-src-1", "domain_id": "dom-1"},
-            )
-        ])
-        results = _destroy_stage("test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT")
+        vr = _make_vr(
+            resources=[
+                ResourceToDelete(
+                    "notebook",
+                    "nb-tgt-1",
+                    "test",
+                    {
+                        "name": "My NB",
+                        "source_notebook_id": "nb-src-1",
+                        "domain_id": "dom-1",
+                    },
+                )
+            ]
+        )
+        results = _destroy_stage(
+            "test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT"
+        )
         dz.delete_notebook.assert_called_once_with(
             domainIdentifier="dom-1", identifier="nb-tgt-1"
         )
@@ -220,13 +280,19 @@ class TestDestroyExecutorNotebooks(unittest.TestCase):
         dz.delete_notebook.side_effect = _client_error("ResourceNotFoundException")
         mock_boto3.side_effect = self._sts_dz(dz)
 
-        vr = _make_vr(resources=[
-            ResourceToDelete(
-                "notebook", "nb-tgt-1", "test",
-                {"name": "NB", "source_notebook_id": "src-1", "domain_id": "dom-1"},
-            )
-        ])
-        results = _destroy_stage("test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT")
+        vr = _make_vr(
+            resources=[
+                ResourceToDelete(
+                    "notebook",
+                    "nb-tgt-1",
+                    "test",
+                    {"name": "NB", "source_notebook_id": "src-1", "domain_id": "dom-1"},
+                )
+            ]
+        )
+        results = _destroy_stage(
+            "test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT"
+        )
         nb_result = next(r for r in results if r.resource_type == "notebook")
         self.assertEqual(nb_result.status, "not_found")
 
@@ -243,14 +309,36 @@ class TestDestroyExecutorNotebooks(unittest.TestCase):
         dz.delete_notebook.side_effect = delete_notebook
         mock_boto3.side_effect = self._sts_dz(dz)
 
-        vr = _make_vr(resources=[
-            ResourceToDelete("notebook", "nb-err", "test",
-                             {"name": "NB1", "source_notebook_id": "src-1", "domain_id": "dom-1"}),
-            ResourceToDelete("notebook", "nb-ok", "test",
-                             {"name": "NB2", "source_notebook_id": "src-2", "domain_id": "dom-1"}),
-        ])
-        results = _destroy_stage("test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT")
-        nb_results = {r.resource_id: r.status for r in results if r.resource_type == "notebook"}
+        vr = _make_vr(
+            resources=[
+                ResourceToDelete(
+                    "notebook",
+                    "nb-err",
+                    "test",
+                    {
+                        "name": "NB1",
+                        "source_notebook_id": "src-1",
+                        "domain_id": "dom-1",
+                    },
+                ),
+                ResourceToDelete(
+                    "notebook",
+                    "nb-ok",
+                    "test",
+                    {
+                        "name": "NB2",
+                        "source_notebook_id": "src-2",
+                        "domain_id": "dom-1",
+                    },
+                ),
+            ]
+        )
+        results = _destroy_stage(
+            "test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT"
+        )
+        nb_results = {
+            r.resource_id: r.status for r in results if r.resource_type == "notebook"
+        }
         self.assertEqual(nb_results["nb-err"], "error")
         self.assertEqual(nb_results["nb-ok"], "deleted")
         self.assertEqual(call_count[0], 2)  # both attempted
@@ -260,11 +348,19 @@ class TestDestroyExecutorNotebooks(unittest.TestCase):
         dz = MagicMock()
         mock_boto3.side_effect = self._sts_dz(dz)
 
-        vr = _make_vr(resources=[
-            ResourceToDelete("notebook", "nb-1", "test",
-                             {"name": "NB", "source_notebook_id": "src-1", "domain_id": ""}),
-        ])
-        results = _destroy_stage("test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT")
+        vr = _make_vr(
+            resources=[
+                ResourceToDelete(
+                    "notebook",
+                    "nb-1",
+                    "test",
+                    {"name": "NB", "source_notebook_id": "src-1", "domain_id": ""},
+                ),
+            ]
+        )
+        results = _destroy_stage(
+            "test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT"
+        )
         nb_result = next(r for r in results if r.resource_type == "notebook")
         self.assertEqual(nb_result.status, "skipped")
         dz.delete_notebook.assert_not_called()
@@ -274,12 +370,24 @@ class TestDestroyExecutorNotebooks(unittest.TestCase):
         dz = MagicMock()
         mock_boto3.side_effect = self._sts_dz(dz)
 
-        vr = _make_vr(resources=[
-            ResourceToDelete("notebook", f"nb-{i}", "test",
-                             {"name": f"NB{i}", "source_notebook_id": f"src-{i}", "domain_id": "dom-1"})
-            for i in range(5)
-        ])
-        results = _destroy_stage("test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT")
+        vr = _make_vr(
+            resources=[
+                ResourceToDelete(
+                    "notebook",
+                    f"nb-{i}",
+                    "test",
+                    {
+                        "name": f"NB{i}",
+                        "source_notebook_id": f"src-{i}",
+                        "domain_id": "dom-1",
+                    },
+                )
+                for i in range(5)
+            ]
+        )
+        results = _destroy_stage(
+            "test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT"
+        )
         nb_results = [r for r in results if r.resource_type == "notebook"]
         self.assertEqual(len(nb_results), 5)
         self.assertTrue(all(r.status == "deleted" for r in nb_results))
@@ -302,6 +410,7 @@ class TestValidateStageNotebooks(unittest.TestCase):
 
     def _make_manifest_with_notebooks(self, notebook_ids=None):
         from smus_cicd.application.application_manifest import ApplicationManifest
+
         return ApplicationManifest(
             application_name="App",
             content=ContentConfig(
@@ -331,10 +440,20 @@ class TestValidateStageNotebooks(unittest.TestCase):
         """Notebooks with tracking metadata are discovered and added to the plan."""
         from smus_cicd.helpers.destroy_validator import _validate_stage
 
-        with patch("smus_cicd.helpers.destroy_validator._discover_notebooks") as mock_discover:
+        with patch(
+            "smus_cicd.helpers.destroy_validator._discover_notebooks"
+        ) as mock_discover:
             mock_discover.return_value = [
-                {"target_notebook_id": "tgt-1", "source_notebook_id": "src-1", "name": "NB1"},
-                {"target_notebook_id": "tgt-2", "source_notebook_id": "src-2", "name": "NB2"},
+                {
+                    "target_notebook_id": "tgt-1",
+                    "source_notebook_id": "src-1",
+                    "name": "NB1",
+                },
+                {
+                    "target_notebook_id": "tgt-2",
+                    "source_notebook_id": "src-2",
+                    "name": "NB2",
+                },
             ]
             result = _validate_stage(
                 "test",
@@ -343,7 +462,9 @@ class TestValidateStageNotebooks(unittest.TestCase):
                 "us-east-1",
             )
 
-        notebook_resources = [r for r in result.resources if r.resource_type == "notebook"]
+        notebook_resources = [
+            r for r in result.resources if r.resource_type == "notebook"
+        ]
         self.assertEqual(len(notebook_resources), 2)
         target_ids = {r.resource_id for r in notebook_resources}
         self.assertEqual(target_ids, {"tgt-1", "tgt-2"})
@@ -358,7 +479,9 @@ class TestValidateStageNotebooks(unittest.TestCase):
         """When notebook_ids specified in manifest, filter is passed to _discover_notebooks."""
         from smus_cicd.helpers.destroy_validator import _validate_stage
 
-        with patch("smus_cicd.helpers.destroy_validator._discover_notebooks") as mock_discover:
+        with patch(
+            "smus_cicd.helpers.destroy_validator._discover_notebooks"
+        ) as mock_discover:
             mock_discover.return_value = []
             _validate_stage(
                 "test",
@@ -381,8 +504,10 @@ class TestValidateStageNotebooks(unittest.TestCase):
         """ListNotebooks API failure → recorded as error in validation result."""
         from smus_cicd.helpers.destroy_validator import _validate_stage
 
-        with patch("smus_cicd.helpers.destroy_validator._discover_notebooks",
-                   side_effect=Exception("ListNotebooksError")):
+        with patch(
+            "smus_cicd.helpers.destroy_validator._discover_notebooks",
+            side_effect=Exception("ListNotebooksError"),
+        ):
             result = _validate_stage(
                 "test",
                 self._make_notebook_stage(),
@@ -390,7 +515,9 @@ class TestValidateStageNotebooks(unittest.TestCase):
                 "us-east-1",
             )
 
-        self.assertTrue(any("ListNotebooks" in e or "notebook" in e.lower() for e in result.errors))
+        self.assertTrue(
+            any("ListNotebooks" in e or "notebook" in e.lower() for e in result.errors)
+        )
 
     @patch(PATCH_GET_WF_DEF, return_value="")
     @patch(PATCH_LIST_RUNS, return_value=[])
@@ -408,7 +535,9 @@ class TestValidateStageNotebooks(unittest.TestCase):
             content=ContentConfig(notebooks=NotebookConfig(enabled=False)),
             stages={},
         )
-        with patch("smus_cicd.helpers.destroy_validator._discover_notebooks") as mock_discover:
+        with patch(
+            "smus_cicd.helpers.destroy_validator._discover_notebooks"
+        ) as mock_discover:
             _validate_stage("test", self._make_notebook_stage(), manifest, "us-east-1")
             mock_discover.assert_not_called()
 

--- a/tests/unit/commands/test_destroy_notebooks.py
+++ b/tests/unit/commands/test_destroy_notebooks.py
@@ -1,0 +1,417 @@
+"""Unit tests for notebook destroy support.
+
+Covers:
+  - _discover_notebooks: pagination, metadata filtering, notebook_ids_filter
+  - destroy_executor notebook deletion: deleted / not_found / error / skipped
+  - Validate stage notebook discovery integration
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from botocore.exceptions import ClientError
+
+from smus_cicd.application.application_manifest import (
+    ContentConfig,
+    DeploymentConfiguration,
+    DomainConfig,
+    NotebookConfig,
+    ProjectConfig,
+    StageConfig,
+)
+from smus_cicd.helpers.destroy_executor import _destroy_stage
+from smus_cicd.helpers.destroy_models import ResourceResult, ResourceToDelete, ValidationResult
+from smus_cicd.helpers.destroy_validator import _discover_notebooks
+
+SOURCE_KEY = "smus-cicd-source-notebook-id"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _client_error(code, message="error"):
+    return ClientError({"Error": {"Code": code, "Message": message}}, "Op")
+
+
+def _make_dz_client(notebook_map):
+    """
+    notebook_map: {target_nb_id: source_nb_id or None}
+    None means no tracking metadata on that notebook.
+    """
+    client = MagicMock()
+    ids = list(notebook_map.keys())
+    client.list_notebooks.return_value = {"items": [{"id": nb_id} for nb_id in ids]}
+
+    def get_notebook(domainIdentifier, notebookIdentifier):
+        source_id = notebook_map.get(notebookIdentifier)
+        metadata = {SOURCE_KEY: source_id} if source_id else {}
+        return {"id": notebookIdentifier, "name": f"NB-{notebookIdentifier}", "metadata": metadata}
+
+    client.get_notebook.side_effect = get_notebook
+    return client
+
+
+def _make_vr(resources=None):
+    return ValidationResult(
+        errors=[],
+        warnings=[],
+        resources=resources or [],
+        active_workflow_runs={},
+    )
+
+
+def _simple_manifest():
+    from smus_cicd.application.application_manifest import ApplicationManifest
+    return ApplicationManifest(
+        application_name="App",
+        content=ContentConfig(),
+        stages={},
+    )
+
+
+def _make_stage_config():
+    return StageConfig(
+        project=ProjectConfig(name="test-project", create=False),
+        domain=DomainConfig(region="us-east-1"),
+        stage="TEST",
+        deployment_configuration=DeploymentConfiguration(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# _discover_notebooks
+# ---------------------------------------------------------------------------
+
+class TestDiscoverNotebooks(unittest.TestCase):
+
+    def test_notebooks_with_tracking_metadata_included(self):
+        dz = _make_dz_client({
+            "tgt-1": "src-1",
+            "tgt-2": "src-2",
+        })
+        result = _discover_notebooks("dom-1", "proj-1", "us-east-1", notebook_ids_filter=None,
+                                     _dz_client_override=dz)
+        self.assertEqual(len(result), 2)
+        source_ids = {r["source_notebook_id"] for r in result}
+        self.assertEqual(source_ids, {"src-1", "src-2"})
+
+    def test_notebooks_without_tracking_metadata_excluded(self):
+        dz = _make_dz_client({
+            "tgt-cicd": "src-1",
+            "tgt-manual": None,  # no tracking key
+        })
+        result = _discover_notebooks("dom-1", "proj-1", "us-east-1", notebook_ids_filter=None,
+                                     _dz_client_override=dz)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["source_notebook_id"], "src-1")
+
+    def test_notebook_ids_filter_restricts_to_matching_source_ids(self):
+        dz = _make_dz_client({
+            "tgt-1": "src-1",
+            "tgt-2": "src-2",
+            "tgt-3": "src-3",
+        })
+        result = _discover_notebooks(
+            "dom-1", "proj-1", "us-east-1",
+            notebook_ids_filter=["src-1", "src-3"],
+            _dz_client_override=dz,
+        )
+        self.assertEqual(len(result), 2)
+        source_ids = {r["source_notebook_id"] for r in result}
+        self.assertEqual(source_ids, {"src-1", "src-3"})
+
+    def test_notebook_ids_filter_none_includes_all_tracked(self):
+        dz = _make_dz_client({
+            "tgt-1": "src-1",
+            "tgt-2": "src-2",
+        })
+        result = _discover_notebooks(
+            "dom-1", "proj-1", "us-east-1",
+            notebook_ids_filter=None,
+            _dz_client_override=dz,
+        )
+        self.assertEqual(len(result), 2)
+
+    def test_source_environment_no_tracking_returns_empty(self):
+        """Notebooks in source environment have no tracking metadata → zero deletions."""
+        dz = _make_dz_client({
+            "nb-source-1": None,
+            "nb-source-2": None,
+        })
+        result = _discover_notebooks("dom-1", "proj-1", "us-east-1", notebook_ids_filter=None,
+                                     _dz_client_override=dz)
+        self.assertEqual(result, [])
+
+    def test_empty_project_returns_empty(self):
+        dz = MagicMock()
+        dz.list_notebooks.return_value = {"items": []}
+        result = _discover_notebooks("dom-1", "proj-1", "us-east-1", notebook_ids_filter=None,
+                                     _dz_client_override=dz)
+        self.assertEqual(result, [])
+
+    def test_pagination_followed(self):
+        dz = MagicMock()
+        dz.list_notebooks.side_effect = [
+            {"items": [{"id": "tgt-1"}], "nextToken": "tok"},
+            {"items": [{"id": "tgt-2"}]},
+        ]
+        dz.get_notebook.side_effect = [
+            {"id": "tgt-1", "metadata": {SOURCE_KEY: "src-1"}},
+            {"id": "tgt-2", "metadata": {SOURCE_KEY: "src-2"}},
+        ]
+        result = _discover_notebooks("dom-1", "proj-1", "us-east-1", notebook_ids_filter=None,
+                                     _dz_client_override=dz)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(dz.list_notebooks.call_count, 2)
+
+    def test_result_contains_target_and_source_ids_and_name(self):
+        dz = _make_dz_client({"tgt-abc": "src-xyz"})
+        result = _discover_notebooks("dom-1", "proj-1", "us-east-1", notebook_ids_filter=None,
+                                     _dz_client_override=dz)
+        self.assertEqual(result[0]["target_notebook_id"], "tgt-abc")
+        self.assertEqual(result[0]["source_notebook_id"], "src-xyz")
+        self.assertIn("name", result[0])
+
+
+# ---------------------------------------------------------------------------
+# Destroy executor: notebook deletion
+# ---------------------------------------------------------------------------
+
+PATCH_BOTO3 = "smus_cicd.helpers.destroy_executor.create_client"
+
+
+class TestDestroyExecutorNotebooks(unittest.TestCase):
+
+    def _sts_dz(self, dz):
+        """Return a boto3 factory that yields an STS mock and the given DZ mock."""
+        sts = MagicMock()
+        sts.get_caller_identity.return_value = {"Account": "111122223333"}
+
+        def factory(service, **kwargs):
+            if service == "sts":
+                return sts
+            return dz
+
+        return factory
+
+    @patch(PATCH_BOTO3)
+    def test_notebook_deleted_successfully(self, mock_boto3):
+        dz = MagicMock()
+        mock_boto3.side_effect = self._sts_dz(dz)
+
+        vr = _make_vr(resources=[
+            ResourceToDelete(
+                "notebook", "nb-tgt-1", "test",
+                {"name": "My NB", "source_notebook_id": "nb-src-1", "domain_id": "dom-1"},
+            )
+        ])
+        results = _destroy_stage("test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT")
+        dz.delete_notebook.assert_called_once_with(
+            domainIdentifier="dom-1", identifier="nb-tgt-1"
+        )
+        notebook_results = [r for r in results if r.resource_type == "notebook"]
+        self.assertEqual(len(notebook_results), 1)
+        self.assertEqual(notebook_results[0].status, "deleted")
+
+    @patch(PATCH_BOTO3)
+    def test_notebook_not_found_recorded(self, mock_boto3):
+        dz = MagicMock()
+        dz.delete_notebook.side_effect = _client_error("ResourceNotFoundException")
+        mock_boto3.side_effect = self._sts_dz(dz)
+
+        vr = _make_vr(resources=[
+            ResourceToDelete(
+                "notebook", "nb-tgt-1", "test",
+                {"name": "NB", "source_notebook_id": "src-1", "domain_id": "dom-1"},
+            )
+        ])
+        results = _destroy_stage("test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT")
+        nb_result = next(r for r in results if r.resource_type == "notebook")
+        self.assertEqual(nb_result.status, "not_found")
+
+    @patch(PATCH_BOTO3)
+    def test_notebook_api_error_recorded_and_continues(self, mock_boto3):
+        dz = MagicMock()
+        call_count = [0]
+
+        def delete_notebook(**kwargs):
+            call_count[0] += 1
+            if kwargs["identifier"] == "nb-err":
+                raise _client_error("AccessDeniedException")
+
+        dz.delete_notebook.side_effect = delete_notebook
+        mock_boto3.side_effect = self._sts_dz(dz)
+
+        vr = _make_vr(resources=[
+            ResourceToDelete("notebook", "nb-err", "test",
+                             {"name": "NB1", "source_notebook_id": "src-1", "domain_id": "dom-1"}),
+            ResourceToDelete("notebook", "nb-ok", "test",
+                             {"name": "NB2", "source_notebook_id": "src-2", "domain_id": "dom-1"}),
+        ])
+        results = _destroy_stage("test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT")
+        nb_results = {r.resource_id: r.status for r in results if r.resource_type == "notebook"}
+        self.assertEqual(nb_results["nb-err"], "error")
+        self.assertEqual(nb_results["nb-ok"], "deleted")
+        self.assertEqual(call_count[0], 2)  # both attempted
+
+    @patch(PATCH_BOTO3)
+    def test_notebook_missing_domain_id_skipped(self, mock_boto3):
+        dz = MagicMock()
+        mock_boto3.side_effect = self._sts_dz(dz)
+
+        vr = _make_vr(resources=[
+            ResourceToDelete("notebook", "nb-1", "test",
+                             {"name": "NB", "source_notebook_id": "src-1", "domain_id": ""}),
+        ])
+        results = _destroy_stage("test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT")
+        nb_result = next(r for r in results if r.resource_type == "notebook")
+        self.assertEqual(nb_result.status, "skipped")
+        dz.delete_notebook.assert_not_called()
+
+    @patch(PATCH_BOTO3)
+    def test_multiple_notebooks_all_deleted(self, mock_boto3):
+        dz = MagicMock()
+        mock_boto3.side_effect = self._sts_dz(dz)
+
+        vr = _make_vr(resources=[
+            ResourceToDelete("notebook", f"nb-{i}", "test",
+                             {"name": f"NB{i}", "source_notebook_id": f"src-{i}", "domain_id": "dom-1"})
+            for i in range(5)
+        ])
+        results = _destroy_stage("test", _make_stage_config(), _simple_manifest(), vr, "us-east-1", "TEXT")
+        nb_results = [r for r in results if r.resource_type == "notebook"]
+        self.assertEqual(len(nb_results), 5)
+        self.assertTrue(all(r.status == "deleted" for r in nb_results))
+        self.assertEqual(dz.delete_notebook.call_count, 5)
+
+
+# ---------------------------------------------------------------------------
+# Validate stage: notebook discovery integration
+# ---------------------------------------------------------------------------
+
+PATCH_DOMAIN = "smus_cicd.helpers.destroy_validator.get_domain_from_target_config"
+PATCH_PROJECT_ID = "smus_cicd.helpers.destroy_validator.get_project_id_by_name"
+PATCH_CONNECTIONS = "smus_cicd.helpers.destroy_validator.get_project_connections"
+PATCH_LIST_WF = "smus_cicd.helpers.destroy_validator.list_workflows"
+PATCH_LIST_RUNS = "smus_cicd.helpers.destroy_validator.list_workflow_runs"
+PATCH_GET_WF_DEF = "smus_cicd.helpers.destroy_validator.get_workflow_definition"
+
+
+class TestValidateStageNotebooks(unittest.TestCase):
+
+    def _make_manifest_with_notebooks(self, notebook_ids=None):
+        from smus_cicd.application.application_manifest import ApplicationManifest
+        return ApplicationManifest(
+            application_name="App",
+            content=ContentConfig(
+                notebooks=NotebookConfig(
+                    enabled=True,
+                    notebook_ids=notebook_ids,
+                )
+            ),
+            stages={},
+        )
+
+    def _make_notebook_stage(self):
+        return StageConfig(
+            project=ProjectConfig(name="target-project", create=False),
+            domain=DomainConfig(region="us-east-1"),
+            stage="TEST",
+            deployment_configuration=DeploymentConfiguration(),
+        )
+
+    @patch(PATCH_GET_WF_DEF, return_value="")
+    @patch(PATCH_LIST_RUNS, return_value=[])
+    @patch(PATCH_LIST_WF, return_value=[])
+    @patch(PATCH_CONNECTIONS, return_value={})
+    @patch(PATCH_PROJECT_ID, return_value="proj-target")
+    @patch(PATCH_DOMAIN, return_value=("dom-1", "test-domain"))
+    def test_cicd_notebooks_added_to_destruction_plan(self, *_):
+        """Notebooks with tracking metadata are discovered and added to the plan."""
+        from smus_cicd.helpers.destroy_validator import _validate_stage
+
+        with patch("smus_cicd.helpers.destroy_validator._discover_notebooks") as mock_discover:
+            mock_discover.return_value = [
+                {"target_notebook_id": "tgt-1", "source_notebook_id": "src-1", "name": "NB1"},
+                {"target_notebook_id": "tgt-2", "source_notebook_id": "src-2", "name": "NB2"},
+            ]
+            result = _validate_stage(
+                "test",
+                self._make_notebook_stage(),
+                self._make_manifest_with_notebooks(),
+                "us-east-1",
+            )
+
+        notebook_resources = [r for r in result.resources if r.resource_type == "notebook"]
+        self.assertEqual(len(notebook_resources), 2)
+        target_ids = {r.resource_id for r in notebook_resources}
+        self.assertEqual(target_ids, {"tgt-1", "tgt-2"})
+
+    @patch(PATCH_GET_WF_DEF, return_value="")
+    @patch(PATCH_LIST_RUNS, return_value=[])
+    @patch(PATCH_LIST_WF, return_value=[])
+    @patch(PATCH_CONNECTIONS, return_value={})
+    @patch(PATCH_PROJECT_ID, return_value="proj-target")
+    @patch(PATCH_DOMAIN, return_value=("dom-1", "test-domain"))
+    def test_discover_notebooks_called_with_notebook_ids_filter(self, *_):
+        """When notebook_ids specified in manifest, filter is passed to _discover_notebooks."""
+        from smus_cicd.helpers.destroy_validator import _validate_stage
+
+        with patch("smus_cicd.helpers.destroy_validator._discover_notebooks") as mock_discover:
+            mock_discover.return_value = []
+            _validate_stage(
+                "test",
+                self._make_notebook_stage(),
+                self._make_manifest_with_notebooks(notebook_ids=["src-1", "src-2"]),
+                "us-east-1",
+            )
+
+        # _discover_notebooks must have been called with the filter list
+        call_kwargs = mock_discover.call_args[1]
+        self.assertEqual(call_kwargs.get("notebook_ids_filter"), ["src-1", "src-2"])
+
+    @patch(PATCH_GET_WF_DEF, return_value="")
+    @patch(PATCH_LIST_RUNS, return_value=[])
+    @patch(PATCH_LIST_WF, return_value=[])
+    @patch(PATCH_CONNECTIONS, return_value={})
+    @patch(PATCH_PROJECT_ID, return_value="proj-target")
+    @patch(PATCH_DOMAIN, return_value=("dom-1", "test-domain"))
+    def test_discover_failure_recorded_as_error(self, *_):
+        """ListNotebooks API failure → recorded as error in validation result."""
+        from smus_cicd.helpers.destroy_validator import _validate_stage
+
+        with patch("smus_cicd.helpers.destroy_validator._discover_notebooks",
+                   side_effect=Exception("ListNotebooksError")):
+            result = _validate_stage(
+                "test",
+                self._make_notebook_stage(),
+                self._make_manifest_with_notebooks(),
+                "us-east-1",
+            )
+
+        self.assertTrue(any("ListNotebooks" in e or "notebook" in e.lower() for e in result.errors))
+
+    @patch(PATCH_GET_WF_DEF, return_value="")
+    @patch(PATCH_LIST_RUNS, return_value=[])
+    @patch(PATCH_LIST_WF, return_value=[])
+    @patch(PATCH_CONNECTIONS, return_value={})
+    @patch(PATCH_PROJECT_ID, return_value="proj-target")
+    @patch(PATCH_DOMAIN, return_value=("dom-1", "test-domain"))
+    def test_notebooks_disabled_in_manifest_not_discovered(self, *_):
+        """When content.notebooks.enabled=False, notebook discovery is skipped."""
+        from smus_cicd.application.application_manifest import ApplicationManifest
+        from smus_cicd.helpers.destroy_validator import _validate_stage
+
+        manifest = ApplicationManifest(
+            application_name="App",
+            content=ContentConfig(notebooks=NotebookConfig(enabled=False)),
+            stages={},
+        )
+        with patch("smus_cicd.helpers.destroy_validator._discover_notebooks") as mock_discover:
+            _validate_stage("test", self._make_notebook_stage(), manifest, "us-east-1")
+            mock_discover.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/helpers/test_notebook_export.py
+++ b/tests/unit/helpers/test_notebook_export.py
@@ -1,0 +1,551 @@
+"""Unit tests for notebook_export.py.
+
+Covers:
+  - _validate_notebook_ids: fail-fast, collects all invalid IDs
+  - _list_all_notebooks: pagination
+  - _compute_backoff_delay: exponential cap
+  - _poll_export_status: SUCCEEDED / FAILED / timeout paths
+  - _build_export_manifest: schema correctness, empty list
+  - export_notebooks: happy path, invalid IDs, partial failure, discovery mode
+"""
+
+import json
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+from botocore.exceptions import ClientError
+
+from smus_cicd.helpers.notebook_export import (
+    ExportedNotebook,
+    _build_export_manifest,
+    _compute_backoff_delay,
+    _list_all_notebooks,
+    _poll_export_status,
+    _validate_notebook_ids,
+    export_notebooks,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _client_error(code, message="error"):
+    return ClientError({"Error": {"Code": code, "Message": message}}, "Op")
+
+
+def _make_get_notebook_response(nb_id, name="Test NB", params=None, meta=None, env=None):
+    return {
+        "id": nb_id,
+        "name": name,
+        "description": f"Desc of {nb_id}",
+        "parameters": params or {},
+        "metadata": meta or {},
+        "environmentConfiguration": env,
+    }
+
+
+def _make_exported_notebook(nb_id, name="NB"):
+    return ExportedNotebook(
+        source_notebook_id=nb_id,
+        name=name,
+        description="desc",
+        file_content=b'{"cells":[]}',
+        file_path=f"notebooks/{nb_id}.ipynb",
+        exported_at="2024-01-01T00:00:00Z",
+        parameters={},
+        metadata={},
+        environment_configuration=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _validate_notebook_ids
+# ---------------------------------------------------------------------------
+
+class TestValidateNotebookIds(unittest.TestCase):
+
+    def _mock_client(self, valid_ids, invalid_ids):
+        """Build a mock DZ client that succeeds for valid_ids, raises ResourceNotFoundException for invalid_ids."""
+        client = MagicMock()
+        def get_notebook(domainIdentifier, notebookIdentifier):
+            if notebookIdentifier in invalid_ids:
+                raise _client_error("ResourceNotFoundException")
+            return _make_get_notebook_response(notebookIdentifier)
+        client.get_notebook.side_effect = get_notebook
+        return client
+
+    def test_all_valid_returns_details_empty_invalid_list(self):
+        client = self._mock_client(["nb-1", "nb-2"], [])
+        valid, invalid = _validate_notebook_ids(client, "dom-1", ["nb-1", "nb-2"])
+        self.assertEqual(len(valid), 2)
+        self.assertEqual(invalid, [])
+
+    def test_all_invalid_returns_empty_valid_all_invalid_ids(self):
+        client = self._mock_client([], ["nb-x", "nb-y"])
+        valid, invalid = _validate_notebook_ids(client, "dom-1", ["nb-x", "nb-y"])
+        self.assertEqual(valid, [])
+        self.assertEqual(sorted(invalid), ["nb-x", "nb-y"])
+
+    def test_partial_invalid_collects_all_invalid(self):
+        """Fail-fast means we validate ALL IDs, not just until first failure."""
+        client = self._mock_client(["nb-1"], ["nb-bad1", "nb-bad2"])
+        valid, invalid = _validate_notebook_ids(
+            client, "dom-1", ["nb-1", "nb-bad1", "nb-bad2"]
+        )
+        self.assertEqual(len(valid), 1)
+        self.assertEqual(sorted(invalid), ["nb-bad1", "nb-bad2"])
+        # GetNotebook must have been called for every ID — not short-circuited
+        self.assertEqual(client.get_notebook.call_count, 3)
+
+    def test_valid_notebook_details_contain_parameters_metadata(self):
+        client = MagicMock()
+        client.get_notebook.return_value = _make_get_notebook_response(
+            "nb-1",
+            params={"key": "val"},
+            meta={"owner": "team"},
+            env={"imageVersion": "v1", "packageConfig": {"packageManager": "pip", "packageSpecification": ""}},
+        )
+        valid, _ = _validate_notebook_ids(client, "dom-1", ["nb-1"])
+        self.assertEqual(valid[0]["parameters"], {"key": "val"})
+        self.assertEqual(valid[0]["metadata"], {"owner": "team"})
+        self.assertIsNotNone(valid[0]["environmentConfiguration"])
+
+    def test_non_resource_not_found_error_propagates(self):
+        client = MagicMock()
+        client.get_notebook.side_effect = _client_error("ThrottlingException")
+        with self.assertRaises(ClientError):
+            _validate_notebook_ids(client, "dom-1", ["nb-1"])
+
+    def test_response_metadata_stripped(self):
+        """ResponseMetadata must not appear in returned notebook details."""
+        client = MagicMock()
+        resp = _make_get_notebook_response("nb-1")
+        resp["ResponseMetadata"] = {"RequestId": "req-123"}
+        client.get_notebook.return_value = resp
+        valid, _ = _validate_notebook_ids(client, "dom-1", ["nb-1"])
+        self.assertNotIn("ResponseMetadata", valid[0])
+
+
+# ---------------------------------------------------------------------------
+# _list_all_notebooks
+# ---------------------------------------------------------------------------
+
+class TestListAllNotebooks(unittest.TestCase):
+
+    def test_single_page_returns_all_items(self):
+        client = MagicMock()
+        client.list_notebooks.return_value = {
+            "items": [{"id": "nb-1"}, {"id": "nb-2"}]
+        }
+        result = _list_all_notebooks(client, "dom-1", "proj-1")
+        self.assertEqual(len(result), 2)
+
+    def test_pagination_follows_next_token(self):
+        client = MagicMock()
+        client.list_notebooks.side_effect = [
+            {"items": [{"id": "nb-1"}], "nextToken": "tok-1"},
+            {"items": [{"id": "nb-2"}], "nextToken": "tok-2"},
+            {"items": [{"id": "nb-3"}]},
+        ]
+        result = _list_all_notebooks(client, "dom-1", "proj-1")
+        self.assertEqual(len(result), 3)
+        self.assertEqual(client.list_notebooks.call_count, 3)
+        # Second call must include nextToken
+        second_call_kwargs = client.list_notebooks.call_args_list[1][1]
+        self.assertEqual(second_call_kwargs["nextToken"], "tok-1")
+
+    def test_empty_project_returns_empty_list(self):
+        client = MagicMock()
+        client.list_notebooks.return_value = {"items": []}
+        result = _list_all_notebooks(client, "dom-1", "proj-1")
+        self.assertEqual(result, [])
+
+    def test_status_active_filter_sent(self):
+        client = MagicMock()
+        client.list_notebooks.return_value = {"items": []}
+        _list_all_notebooks(client, "dom-1", "proj-1")
+        kwargs = client.list_notebooks.call_args[1]
+        self.assertEqual(kwargs["status"], "ACTIVE")
+        self.assertEqual(kwargs["owningProjectIdentifier"], "proj-1")
+        self.assertEqual(kwargs["domainIdentifier"], "dom-1")
+
+    def test_api_error_propagates(self):
+        client = MagicMock()
+        client.list_notebooks.side_effect = Exception("ServiceError")
+        with self.assertRaises(Exception, msg="ServiceError"):
+            _list_all_notebooks(client, "dom-1", "proj-1")
+
+
+# ---------------------------------------------------------------------------
+# _compute_backoff_delay
+# ---------------------------------------------------------------------------
+
+class TestComputeBackoffDelay(unittest.TestCase):
+    """Property 8: delay for attempt i equals min(initial × 2^i, max_interval)."""
+
+    def test_first_attempt_starts_at_initial(self):
+        delay = _compute_backoff_delay(0, initial=1.0, cap=30.0)
+        # 1.0 * 2^0 = 1.0 (plus up to 0.5 jitter)
+        self.assertGreaterEqual(delay, 1.0)
+        self.assertLessEqual(delay, 1.5)
+
+    def test_delay_doubles_each_attempt(self):
+        # Without jitter randomness affecting assertions, test the base (cap not hit)
+        # Use large cap so cap doesn't kick in for early attempts
+        d0_base = 1.0  # 1 * 2^0
+        d1_base = 2.0  # 1 * 2^1
+        d2_base = 4.0  # 1 * 2^2
+        # Run many samples — each should be within [base, base+0.5]
+        for _ in range(20):
+            d0 = _compute_backoff_delay(0, initial=1.0, cap=100.0)
+            d1 = _compute_backoff_delay(1, initial=1.0, cap=100.0)
+            d2 = _compute_backoff_delay(2, initial=1.0, cap=100.0)
+            self.assertGreaterEqual(d0, d0_base)
+            self.assertLessEqual(d0, d0_base + 0.5)
+            self.assertGreaterEqual(d1, d1_base)
+            self.assertLessEqual(d1, d1_base + 0.5)
+            self.assertGreaterEqual(d2, d2_base)
+            self.assertLessEqual(d2, d2_base + 0.5)
+
+    def test_delay_capped_at_max_interval(self):
+        # Attempt 10 with initial=1 would be 1024s without cap
+        for _ in range(20):
+            delay = _compute_backoff_delay(10, initial=1.0, cap=30.0)
+            self.assertLessEqual(delay, 30.5)
+            self.assertGreaterEqual(delay, 30.0)
+
+    def test_cap_respected_before_large_attempt(self):
+        # At attempt 5, 1 * 2^5 = 32 > cap=30 → should be 30 + jitter
+        for _ in range(10):
+            delay = _compute_backoff_delay(5, initial=1.0, cap=30.0)
+            self.assertGreaterEqual(delay, 30.0)
+            self.assertLessEqual(delay, 30.5)
+
+
+# ---------------------------------------------------------------------------
+# _poll_export_status
+# ---------------------------------------------------------------------------
+
+class TestPollExportStatus(unittest.TestCase):
+
+    @patch("smus_cicd.helpers.notebook_export.time.sleep")
+    @patch("smus_cicd.helpers.notebook_export.time.monotonic")
+    def test_succeeded_returns_output_location(self, mock_mono, mock_sleep):
+        mock_mono.side_effect = [0.0, 1.0]  # start, then first poll elapsed
+        client = MagicMock()
+        client.get_notebook_export.return_value = {
+            "status": "SUCCEEDED",
+            "outputLocation": "s3://bucket/export.ipynb",
+        }
+        result = _poll_export_status(client, "dom-1", "exp-1", "nb-1", 300)
+        self.assertEqual(result, "s3://bucket/export.ipynb")
+
+    @patch("smus_cicd.helpers.notebook_export.time.sleep")
+    @patch("smus_cicd.helpers.notebook_export.time.monotonic")
+    def test_failed_status_returns_none(self, mock_mono, mock_sleep):
+        mock_mono.side_effect = [0.0, 1.0]
+        client = MagicMock()
+        client.get_notebook_export.return_value = {
+            "status": "FAILED",
+            "error": {"message": "Export error"},
+        }
+        result = _poll_export_status(client, "dom-1", "exp-1", "nb-1", 300)
+        self.assertIsNone(result)
+
+    @patch("smus_cicd.helpers.notebook_export.time.sleep")
+    @patch("smus_cicd.helpers.notebook_export.time.monotonic")
+    def test_timeout_returns_none(self, mock_mono, mock_sleep):
+        # monotonic always returns elapsed > timeout so we time out immediately
+        mock_mono.side_effect = [0.0, 400.0, 400.0]
+        client = MagicMock()
+        client.get_notebook_export.return_value = {"status": "IN_PROGRESS"}
+        result = _poll_export_status(client, "dom-1", "exp-1", "nb-1", polling_timeout=300)
+        self.assertIsNone(result)
+
+    @patch("smus_cicd.helpers.notebook_export.time.sleep")
+    @patch("smus_cicd.helpers.notebook_export.time.monotonic")
+    def test_polls_multiple_times_before_success(self, mock_mono, mock_sleep):
+        # Three IN_PROGRESS polls, then SUCCEEDED
+        mock_mono.side_effect = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+        client = MagicMock()
+        client.get_notebook_export.side_effect = [
+            {"status": "IN_PROGRESS"},
+            {"status": "IN_PROGRESS"},
+            {"status": "SUCCEEDED", "outputLocation": "s3://b/f.ipynb"},
+        ]
+        result = _poll_export_status(client, "dom-1", "exp-1", "nb-1", 300)
+        self.assertEqual(result, "s3://b/f.ipynb")
+        self.assertEqual(client.get_notebook_export.call_count, 3)
+        # sleep called between polls
+        self.assertGreaterEqual(mock_sleep.call_count, 2)
+
+
+# ---------------------------------------------------------------------------
+# _build_export_manifest
+# ---------------------------------------------------------------------------
+
+class TestBuildExportManifest(unittest.TestCase):
+
+    def test_schema_has_metadata_and_notebooks_keys(self):
+        manifest = _build_export_manifest([], "dom-1", "proj-1")
+        self.assertIn("metadata", manifest)
+        self.assertIn("notebooks", manifest)
+        self.assertEqual(set(manifest.keys()), {"metadata", "notebooks"})
+
+    def test_metadata_fields_present(self):
+        manifest = _build_export_manifest([], "dom-1", "proj-1")
+        meta = manifest["metadata"]
+        self.assertEqual(meta["sourceDomainId"], "dom-1")
+        self.assertEqual(meta["sourceProjectId"], "proj-1")
+        self.assertIn("exportTimestamp", meta)
+        self.assertEqual(meta["notebookCount"], 0)
+
+    def test_notebook_count_matches_list_length(self):
+        notebooks = [
+            _make_exported_notebook("nb-1"),
+            _make_exported_notebook("nb-2"),
+        ]
+        manifest = _build_export_manifest(notebooks, "dom-1", "proj-1")
+        self.assertEqual(manifest["metadata"]["notebookCount"], 2)
+        self.assertEqual(len(manifest["notebooks"]), 2)
+
+    def test_notebook_entry_has_all_required_fields(self):
+        nb = ExportedNotebook(
+            source_notebook_id="nb-abc",
+            name="My Notebook",
+            description="A test",
+            file_content=b"{}",
+            file_path="notebooks/nb-abc.ipynb",
+            exported_at="2024-01-01T00:00:00Z",
+            parameters={"k": "v"},
+            metadata={"owner": "team"},
+            environment_configuration={"imageVersion": "v1", "packageConfig": {"packageManager": "pip", "packageSpecification": ""}},
+        )
+        manifest = _build_export_manifest([nb], "dom-1", "proj-1")
+        entry = manifest["notebooks"][0]
+        required = {
+            "sourceNotebookId", "name", "description", "filePath",
+            "exportedAt", "parameters", "metadata", "environmentConfiguration",
+        }
+        self.assertEqual(set(entry.keys()), required)
+        self.assertEqual(entry["sourceNotebookId"], "nb-abc")
+        self.assertEqual(entry["filePath"], "notebooks/nb-abc.ipynb")
+
+    def test_empty_notebooks_produces_count_zero(self):
+        manifest = _build_export_manifest([], "dom-1", "proj-1")
+        self.assertEqual(manifest["metadata"]["notebookCount"], 0)
+        self.assertEqual(manifest["notebooks"], [])
+
+    def test_manifest_is_json_serialisable(self):
+        notebooks = [_make_exported_notebook("nb-1"), _make_exported_notebook("nb-2")]
+        manifest = _build_export_manifest(notebooks, "dom-1", "proj-1")
+        # Must not raise
+        json_str = json.dumps(manifest)
+        parsed = json.loads(json_str)
+        self.assertEqual(parsed["metadata"]["notebookCount"], 2)
+
+
+# ---------------------------------------------------------------------------
+# export_notebooks (integration of all internal pieces)
+# ---------------------------------------------------------------------------
+
+PATCH_DZ = "smus_cicd.helpers.notebook_export._get_datazone_client"
+PATCH_S3 = "smus_cicd.helpers.notebook_export._get_s3_client"
+
+
+class TestExportNotebooks(unittest.TestCase):
+
+    def _make_dz_client(self, valid_ids=None, notebook_details=None):
+        """Build a DZ mock that succeeds for the given IDs."""
+        valid_ids = valid_ids or []
+        notebook_details = notebook_details or {}
+
+        def get_notebook(domainIdentifier, notebookIdentifier):
+            if notebookIdentifier not in valid_ids:
+                raise _client_error("ResourceNotFoundException")
+            return notebook_details.get(
+                notebookIdentifier,
+                _make_get_notebook_response(notebookIdentifier),
+            )
+
+        client = MagicMock()
+        client.get_notebook.side_effect = get_notebook
+        return client
+
+    def _make_s3_client_with_content(self, content=b'{"cells":[]}'):
+        s3 = MagicMock()
+        s3.get_object.return_value = {"Body": MagicMock(read=MagicMock(return_value=content))}
+        return s3
+
+    # ── notebook_ids specified path ──────────────────────────────────────
+
+    @patch(PATCH_S3)
+    @patch(PATCH_DZ)
+    def test_invalid_ids_raises_system_exit(self, mock_dz, mock_s3):
+        mock_dz.return_value = self._make_dz_client(valid_ids=["nb-1"], notebook_details={})
+        mock_s3.return_value = MagicMock()
+        with self.assertRaises(SystemExit) as ctx:
+            export_notebooks("dom-1", "proj-1", "us-east-1", notebook_ids=["nb-1", "nb-bad"])
+        self.assertIn("nb-bad", str(ctx.exception))
+
+    @patch(PATCH_S3)
+    @patch(PATCH_DZ)
+    def test_all_invalid_ids_listed_in_error(self, mock_dz, mock_s3):
+        dz = MagicMock()
+        dz.get_notebook.side_effect = _client_error("ResourceNotFoundException")
+        mock_dz.return_value = dz
+        mock_s3.return_value = MagicMock()
+        with self.assertRaises(SystemExit) as ctx:
+            export_notebooks("dom-1", "proj-1", "us-east-1", notebook_ids=["nb-a", "nb-b"])
+        error_msg = str(ctx.exception)
+        self.assertIn("nb-a", error_msg)
+        self.assertIn("nb-b", error_msg)
+
+    @patch(PATCH_S3)
+    @patch(PATCH_DZ)
+    def test_valid_ids_exports_and_returns_manifest(self, mock_dz, mock_s3):
+        dz = MagicMock()
+        dz.get_notebook.return_value = _make_get_notebook_response("nb-1")
+        dz.start_notebook_export.return_value = {"exportIdentifier": "exp-1"}
+        dz.get_notebook_export.return_value = {
+            "status": "SUCCEEDED",
+            "outputLocation": "s3://bucket/nb-1.ipynb",
+        }
+        mock_dz.return_value = dz
+        mock_s3.return_value = self._make_s3_client_with_content()
+
+        exported, manifest = export_notebooks(
+            "dom-1", "proj-1", "us-east-1", notebook_ids=["nb-1"]
+        )
+        self.assertEqual(len(exported), 1)
+        self.assertEqual(exported[0].source_notebook_id, "nb-1")
+        self.assertEqual(manifest["metadata"]["notebookCount"], 1)
+
+    @patch(PATCH_S3)
+    @patch(PATCH_DZ)
+    def test_start_export_failure_raises_system_exit(self, mock_dz, mock_s3):
+        """When StartNotebookExport fails, the notebook is counted as failed → SystemExit."""
+        dz = MagicMock()
+        dz.get_notebook.return_value = _make_get_notebook_response("nb-1")
+        dz.start_notebook_export.side_effect = Exception("StartExportError")
+        mock_dz.return_value = dz
+        mock_s3.return_value = MagicMock()
+
+        with self.assertRaises(SystemExit):
+            export_notebooks("dom-1", "proj-1", "us-east-1", notebook_ids=["nb-1"])
+
+    # ── discovery mode (notebook_ids omitted) ────────────────────────────
+
+    @patch(PATCH_S3)
+    @patch(PATCH_DZ)
+    def test_discovery_mode_lists_and_exports_notebooks(self, mock_dz, mock_s3):
+        dz = MagicMock()
+        # ListNotebooks returns one notebook summary
+        dz.list_notebooks.return_value = {"items": [{"id": "nb-2", "name": "NB2"}]}
+        # GetNotebook (for full details) returns full response
+        dz.get_notebook.return_value = _make_get_notebook_response("nb-2")
+        dz.start_notebook_export.return_value = {"exportIdentifier": "exp-2"}
+        dz.get_notebook_export.return_value = {
+            "status": "SUCCEEDED",
+            "outputLocation": "s3://bucket/nb-2.ipynb",
+        }
+        mock_dz.return_value = dz
+        mock_s3.return_value = self._make_s3_client_with_content()
+
+        exported, manifest = export_notebooks("dom-1", "proj-1", "us-east-1")
+        self.assertEqual(len(exported), 1)
+        self.assertEqual(manifest["metadata"]["notebookCount"], 1)
+
+    @patch(PATCH_S3)
+    @patch(PATCH_DZ)
+    def test_discovery_mode_empty_project_returns_empty_manifest(self, mock_dz, mock_s3):
+        dz = MagicMock()
+        dz.list_notebooks.return_value = {"items": []}
+        mock_dz.return_value = dz
+        mock_s3.return_value = MagicMock()
+
+        exported, manifest = export_notebooks("dom-1", "proj-1", "us-east-1")
+        self.assertEqual(exported, [])
+        self.assertEqual(manifest["metadata"]["notebookCount"], 0)
+        self.assertEqual(manifest["notebooks"], [])
+
+    @patch(PATCH_S3)
+    @patch(PATCH_DZ)
+    def test_list_notebooks_failure_raises_exception(self, mock_dz, mock_s3):
+        dz = MagicMock()
+        dz.list_notebooks.side_effect = Exception("ListNotebooksError")
+        mock_dz.return_value = dz
+        mock_s3.return_value = MagicMock()
+
+        with self.assertRaises(Exception, msg="ListNotebooksError"):
+            export_notebooks("dom-1", "proj-1", "us-east-1")
+
+    @patch(PATCH_S3)
+    @patch(PATCH_DZ)
+    def test_partial_export_failure_raises_system_exit(self, mock_dz, mock_s3):
+        """One notebook fails export, one succeeds → SystemExit with failed ID listed."""
+        dz = MagicMock()
+        dz.list_notebooks.return_value = {
+            "items": [{"id": "nb-ok"}, {"id": "nb-fail"}]
+        }
+
+        def get_notebook(domainIdentifier, notebookIdentifier):
+            return _make_get_notebook_response(notebookIdentifier)
+
+        def start_export(domainIdentifier, notebookIdentifier, **kwargs):
+            if notebookIdentifier == "nb-fail":
+                raise Exception("ExportError")
+            return {"exportIdentifier": "exp-ok"}
+
+        dz.get_notebook.side_effect = get_notebook
+        dz.start_notebook_export.side_effect = start_export
+        dz.get_notebook_export.return_value = {
+            "status": "SUCCEEDED",
+            "outputLocation": "s3://bucket/nb-ok.ipynb",
+        }
+        mock_dz.return_value = dz
+        mock_s3.return_value = self._make_s3_client_with_content()
+
+        with self.assertRaises(SystemExit) as ctx:
+            export_notebooks("dom-1", "proj-1", "us-east-1")
+        self.assertIn("nb-fail", str(ctx.exception))
+
+    @patch(PATCH_S3)
+    @patch(PATCH_DZ)
+    def test_export_file_content_saved_in_returned_object(self, mock_dz, mock_s3):
+        ipynb_content = b'{"cells": [], "metadata": {}, "nbformat": 4}'
+        dz = MagicMock()
+        dz.get_notebook.return_value = _make_get_notebook_response("nb-1")
+        dz.start_notebook_export.return_value = {"exportIdentifier": "exp-1"}
+        dz.get_notebook_export.return_value = {
+            "status": "SUCCEEDED",
+            "outputLocation": "s3://bucket/nb-1.ipynb",
+        }
+        mock_dz.return_value = dz
+        s3 = MagicMock()
+        s3.get_object.return_value = {"Body": MagicMock(read=MagicMock(return_value=ipynb_content))}
+        mock_s3.return_value = s3
+
+        exported, _ = export_notebooks("dom-1", "proj-1", "us-east-1", notebook_ids=["nb-1"])
+        self.assertEqual(exported[0].file_content, ipynb_content)
+
+    @patch(PATCH_S3)
+    @patch(PATCH_DZ)
+    def test_file_path_uses_notebook_id(self, mock_dz, mock_s3):
+        dz = MagicMock()
+        dz.get_notebook.return_value = _make_get_notebook_response("nb-abc123")
+        dz.start_notebook_export.return_value = {"exportIdentifier": "exp-1"}
+        dz.get_notebook_export.return_value = {
+            "status": "SUCCEEDED",
+            "outputLocation": "s3://bucket/nb.ipynb",
+        }
+        mock_dz.return_value = dz
+        mock_s3.return_value = self._make_s3_client_with_content()
+
+        exported, _ = export_notebooks("dom-1", "proj-1", "us-east-1", notebook_ids=["nb-abc123"])
+        self.assertEqual(exported[0].file_path, "notebooks/nb-abc123.ipynb")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/helpers/test_notebook_export.py
+++ b/tests/unit/helpers/test_notebook_export.py
@@ -11,7 +11,7 @@ Covers:
 
 import json
 import unittest
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 from botocore.exceptions import ClientError
 
@@ -25,16 +25,18 @@ from smus_cicd.helpers.notebook_export import (
     export_notebooks,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _client_error(code, message="error"):
     return ClientError({"Error": {"Code": code, "Message": message}}, "Op")
 
 
-def _make_get_notebook_response(nb_id, name="Test NB", params=None, meta=None, env=None):
+def _make_get_notebook_response(
+    nb_id, name="Test NB", params=None, meta=None, env=None
+):
     return {
         "id": nb_id,
         "name": name,
@@ -63,15 +65,18 @@ def _make_exported_notebook(nb_id, name="NB"):
 # _validate_notebook_ids
 # ---------------------------------------------------------------------------
 
+
 class TestValidateNotebookIds(unittest.TestCase):
 
     def _mock_client(self, valid_ids, invalid_ids):
         """Build a mock DZ client that succeeds for valid_ids, raises ResourceNotFoundException for invalid_ids."""
         client = MagicMock()
-        def get_notebook(domainIdentifier, notebookIdentifier):
-            if notebookIdentifier in invalid_ids:
+
+        def get_notebook(domainIdentifier, identifier):
+            if identifier in invalid_ids:
                 raise _client_error("ResourceNotFoundException")
-            return _make_get_notebook_response(notebookIdentifier)
+            return _make_get_notebook_response(identifier)
+
         client.get_notebook.side_effect = get_notebook
         return client
 
@@ -104,7 +109,10 @@ class TestValidateNotebookIds(unittest.TestCase):
             "nb-1",
             params={"key": "val"},
             meta={"owner": "team"},
-            env={"imageVersion": "v1", "packageConfig": {"packageManager": "pip", "packageSpecification": ""}},
+            env={
+                "imageVersion": "v1",
+                "packageConfig": {"packageManager": "pip", "packageSpecification": ""},
+            },
         )
         valid, _ = _validate_notebook_ids(client, "dom-1", ["nb-1"])
         self.assertEqual(valid[0]["parameters"], {"key": "val"})
@@ -131,13 +139,12 @@ class TestValidateNotebookIds(unittest.TestCase):
 # _list_all_notebooks
 # ---------------------------------------------------------------------------
 
+
 class TestListAllNotebooks(unittest.TestCase):
 
     def test_single_page_returns_all_items(self):
         client = MagicMock()
-        client.list_notebooks.return_value = {
-            "items": [{"id": "nb-1"}, {"id": "nb-2"}]
-        }
+        client.list_notebooks.return_value = {"items": [{"id": "nb-1"}, {"id": "nb-2"}]}
         result = _list_all_notebooks(client, "dom-1", "proj-1")
         self.assertEqual(len(result), 2)
 
@@ -180,6 +187,7 @@ class TestListAllNotebooks(unittest.TestCase):
 # ---------------------------------------------------------------------------
 # _compute_backoff_delay
 # ---------------------------------------------------------------------------
+
 
 class TestComputeBackoffDelay(unittest.TestCase):
     """Property 8: delay for attempt i equals min(initial × 2^i, max_interval)."""
@@ -227,6 +235,7 @@ class TestComputeBackoffDelay(unittest.TestCase):
 # _poll_export_status
 # ---------------------------------------------------------------------------
 
+
 class TestPollExportStatus(unittest.TestCase):
 
     @patch("smus_cicd.helpers.notebook_export.time.sleep")
@@ -260,7 +269,9 @@ class TestPollExportStatus(unittest.TestCase):
         mock_mono.side_effect = [0.0, 400.0, 400.0]
         client = MagicMock()
         client.get_notebook_export.return_value = {"status": "IN_PROGRESS"}
-        result = _poll_export_status(client, "dom-1", "exp-1", "nb-1", polling_timeout=300)
+        result = _poll_export_status(
+            client, "dom-1", "exp-1", "nb-1", polling_timeout=300
+        )
         self.assertIsNone(result)
 
     @patch("smus_cicd.helpers.notebook_export.time.sleep")
@@ -284,6 +295,7 @@ class TestPollExportStatus(unittest.TestCase):
 # ---------------------------------------------------------------------------
 # _build_export_manifest
 # ---------------------------------------------------------------------------
+
 
 class TestBuildExportManifest(unittest.TestCase):
 
@@ -320,13 +332,22 @@ class TestBuildExportManifest(unittest.TestCase):
             exported_at="2024-01-01T00:00:00Z",
             parameters={"k": "v"},
             metadata={"owner": "team"},
-            environment_configuration={"imageVersion": "v1", "packageConfig": {"packageManager": "pip", "packageSpecification": ""}},
+            environment_configuration={
+                "imageVersion": "v1",
+                "packageConfig": {"packageManager": "pip", "packageSpecification": ""},
+            },
         )
         manifest = _build_export_manifest([nb], "dom-1", "proj-1")
         entry = manifest["notebooks"][0]
         required = {
-            "sourceNotebookId", "name", "description", "filePath",
-            "exportedAt", "parameters", "metadata", "environmentConfiguration",
+            "sourceNotebookId",
+            "name",
+            "description",
+            "filePath",
+            "exportedAt",
+            "parameters",
+            "metadata",
+            "environmentConfiguration",
         }
         self.assertEqual(set(entry.keys()), required)
         self.assertEqual(entry["sourceNotebookId"], "nb-abc")
@@ -361,12 +382,12 @@ class TestExportNotebooks(unittest.TestCase):
         valid_ids = valid_ids or []
         notebook_details = notebook_details or {}
 
-        def get_notebook(domainIdentifier, notebookIdentifier):
-            if notebookIdentifier not in valid_ids:
+        def get_notebook(domainIdentifier, identifier):
+            if identifier not in valid_ids:
                 raise _client_error("ResourceNotFoundException")
             return notebook_details.get(
-                notebookIdentifier,
-                _make_get_notebook_response(notebookIdentifier),
+                identifier,
+                _make_get_notebook_response(identifier),
             )
 
         client = MagicMock()
@@ -375,7 +396,9 @@ class TestExportNotebooks(unittest.TestCase):
 
     def _make_s3_client_with_content(self, content=b'{"cells":[]}'):
         s3 = MagicMock()
-        s3.get_object.return_value = {"Body": MagicMock(read=MagicMock(return_value=content))}
+        s3.get_object.return_value = {
+            "Body": MagicMock(read=MagicMock(return_value=content))
+        }
         return s3
 
     # ── notebook_ids specified path ──────────────────────────────────────
@@ -383,10 +406,14 @@ class TestExportNotebooks(unittest.TestCase):
     @patch(PATCH_S3)
     @patch(PATCH_DZ)
     def test_invalid_ids_raises_system_exit(self, mock_dz, mock_s3):
-        mock_dz.return_value = self._make_dz_client(valid_ids=["nb-1"], notebook_details={})
+        mock_dz.return_value = self._make_dz_client(
+            valid_ids=["nb-1"], notebook_details={}
+        )
         mock_s3.return_value = MagicMock()
         with self.assertRaises(SystemExit) as ctx:
-            export_notebooks("dom-1", "proj-1", "us-east-1", notebook_ids=["nb-1", "nb-bad"])
+            export_notebooks(
+                "dom-1", "proj-1", "us-east-1", notebook_ids=["nb-1", "nb-bad"]
+            )
         self.assertIn("nb-bad", str(ctx.exception))
 
     @patch(PATCH_S3)
@@ -397,7 +424,9 @@ class TestExportNotebooks(unittest.TestCase):
         mock_dz.return_value = dz
         mock_s3.return_value = MagicMock()
         with self.assertRaises(SystemExit) as ctx:
-            export_notebooks("dom-1", "proj-1", "us-east-1", notebook_ids=["nb-a", "nb-b"])
+            export_notebooks(
+                "dom-1", "proj-1", "us-east-1", notebook_ids=["nb-a", "nb-b"]
+            )
         error_msg = str(ctx.exception)
         self.assertIn("nb-a", error_msg)
         self.assertIn("nb-b", error_msg)
@@ -407,7 +436,7 @@ class TestExportNotebooks(unittest.TestCase):
     def test_valid_ids_exports_and_returns_manifest(self, mock_dz, mock_s3):
         dz = MagicMock()
         dz.get_notebook.return_value = _make_get_notebook_response("nb-1")
-        dz.start_notebook_export.return_value = {"exportIdentifier": "exp-1"}
+        dz.start_notebook_export.return_value = {"id": "exp-1"}
         dz.get_notebook_export.return_value = {
             "status": "SUCCEEDED",
             "outputLocation": "s3://bucket/nb-1.ipynb",
@@ -445,7 +474,7 @@ class TestExportNotebooks(unittest.TestCase):
         dz.list_notebooks.return_value = {"items": [{"id": "nb-2", "name": "NB2"}]}
         # GetNotebook (for full details) returns full response
         dz.get_notebook.return_value = _make_get_notebook_response("nb-2")
-        dz.start_notebook_export.return_value = {"exportIdentifier": "exp-2"}
+        dz.start_notebook_export.return_value = {"id": "exp-2"}
         dz.get_notebook_export.return_value = {
             "status": "SUCCEEDED",
             "outputLocation": "s3://bucket/nb-2.ipynb",
@@ -459,7 +488,9 @@ class TestExportNotebooks(unittest.TestCase):
 
     @patch(PATCH_S3)
     @patch(PATCH_DZ)
-    def test_discovery_mode_empty_project_returns_empty_manifest(self, mock_dz, mock_s3):
+    def test_discovery_mode_empty_project_returns_empty_manifest(
+        self, mock_dz, mock_s3
+    ):
         dz = MagicMock()
         dz.list_notebooks.return_value = {"items": []}
         mock_dz.return_value = dz
@@ -486,17 +517,15 @@ class TestExportNotebooks(unittest.TestCase):
     def test_partial_export_failure_raises_system_exit(self, mock_dz, mock_s3):
         """One notebook fails export, one succeeds → SystemExit with failed ID listed."""
         dz = MagicMock()
-        dz.list_notebooks.return_value = {
-            "items": [{"id": "nb-ok"}, {"id": "nb-fail"}]
-        }
+        dz.list_notebooks.return_value = {"items": [{"id": "nb-ok"}, {"id": "nb-fail"}]}
 
-        def get_notebook(domainIdentifier, notebookIdentifier):
-            return _make_get_notebook_response(notebookIdentifier)
+        def get_notebook(domainIdentifier, identifier):
+            return _make_get_notebook_response(identifier)
 
         def start_export(domainIdentifier, notebookIdentifier, **kwargs):
             if notebookIdentifier == "nb-fail":
                 raise Exception("ExportError")
-            return {"exportIdentifier": "exp-ok"}
+            return {"id": "exp-ok"}
 
         dz.get_notebook.side_effect = get_notebook
         dz.start_notebook_export.side_effect = start_export
@@ -517,17 +546,21 @@ class TestExportNotebooks(unittest.TestCase):
         ipynb_content = b'{"cells": [], "metadata": {}, "nbformat": 4}'
         dz = MagicMock()
         dz.get_notebook.return_value = _make_get_notebook_response("nb-1")
-        dz.start_notebook_export.return_value = {"exportIdentifier": "exp-1"}
+        dz.start_notebook_export.return_value = {"id": "exp-1"}
         dz.get_notebook_export.return_value = {
             "status": "SUCCEEDED",
             "outputLocation": "s3://bucket/nb-1.ipynb",
         }
         mock_dz.return_value = dz
         s3 = MagicMock()
-        s3.get_object.return_value = {"Body": MagicMock(read=MagicMock(return_value=ipynb_content))}
+        s3.get_object.return_value = {
+            "Body": MagicMock(read=MagicMock(return_value=ipynb_content))
+        }
         mock_s3.return_value = s3
 
-        exported, _ = export_notebooks("dom-1", "proj-1", "us-east-1", notebook_ids=["nb-1"])
+        exported, _ = export_notebooks(
+            "dom-1", "proj-1", "us-east-1", notebook_ids=["nb-1"]
+        )
         self.assertEqual(exported[0].file_content, ipynb_content)
 
     @patch(PATCH_S3)
@@ -535,7 +568,7 @@ class TestExportNotebooks(unittest.TestCase):
     def test_file_path_uses_notebook_id(self, mock_dz, mock_s3):
         dz = MagicMock()
         dz.get_notebook.return_value = _make_get_notebook_response("nb-abc123")
-        dz.start_notebook_export.return_value = {"exportIdentifier": "exp-1"}
+        dz.start_notebook_export.return_value = {"id": "exp-1"}
         dz.get_notebook_export.return_value = {
             "status": "SUCCEEDED",
             "outputLocation": "s3://bucket/nb.ipynb",
@@ -543,7 +576,9 @@ class TestExportNotebooks(unittest.TestCase):
         mock_dz.return_value = dz
         mock_s3.return_value = self._make_s3_client_with_content()
 
-        exported, _ = export_notebooks("dom-1", "proj-1", "us-east-1", notebook_ids=["nb-abc123"])
+        exported, _ = export_notebooks(
+            "dom-1", "proj-1", "us-east-1", notebook_ids=["nb-abc123"]
+        )
         self.assertEqual(exported[0].file_path, "notebooks/nb-abc123.ipynb")
 
 

--- a/tests/unit/helpers/test_notebook_import.py
+++ b/tests/unit/helpers/test_notebook_import.py
@@ -10,7 +10,6 @@ Covers:
     missing S3 connection, missing file in bundle
 """
 
-import hashlib
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -18,8 +17,6 @@ from botocore.exceptions import ClientError
 
 from smus_cicd.helpers.notebook_import import (
     SOURCE_NOTEBOOK_METADATA_KEY,
-    NotebookSyncSummary,
-    SyncStatus,
     _build_update_kwargs,
     _discover_target_notebooks,
     _generate_client_token,
@@ -27,10 +24,10 @@ from smus_cicd.helpers.notebook_import import (
     sync_notebooks,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _client_error(code, message="error"):
     return ClientError({"Error": {"Code": code, "Message": message}}, "Op")
@@ -48,8 +45,14 @@ def _make_manifest(notebooks=None, source_project="proj-src", source_domain="dom
     }
 
 
-def _make_entry(nb_id="nb-1", name="NB", description="Desc",
-                parameters=None, metadata=None, env_config=None):
+def _make_entry(
+    nb_id="nb-1",
+    name="NB",
+    description="Desc",
+    parameters=None,
+    metadata=None,
+    env_config=None,
+):
     return {
         "sourceNotebookId": nb_id,
         "name": name,
@@ -66,6 +69,7 @@ def _make_entry(nb_id="nb-1", name="NB", description="Desc",
 # _validate_notebook_manifest
 # ---------------------------------------------------------------------------
 
+
 class TestValidateNotebookManifest(unittest.TestCase):
 
     def test_valid_manifest_passes(self):
@@ -79,10 +83,16 @@ class TestValidateNotebookManifest(unittest.TestCase):
 
     def test_missing_notebooks_key_raises(self):
         with self.assertRaises(ValueError) as ctx:
-            _validate_notebook_manifest({"metadata": {
-                "sourceProjectId": "p", "sourceDomainId": "d",
-                "exportTimestamp": "t", "notebookCount": 0,
-            }})
+            _validate_notebook_manifest(
+                {
+                    "metadata": {
+                        "sourceProjectId": "p",
+                        "sourceDomainId": "d",
+                        "exportTimestamp": "t",
+                        "notebookCount": 0,
+                    }
+                }
+            )
         self.assertIn("notebooks", str(ctx.exception))
 
     def test_missing_source_project_id_raises(self):
@@ -120,6 +130,7 @@ class TestValidateNotebookManifest(unittest.TestCase):
 # _generate_client_token
 # ---------------------------------------------------------------------------
 
+
 class TestGenerateClientToken(unittest.TestCase):
     """Property 5: deterministic, ≤ 64 chars, distinct inputs → distinct outputs."""
 
@@ -152,6 +163,7 @@ class TestGenerateClientToken(unittest.TestCase):
 # _build_update_kwargs  (Property 7)
 # ---------------------------------------------------------------------------
 
+
 class TestBuildUpdateKwargs(unittest.TestCase):
 
     def _kwargs(self, **entry_overrides):
@@ -164,7 +176,7 @@ class TestBuildUpdateKwargs(unittest.TestCase):
         if "metadata" in entry_overrides:
             entry["metadata"] = entry_overrides.pop("metadata")
         entry.update(entry_overrides)
-        return _build_update_kwargs("dom-1", "proj-1", "tgt-nb-1", entry)
+        return _build_update_kwargs("dom-1", "tgt-nb-1", entry)
 
     def test_always_includes_name_and_description(self):
         kwargs = self._kwargs(name="My NB", description="Some desc")
@@ -207,19 +219,35 @@ class TestBuildUpdateKwargs(unittest.TestCase):
         self.assertNotIn("environmentConfiguration", kwargs)
 
     def test_environment_configuration_included_when_set(self):
-        env = {"imageVersion": "v2", "packageConfig": {"packageManager": "pip", "packageSpecification": "pandas"}}
+        env = {
+            "imageVersion": "v2",
+            "packageConfig": {
+                "packageManager": "pip",
+                "packageSpecification": "pandas",
+            },
+        }
         kwargs = self._kwargs(env_config=env)
         self.assertEqual(kwargs["environmentConfiguration"], env)
 
     def test_required_api_fields_always_present(self):
         kwargs = self._kwargs()
-        for field in ("domainIdentifier", "identifier", "owningProjectIdentifier", "name", "description", "metadata"):
+        # UpdateNotebook takes domainIdentifier + identifier (both required)
+        # plus name/description/metadata. It does NOT accept
+        # owningProjectIdentifier — passing it would fail botocore validation.
+        for field in (
+            "domainIdentifier",
+            "identifier",
+            "name",
+            "description",
+            "metadata",
+        ):
             self.assertIn(field, kwargs)
 
 
 # ---------------------------------------------------------------------------
 # _discover_target_notebooks
 # ---------------------------------------------------------------------------
+
 
 class TestDiscoverTargetNotebooks(unittest.TestCase):
 
@@ -230,31 +258,33 @@ class TestDiscoverTargetNotebooks(unittest.TestCase):
         """
         client = MagicMock()
         ids = list(notebook_metadata_map.keys())
-        client.list_notebooks.return_value = {
-            "items": [{"id": nb_id} for nb_id in ids]
-        }
+        client.list_notebooks.return_value = {"items": [{"id": nb_id} for nb_id in ids]}
 
-        def get_notebook(domainIdentifier, notebookIdentifier):
-            meta = notebook_metadata_map.get(notebookIdentifier, {})
-            return {"id": notebookIdentifier, "name": notebookIdentifier, "metadata": meta}
+        def get_notebook(domainIdentifier, identifier):
+            meta = notebook_metadata_map.get(identifier, {})
+            return {"id": identifier, "name": identifier, "metadata": meta}
 
         client.get_notebook.side_effect = get_notebook
         return client
 
     def test_notebooks_with_tracking_key_are_mapped(self):
-        client = self._make_dz_client({
-            "tgt-1": {SOURCE_NOTEBOOK_METADATA_KEY: "src-1"},
-            "tgt-2": {SOURCE_NOTEBOOK_METADATA_KEY: "src-2"},
-        })
+        client = self._make_dz_client(
+            {
+                "tgt-1": {SOURCE_NOTEBOOK_METADATA_KEY: "src-1"},
+                "tgt-2": {SOURCE_NOTEBOOK_METADATA_KEY: "src-2"},
+            }
+        )
         result = _discover_target_notebooks(client, "dom-1", "proj-1")
         self.assertEqual(result["src-1"], "tgt-1")
         self.assertEqual(result["src-2"], "tgt-2")
 
     def test_notebooks_without_tracking_key_are_excluded(self):
-        client = self._make_dz_client({
-            "tgt-managed": {},  # no tracking key
-            "tgt-cicd": {SOURCE_NOTEBOOK_METADATA_KEY: "src-1"},
-        })
+        client = self._make_dz_client(
+            {
+                "tgt-managed": {},  # no tracking key
+                "tgt-cicd": {SOURCE_NOTEBOOK_METADATA_KEY: "src-1"},
+            }
+        )
         result = _discover_target_notebooks(client, "dom-1", "proj-1")
         self.assertIn("src-1", result)
         self.assertNotIn("tgt-managed", result.values())
@@ -273,10 +303,10 @@ class TestDiscoverTargetNotebooks(unittest.TestCase):
             {"items": [{"id": "tgt-2"}]},
         ]
 
-        def get_notebook(domainIdentifier, notebookIdentifier):
+        def get_notebook(domainIdentifier, identifier):
             return {
-                "id": notebookIdentifier,
-                "metadata": {SOURCE_NOTEBOOK_METADATA_KEY: f"src-{notebookIdentifier}"},
+                "id": identifier,
+                "metadata": {SOURCE_NOTEBOOK_METADATA_KEY: f"src-{identifier}"},
             }
 
         client.get_notebook.side_effect = get_notebook
@@ -286,12 +316,17 @@ class TestDiscoverTargetNotebooks(unittest.TestCase):
 
     def test_get_notebook_failure_skips_that_notebook(self):
         client = MagicMock()
-        client.list_notebooks.return_value = {"items": [{"id": "tgt-bad"}, {"id": "tgt-ok"}]}
+        client.list_notebooks.return_value = {
+            "items": [{"id": "tgt-bad"}, {"id": "tgt-ok"}]
+        }
 
-        def get_notebook(domainIdentifier, notebookIdentifier):
-            if notebookIdentifier == "tgt-bad":
+        def get_notebook(domainIdentifier, identifier):
+            if identifier == "tgt-bad":
                 raise Exception("GetNotebookError")
-            return {"id": notebookIdentifier, "metadata": {SOURCE_NOTEBOOK_METADATA_KEY: "src-ok"}}
+            return {
+                "id": identifier,
+                "metadata": {SOURCE_NOTEBOOK_METADATA_KEY: "src-ok"},
+            }
 
         client.get_notebook.side_effect = get_notebook
         result = _discover_target_notebooks(client, "dom-1", "proj-1")
@@ -328,7 +363,9 @@ class TestSyncNotebooks(unittest.TestCase):
     def test_invalid_manifest_raises_before_api_calls(self):
         with self.assertRaises(ValueError):
             sync_notebooks(
-                "dom-1", "proj-1", "us-east-1",
+                "dom-1",
+                "proj-1",
+                "us-east-1",
                 manifest_data={"metadata": {}},  # missing notebooks key
                 notebook_files={},
                 s3_uri=S3_URI,
@@ -337,7 +374,9 @@ class TestSyncNotebooks(unittest.TestCase):
     def test_missing_s3_uri_raises_value_error(self):
         with self.assertRaises(ValueError):
             sync_notebooks(
-                "dom-1", "proj-1", "us-east-1",
+                "dom-1",
+                "proj-1",
+                "us-east-1",
                 manifest_data=_make_manifest(),
                 notebook_files={},
                 s3_uri="",
@@ -354,7 +393,9 @@ class TestSyncNotebooks(unittest.TestCase):
 
         manifest = _make_manifest(notebooks=[_make_entry("nb-1")])
         summary = sync_notebooks(
-            "dom-1", "proj-1", "us-east-1",
+            "dom-1",
+            "proj-1",
+            "us-east-1",
             manifest_data=manifest,
             notebook_files=NOTEBOOK_FILES,
             s3_uri=S3_URI,
@@ -365,15 +406,21 @@ class TestSyncNotebooks(unittest.TestCase):
 
     @patch(PATCH_S3)
     @patch(PATCH_DZ)
-    def test_start_notebook_sync_called_without_notebook_id_for_new(self, mock_dz, mock_s3):
+    def test_start_notebook_sync_called_without_notebook_id_for_new(
+        self, mock_dz, mock_s3
+    ):
         dz = self._make_dz_no_existing()
         mock_dz.return_value = dz
         mock_s3.return_value = self._make_s3()
 
         manifest = _make_manifest(notebooks=[_make_entry("nb-1")])
         sync_notebooks(
-            "dom-1", "proj-1", "us-east-1",
-            manifest_data=manifest, notebook_files=NOTEBOOK_FILES, s3_uri=S3_URI,
+            "dom-1",
+            "proj-1",
+            "us-east-1",
+            manifest_data=manifest,
+            notebook_files=NOTEBOOK_FILES,
+            s3_uri=S3_URI,
         )
         call_kwargs = dz.start_notebook_sync.call_args[1]
         self.assertNotIn("notebookId", call_kwargs)
@@ -397,8 +444,12 @@ class TestSyncNotebooks(unittest.TestCase):
 
         manifest = _make_manifest(notebooks=[_make_entry("nb-1")])
         summary = sync_notebooks(
-            "dom-1", "proj-1", "us-east-1",
-            manifest_data=manifest, notebook_files=NOTEBOOK_FILES, s3_uri=S3_URI,
+            "dom-1",
+            "proj-1",
+            "us-east-1",
+            manifest_data=manifest,
+            notebook_files=NOTEBOOK_FILES,
+            s3_uri=S3_URI,
         )
         self.assertEqual(summary.updated, 1)
         self.assertEqual(summary.created, 0)
@@ -423,7 +474,12 @@ class TestSyncNotebooks(unittest.TestCase):
             call_count[0] += 1
             if kwargs.get("notebookId") == "tgt-deleted":
                 raise ClientError(
-                    {"Error": {"Code": "ResourceNotFoundException", "Message": "Not found"}},
+                    {
+                        "Error": {
+                            "Code": "ResourceNotFoundException",
+                            "Message": "Not found",
+                        }
+                    },
                     "StartNotebookSync",
                 )
             return {"notebookId": "brand-new-id"}
@@ -435,8 +491,12 @@ class TestSyncNotebooks(unittest.TestCase):
 
         manifest = _make_manifest(notebooks=[_make_entry("nb-1")])
         summary = sync_notebooks(
-            "dom-1", "proj-1", "us-east-1",
-            manifest_data=manifest, notebook_files=NOTEBOOK_FILES, s3_uri=S3_URI,
+            "dom-1",
+            "proj-1",
+            "us-east-1",
+            manifest_data=manifest,
+            notebook_files=NOTEBOOK_FILES,
+            s3_uri=S3_URI,
         )
         # Should have retried without notebookId and created
         self.assertEqual(summary.failed, 0)
@@ -454,8 +514,12 @@ class TestSyncNotebooks(unittest.TestCase):
 
         manifest = _make_manifest(notebooks=[_make_entry("nb-1")])
         summary = sync_notebooks(
-            "dom-1", "proj-1", "us-east-1",
-            manifest_data=manifest, notebook_files=NOTEBOOK_FILES, s3_uri=S3_URI,
+            "dom-1",
+            "proj-1",
+            "us-east-1",
+            manifest_data=manifest,
+            notebook_files=NOTEBOOK_FILES,
+            s3_uri=S3_URI,
         )
         self.assertEqual(summary.failed, 1)
         self.assertIn("nb-1", summary.failed_ids)
@@ -471,8 +535,12 @@ class TestSyncNotebooks(unittest.TestCase):
         manifest = _make_manifest(notebooks=[_make_entry("nb-missing")])
         # notebook_files dict is empty — file is missing
         summary = sync_notebooks(
-            "dom-1", "proj-1", "us-east-1",
-            manifest_data=manifest, notebook_files={}, s3_uri=S3_URI,
+            "dom-1",
+            "proj-1",
+            "us-east-1",
+            manifest_data=manifest,
+            notebook_files={},
+            s3_uri=S3_URI,
         )
         self.assertEqual(summary.failed, 1)
         self.assertIn("nb-missing", summary.failed_ids)
@@ -489,8 +557,12 @@ class TestSyncNotebooks(unittest.TestCase):
 
         manifest = _make_manifest(notebooks=[_make_entry("nb-1")])
         summary = sync_notebooks(
-            "dom-1", "proj-1", "us-east-1",
-            manifest_data=manifest, notebook_files=NOTEBOOK_FILES, s3_uri=S3_URI,
+            "dom-1",
+            "proj-1",
+            "us-east-1",
+            manifest_data=manifest,
+            notebook_files=NOTEBOOK_FILES,
+            s3_uri=S3_URI,
         )
         self.assertEqual(summary.failed, 1)
         self.assertEqual(summary.created, 0)
@@ -510,8 +582,12 @@ class TestSyncNotebooks(unittest.TestCase):
         manifest = _make_manifest(notebooks=entries)
 
         summary = sync_notebooks(
-            "dom-1", "proj-1", "us-east-1",
-            manifest_data=manifest, notebook_files=notebook_files, s3_uri=S3_URI,
+            "dom-1",
+            "proj-1",
+            "us-east-1",
+            manifest_data=manifest,
+            notebook_files=notebook_files,
+            s3_uri=S3_URI,
         )
         self.assertEqual(summary.total, 5)
         self.assertEqual(summary.created + summary.updated + summary.failed, 5)
@@ -526,8 +602,12 @@ class TestSyncNotebooks(unittest.TestCase):
 
         manifest = _make_manifest(notebooks=[])
         summary = sync_notebooks(
-            "dom-1", "proj-1", "us-east-1",
-            manifest_data=manifest, notebook_files={}, s3_uri=S3_URI,
+            "dom-1",
+            "proj-1",
+            "us-east-1",
+            manifest_data=manifest,
+            notebook_files={},
+            s3_uri=S3_URI,
         )
         self.assertEqual(summary.created, 0)
         self.assertEqual(summary.updated, 0)
@@ -544,12 +624,18 @@ class TestSyncNotebooks(unittest.TestCase):
 
         manifest = _make_manifest(notebooks=[_make_entry("nb-1", metadata={})])
         sync_notebooks(
-            "dom-1", "proj-1", "us-east-1",
-            manifest_data=manifest, notebook_files=NOTEBOOK_FILES, s3_uri=S3_URI,
+            "dom-1",
+            "proj-1",
+            "us-east-1",
+            manifest_data=manifest,
+            notebook_files=NOTEBOOK_FILES,
+            s3_uri=S3_URI,
         )
         update_kwargs = dz.update_notebook.call_args[1]
         self.assertIn(SOURCE_NOTEBOOK_METADATA_KEY, update_kwargs["metadata"])
-        self.assertEqual(update_kwargs["metadata"][SOURCE_NOTEBOOK_METADATA_KEY], "nb-1")
+        self.assertEqual(
+            update_kwargs["metadata"][SOURCE_NOTEBOOK_METADATA_KEY], "nb-1"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/helpers/test_notebook_import.py
+++ b/tests/unit/helpers/test_notebook_import.py
@@ -1,0 +1,556 @@
+"""Unit tests for notebook_import.py.
+
+Covers:
+  - _validate_notebook_manifest: required key checks
+  - _generate_client_token: determinism, length bound, distinct outputs
+  - _build_update_kwargs: Property 7 rules (metadata key always present,
+    parameters omitted when empty, environmentConfiguration omitted when None)
+  - _discover_target_notebooks: pagination, metadata filtering
+  - sync_notebooks: happy paths (create, update, fallback), partial failures,
+    missing S3 connection, missing file in bundle
+"""
+
+import hashlib
+import unittest
+from unittest.mock import MagicMock, patch
+
+from botocore.exceptions import ClientError
+
+from smus_cicd.helpers.notebook_import import (
+    SOURCE_NOTEBOOK_METADATA_KEY,
+    NotebookSyncSummary,
+    SyncStatus,
+    _build_update_kwargs,
+    _discover_target_notebooks,
+    _generate_client_token,
+    _validate_notebook_manifest,
+    sync_notebooks,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _client_error(code, message="error"):
+    return ClientError({"Error": {"Code": code, "Message": message}}, "Op")
+
+
+def _make_manifest(notebooks=None, source_project="proj-src", source_domain="dom-1"):
+    return {
+        "metadata": {
+            "sourceProjectId": source_project,
+            "sourceDomainId": source_domain,
+            "exportTimestamp": "2024-01-01T00:00:00Z",
+            "notebookCount": len(notebooks or []),
+        },
+        "notebooks": notebooks or [],
+    }
+
+
+def _make_entry(nb_id="nb-1", name="NB", description="Desc",
+                parameters=None, metadata=None, env_config=None):
+    return {
+        "sourceNotebookId": nb_id,
+        "name": name,
+        "description": description,
+        "filePath": f"notebooks/{nb_id}.ipynb",
+        "exportedAt": "2024-01-01T00:00:00Z",
+        "parameters": parameters if parameters is not None else {},
+        "metadata": metadata if metadata is not None else {},
+        "environmentConfiguration": env_config,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _validate_notebook_manifest
+# ---------------------------------------------------------------------------
+
+class TestValidateNotebookManifest(unittest.TestCase):
+
+    def test_valid_manifest_passes(self):
+        # Should not raise
+        _validate_notebook_manifest(_make_manifest())
+
+    def test_missing_metadata_key_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            _validate_notebook_manifest({"notebooks": []})
+        self.assertIn("metadata", str(ctx.exception))
+
+    def test_missing_notebooks_key_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            _validate_notebook_manifest({"metadata": {
+                "sourceProjectId": "p", "sourceDomainId": "d",
+                "exportTimestamp": "t", "notebookCount": 0,
+            }})
+        self.assertIn("notebooks", str(ctx.exception))
+
+    def test_missing_source_project_id_raises(self):
+        manifest = _make_manifest()
+        del manifest["metadata"]["sourceProjectId"]
+        with self.assertRaises(ValueError):
+            _validate_notebook_manifest(manifest)
+
+    def test_missing_source_domain_id_raises(self):
+        manifest = _make_manifest()
+        del manifest["metadata"]["sourceDomainId"]
+        with self.assertRaises(ValueError):
+            _validate_notebook_manifest(manifest)
+
+    def test_missing_export_timestamp_raises(self):
+        manifest = _make_manifest()
+        del manifest["metadata"]["exportTimestamp"]
+        with self.assertRaises(ValueError):
+            _validate_notebook_manifest(manifest)
+
+    def test_missing_notebook_count_raises(self):
+        manifest = _make_manifest()
+        del manifest["metadata"]["notebookCount"]
+        with self.assertRaises(ValueError):
+            _validate_notebook_manifest(manifest)
+
+    def test_no_api_calls_before_validation(self):
+        """Validation is pure — no API calls should be made."""
+        # Just calling _validate_notebook_manifest is enough; if it didn't raise
+        # on a valid manifest, we know it was fast/pure
+        _validate_notebook_manifest(_make_manifest())  # no mocks needed
+
+
+# ---------------------------------------------------------------------------
+# _generate_client_token
+# ---------------------------------------------------------------------------
+
+class TestGenerateClientToken(unittest.TestCase):
+    """Property 5: deterministic, ≤ 64 chars, distinct inputs → distinct outputs."""
+
+    def test_same_inputs_produce_same_token(self):
+        t1 = _generate_client_token("nb-1", "2024-01-01T00:00:00")
+        t2 = _generate_client_token("nb-1", "2024-01-01T00:00:00")
+        self.assertEqual(t1, t2)
+
+    def test_token_max_64_chars(self):
+        token = _generate_client_token("nb-abc123", "1700000000")
+        self.assertLessEqual(len(token), 64)
+
+    def test_different_notebook_ids_produce_different_tokens(self):
+        t1 = _generate_client_token("nb-1", "ts")
+        t2 = _generate_client_token("nb-2", "ts")
+        self.assertNotEqual(t1, t2)
+
+    def test_different_timestamps_produce_different_tokens(self):
+        t1 = _generate_client_token("nb-1", "ts-1")
+        t2 = _generate_client_token("nb-1", "ts-2")
+        self.assertNotEqual(t1, t2)
+
+    def test_long_source_id_stays_within_64_chars(self):
+        long_id = "a" * 36  # max valid ID length
+        token = _generate_client_token(long_id, "timestamp-" + "x" * 50)
+        self.assertLessEqual(len(token), 64)
+
+
+# ---------------------------------------------------------------------------
+# _build_update_kwargs  (Property 7)
+# ---------------------------------------------------------------------------
+
+class TestBuildUpdateKwargs(unittest.TestCase):
+
+    def _kwargs(self, **entry_overrides):
+        entry = _make_entry()
+        # Translate convenience kwarg names to manifest entry key names
+        if "env_config" in entry_overrides:
+            entry["environmentConfiguration"] = entry_overrides.pop("env_config")
+        if "parameters" in entry_overrides:
+            entry["parameters"] = entry_overrides.pop("parameters")
+        if "metadata" in entry_overrides:
+            entry["metadata"] = entry_overrides.pop("metadata")
+        entry.update(entry_overrides)
+        return _build_update_kwargs("dom-1", "proj-1", "tgt-nb-1", entry)
+
+    def test_always_includes_name_and_description(self):
+        kwargs = self._kwargs(name="My NB", description="Some desc")
+        self.assertEqual(kwargs["name"], "My NB")
+        self.assertEqual(kwargs["description"], "Some desc")
+
+    def test_metadata_always_contains_tracking_key(self):
+        """smus-cicd-source-notebook-id must always be present."""
+        kwargs = self._kwargs(metadata={})
+        self.assertIn(SOURCE_NOTEBOOK_METADATA_KEY, kwargs["metadata"])
+        self.assertEqual(kwargs["metadata"][SOURCE_NOTEBOOK_METADATA_KEY], "nb-1")
+
+    def test_tracking_key_merged_with_existing_metadata(self):
+        kwargs = self._kwargs(metadata={"owner": "team-ds", "version": "2.1"})
+        meta = kwargs["metadata"]
+        self.assertEqual(meta["owner"], "team-ds")
+        self.assertEqual(meta["version"], "2.1")
+        self.assertIn(SOURCE_NOTEBOOK_METADATA_KEY, meta)
+
+    def test_metadata_only_tracking_key_when_manifest_metadata_empty(self):
+        """Empty manifest metadata → metadata in kwargs contains only tracking key."""
+        kwargs = self._kwargs(metadata={})
+        self.assertEqual(
+            set(kwargs["metadata"].keys()),
+            {SOURCE_NOTEBOOK_METADATA_KEY},
+        )
+
+    def test_parameters_omitted_when_empty_dict(self):
+        """Property 7: parameters is omitted when empty."""
+        kwargs = self._kwargs(parameters={})
+        self.assertNotIn("parameters", kwargs)
+
+    def test_parameters_included_when_non_empty(self):
+        kwargs = self._kwargs(parameters={"dataset_path": "s3://b/d.csv"})
+        self.assertEqual(kwargs["parameters"], {"dataset_path": "s3://b/d.csv"})
+
+    def test_environment_configuration_omitted_when_none(self):
+        """Property 7: environmentConfiguration omitted when None."""
+        kwargs = self._kwargs(env_config=None)
+        self.assertNotIn("environmentConfiguration", kwargs)
+
+    def test_environment_configuration_included_when_set(self):
+        env = {"imageVersion": "v2", "packageConfig": {"packageManager": "pip", "packageSpecification": "pandas"}}
+        kwargs = self._kwargs(env_config=env)
+        self.assertEqual(kwargs["environmentConfiguration"], env)
+
+    def test_required_api_fields_always_present(self):
+        kwargs = self._kwargs()
+        for field in ("domainIdentifier", "identifier", "owningProjectIdentifier", "name", "description", "metadata"):
+            self.assertIn(field, kwargs)
+
+
+# ---------------------------------------------------------------------------
+# _discover_target_notebooks
+# ---------------------------------------------------------------------------
+
+class TestDiscoverTargetNotebooks(unittest.TestCase):
+
+    def _make_dz_client(self, notebook_metadata_map):
+        """
+        notebook_metadata_map: {nb_id: metadata_dict}
+        ListNotebooks returns all IDs; GetNotebook returns the metadata for each.
+        """
+        client = MagicMock()
+        ids = list(notebook_metadata_map.keys())
+        client.list_notebooks.return_value = {
+            "items": [{"id": nb_id} for nb_id in ids]
+        }
+
+        def get_notebook(domainIdentifier, notebookIdentifier):
+            meta = notebook_metadata_map.get(notebookIdentifier, {})
+            return {"id": notebookIdentifier, "name": notebookIdentifier, "metadata": meta}
+
+        client.get_notebook.side_effect = get_notebook
+        return client
+
+    def test_notebooks_with_tracking_key_are_mapped(self):
+        client = self._make_dz_client({
+            "tgt-1": {SOURCE_NOTEBOOK_METADATA_KEY: "src-1"},
+            "tgt-2": {SOURCE_NOTEBOOK_METADATA_KEY: "src-2"},
+        })
+        result = _discover_target_notebooks(client, "dom-1", "proj-1")
+        self.assertEqual(result["src-1"], "tgt-1")
+        self.assertEqual(result["src-2"], "tgt-2")
+
+    def test_notebooks_without_tracking_key_are_excluded(self):
+        client = self._make_dz_client({
+            "tgt-managed": {},  # no tracking key
+            "tgt-cicd": {SOURCE_NOTEBOOK_METADATA_KEY: "src-1"},
+        })
+        result = _discover_target_notebooks(client, "dom-1", "proj-1")
+        self.assertIn("src-1", result)
+        self.assertNotIn("tgt-managed", result.values())
+        self.assertEqual(len(result), 1)
+
+    def test_empty_project_returns_empty_map(self):
+        client = MagicMock()
+        client.list_notebooks.return_value = {"items": []}
+        result = _discover_target_notebooks(client, "dom-1", "proj-1")
+        self.assertEqual(result, {})
+
+    def test_pagination_followed(self):
+        client = MagicMock()
+        client.list_notebooks.side_effect = [
+            {"items": [{"id": "tgt-1"}], "nextToken": "tok"},
+            {"items": [{"id": "tgt-2"}]},
+        ]
+
+        def get_notebook(domainIdentifier, notebookIdentifier):
+            return {
+                "id": notebookIdentifier,
+                "metadata": {SOURCE_NOTEBOOK_METADATA_KEY: f"src-{notebookIdentifier}"},
+            }
+
+        client.get_notebook.side_effect = get_notebook
+        result = _discover_target_notebooks(client, "dom-1", "proj-1")
+        self.assertEqual(len(result), 2)
+        self.assertEqual(client.list_notebooks.call_count, 2)
+
+    def test_get_notebook_failure_skips_that_notebook(self):
+        client = MagicMock()
+        client.list_notebooks.return_value = {"items": [{"id": "tgt-bad"}, {"id": "tgt-ok"}]}
+
+        def get_notebook(domainIdentifier, notebookIdentifier):
+            if notebookIdentifier == "tgt-bad":
+                raise Exception("GetNotebookError")
+            return {"id": notebookIdentifier, "metadata": {SOURCE_NOTEBOOK_METADATA_KEY: "src-ok"}}
+
+        client.get_notebook.side_effect = get_notebook
+        result = _discover_target_notebooks(client, "dom-1", "proj-1")
+        self.assertEqual(result, {"src-ok": "tgt-ok"})
+
+
+# ---------------------------------------------------------------------------
+# sync_notebooks (public API)
+# ---------------------------------------------------------------------------
+
+PATCH_DZ = "smus_cicd.helpers.notebook_import._get_datazone_client"
+PATCH_S3 = "smus_cicd.helpers.notebook_import._get_s3_client"
+NOTEBOOK_FILES = {"notebooks/nb-1.ipynb": b'{"cells":[]}'}
+S3_URI = "s3://test-bucket/shared"
+
+
+class TestSyncNotebooks(unittest.TestCase):
+
+    def _make_dz_no_existing(self):
+        """DZ client where target project has no existing CI/CD notebooks."""
+        dz = MagicMock()
+        dz.list_notebooks.return_value = {"items": []}
+        dz.start_notebook_sync.return_value = {"notebookId": "new-nb-id"}
+        dz.update_notebook.return_value = {}
+        return dz
+
+    def _make_s3(self):
+        s3 = MagicMock()
+        s3.put_object.return_value = {}
+        return s3
+
+    # ── validation ────────────────────────────────────────────────────────
+
+    def test_invalid_manifest_raises_before_api_calls(self):
+        with self.assertRaises(ValueError):
+            sync_notebooks(
+                "dom-1", "proj-1", "us-east-1",
+                manifest_data={"metadata": {}},  # missing notebooks key
+                notebook_files={},
+                s3_uri=S3_URI,
+            )
+
+    def test_missing_s3_uri_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            sync_notebooks(
+                "dom-1", "proj-1", "us-east-1",
+                manifest_data=_make_manifest(),
+                notebook_files={},
+                s3_uri="",
+            )
+
+    # ── happy path: create ───────────────────────────────────────────────
+
+    @patch(PATCH_S3)
+    @patch(PATCH_DZ)
+    def test_create_new_notebook_increments_created(self, mock_dz, mock_s3):
+        dz = self._make_dz_no_existing()
+        mock_dz.return_value = dz
+        mock_s3.return_value = self._make_s3()
+
+        manifest = _make_manifest(notebooks=[_make_entry("nb-1")])
+        summary = sync_notebooks(
+            "dom-1", "proj-1", "us-east-1",
+            manifest_data=manifest,
+            notebook_files=NOTEBOOK_FILES,
+            s3_uri=S3_URI,
+        )
+        self.assertEqual(summary.created, 1)
+        self.assertEqual(summary.updated, 0)
+        self.assertEqual(summary.failed, 0)
+
+    @patch(PATCH_S3)
+    @patch(PATCH_DZ)
+    def test_start_notebook_sync_called_without_notebook_id_for_new(self, mock_dz, mock_s3):
+        dz = self._make_dz_no_existing()
+        mock_dz.return_value = dz
+        mock_s3.return_value = self._make_s3()
+
+        manifest = _make_manifest(notebooks=[_make_entry("nb-1")])
+        sync_notebooks(
+            "dom-1", "proj-1", "us-east-1",
+            manifest_data=manifest, notebook_files=NOTEBOOK_FILES, s3_uri=S3_URI,
+        )
+        call_kwargs = dz.start_notebook_sync.call_args[1]
+        self.assertNotIn("notebookId", call_kwargs)
+
+    # ── happy path: update ───────────────────────────────────────────────
+
+    @patch(PATCH_S3)
+    @patch(PATCH_DZ)
+    def test_update_existing_notebook_increments_updated(self, mock_dz, mock_s3):
+        dz = MagicMock()
+        # Existing target notebook maps "nb-1" → "tgt-existing"
+        dz.list_notebooks.return_value = {"items": [{"id": "tgt-existing"}]}
+        dz.get_notebook.return_value = {
+            "id": "tgt-existing",
+            "metadata": {SOURCE_NOTEBOOK_METADATA_KEY: "nb-1"},
+        }
+        dz.start_notebook_sync.return_value = {"notebookId": "tgt-existing"}
+        dz.update_notebook.return_value = {}
+        mock_dz.return_value = dz
+        mock_s3.return_value = self._make_s3()
+
+        manifest = _make_manifest(notebooks=[_make_entry("nb-1")])
+        summary = sync_notebooks(
+            "dom-1", "proj-1", "us-east-1",
+            manifest_data=manifest, notebook_files=NOTEBOOK_FILES, s3_uri=S3_URI,
+        )
+        self.assertEqual(summary.updated, 1)
+        self.assertEqual(summary.created, 0)
+        # StartNotebookSync called WITH notebookId
+        call_kwargs = dz.start_notebook_sync.call_args[1]
+        self.assertEqual(call_kwargs["notebookId"], "tgt-existing")
+
+    # ── ResourceNotFoundException fallback ───────────────────────────────
+
+    @patch(PATCH_S3)
+    @patch(PATCH_DZ)
+    def test_resource_not_found_fallback_creates_new(self, mock_dz, mock_s3):
+        dz = MagicMock()
+        dz.list_notebooks.return_value = {"items": [{"id": "tgt-deleted"}]}
+        dz.get_notebook.return_value = {
+            "id": "tgt-deleted",
+            "metadata": {SOURCE_NOTEBOOK_METADATA_KEY: "nb-1"},
+        }
+        call_count = [0]
+
+        def start_sync(**kwargs):
+            call_count[0] += 1
+            if kwargs.get("notebookId") == "tgt-deleted":
+                raise ClientError(
+                    {"Error": {"Code": "ResourceNotFoundException", "Message": "Not found"}},
+                    "StartNotebookSync",
+                )
+            return {"notebookId": "brand-new-id"}
+
+        dz.start_notebook_sync.side_effect = start_sync
+        dz.update_notebook.return_value = {}
+        mock_dz.return_value = dz
+        mock_s3.return_value = self._make_s3()
+
+        manifest = _make_manifest(notebooks=[_make_entry("nb-1")])
+        summary = sync_notebooks(
+            "dom-1", "proj-1", "us-east-1",
+            manifest_data=manifest, notebook_files=NOTEBOOK_FILES, s3_uri=S3_URI,
+        )
+        # Should have retried without notebookId and created
+        self.assertEqual(summary.failed, 0)
+        self.assertEqual(call_count[0], 2)  # first WITH, then WITHOUT
+
+    # ── UpdateNotebook failure ────────────────────────────────────────────
+
+    @patch(PATCH_S3)
+    @patch(PATCH_DZ)
+    def test_update_notebook_failure_counts_as_failed(self, mock_dz, mock_s3):
+        dz = self._make_dz_no_existing()
+        dz.update_notebook.side_effect = Exception("UpdateFailed")
+        mock_dz.return_value = dz
+        mock_s3.return_value = self._make_s3()
+
+        manifest = _make_manifest(notebooks=[_make_entry("nb-1")])
+        summary = sync_notebooks(
+            "dom-1", "proj-1", "us-east-1",
+            manifest_data=manifest, notebook_files=NOTEBOOK_FILES, s3_uri=S3_URI,
+        )
+        self.assertEqual(summary.failed, 1)
+        self.assertIn("nb-1", summary.failed_ids)
+
+    # ── missing file in bundle ────────────────────────────────────────────
+
+    @patch(PATCH_S3)
+    @patch(PATCH_DZ)
+    def test_missing_file_in_bundle_counts_as_failed(self, mock_dz, mock_s3):
+        mock_dz.return_value = self._make_dz_no_existing()
+        mock_s3.return_value = self._make_s3()
+
+        manifest = _make_manifest(notebooks=[_make_entry("nb-missing")])
+        # notebook_files dict is empty — file is missing
+        summary = sync_notebooks(
+            "dom-1", "proj-1", "us-east-1",
+            manifest_data=manifest, notebook_files={}, s3_uri=S3_URI,
+        )
+        self.assertEqual(summary.failed, 1)
+        self.assertIn("nb-missing", summary.failed_ids)
+
+    # ── S3 upload failure ─────────────────────────────────────────────────
+
+    @patch(PATCH_S3)
+    @patch(PATCH_DZ)
+    def test_s3_upload_failure_skips_sync_for_that_notebook(self, mock_dz, mock_s3):
+        mock_dz.return_value = self._make_dz_no_existing()
+        s3 = MagicMock()
+        s3.put_object.side_effect = Exception("S3UploadError")
+        mock_s3.return_value = s3
+
+        manifest = _make_manifest(notebooks=[_make_entry("nb-1")])
+        summary = sync_notebooks(
+            "dom-1", "proj-1", "us-east-1",
+            manifest_data=manifest, notebook_files=NOTEBOOK_FILES, s3_uri=S3_URI,
+        )
+        self.assertEqual(summary.failed, 1)
+        self.assertEqual(summary.created, 0)
+
+    # ── summary invariant (Property 11) ───────────────────────────────────
+
+    @patch(PATCH_S3)
+    @patch(PATCH_DZ)
+    def test_summary_counts_sum_equals_total_notebooks(self, mock_dz, mock_s3):
+        """Property 11: created + updated + failed == len(manifest notebooks)."""
+        dz = self._make_dz_no_existing()
+        mock_dz.return_value = dz
+        mock_s3.return_value = self._make_s3()
+
+        entries = [_make_entry(f"nb-{i}") for i in range(5)]
+        notebook_files = {e["filePath"]: b'{"cells":[]}' for e in entries}
+        manifest = _make_manifest(notebooks=entries)
+
+        summary = sync_notebooks(
+            "dom-1", "proj-1", "us-east-1",
+            manifest_data=manifest, notebook_files=notebook_files, s3_uri=S3_URI,
+        )
+        self.assertEqual(summary.total, 5)
+        self.assertEqual(summary.created + summary.updated + summary.failed, 5)
+
+    # ── empty manifest ────────────────────────────────────────────────────
+
+    @patch(PATCH_S3)
+    @patch(PATCH_DZ)
+    def test_empty_manifest_returns_zero_summary(self, mock_dz, mock_s3):
+        mock_dz.return_value = MagicMock()
+        mock_s3.return_value = MagicMock()
+
+        manifest = _make_manifest(notebooks=[])
+        summary = sync_notebooks(
+            "dom-1", "proj-1", "us-east-1",
+            manifest_data=manifest, notebook_files={}, s3_uri=S3_URI,
+        )
+        self.assertEqual(summary.created, 0)
+        self.assertEqual(summary.updated, 0)
+        self.assertEqual(summary.failed, 0)
+
+    # ── UpdateNotebook always passes tracking metadata ────────────────────
+
+    @patch(PATCH_S3)
+    @patch(PATCH_DZ)
+    def test_update_notebook_called_with_tracking_key(self, mock_dz, mock_s3):
+        dz = self._make_dz_no_existing()
+        mock_dz.return_value = dz
+        mock_s3.return_value = self._make_s3()
+
+        manifest = _make_manifest(notebooks=[_make_entry("nb-1", metadata={})])
+        sync_notebooks(
+            "dom-1", "proj-1", "us-east-1",
+            manifest_data=manifest, notebook_files=NOTEBOOK_FILES, s3_uri=S3_URI,
+        )
+        update_kwargs = dz.update_notebook.call_args[1]
+        self.assertIn(SOURCE_NOTEBOOK_METADATA_KEY, update_kwargs["metadata"])
+        self.assertEqual(update_kwargs["metadata"][SOURCE_NOTEBOOK_METADATA_KEY], "nb-1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add requirements, design, and implementation task list for promoting SageMaker Unified Studio notebooks across environments using DataZone Import/Export APIs.

## Key Design Decisions

- **Upsert strategy**: Import creates a new notebook, polls until ACTIVE, applies metadata via UpdateNotebook, then deletes the old version with the same name
- **Name-based matching**: Notebooks are identified by name across environments (no ID-based filters)
- **Unique names enforced**: Bundle command fails if duplicate notebook names are detected
- **Follows existing patterns**: Mirrors catalog import/export architecture

## APIs Used

- ListNotebooks, GetNotebook, StartNotebookExport, GetNotebookExport
- StartNotebookImport, UpdateNotebook, DeleteNotebook

## Spec Files

- `.kiro/specs/data-notebooks-support/requirements.md` — 12 requirements
- `.kiro/specs/data-notebooks-support/design.md` — Architecture, components, 10 correctness properties
- `.kiro/specs/data-notebooks-support/tasks.md` — 24 implementation tasks

## Out of Scope

- Notebook schedules (no public API for schedule management)