### PR TITLE
fix(workflows): Mitigate script injection in GitHub Actions

### DIFF
--- a/.github/workflows/e2e-mlops-deploy.yml
+++ b/.github/workflows/e2e-mlops-deploy.yml
@@ -58,8 +58,11 @@ jobs:
     steps:
       - id: set
         shell: bash
+        env:
+          INPUT_STAGE: ${{ inputs.stage }}
+          INPUT_MODEL_PACKAGE_ARN: ${{ inputs.model_package_arn }}
         run: |
-          STAGE="${{ inputs.stage }}"
+          STAGE="$INPUT_STAGE"
           STAGE="${STAGE:-dev}"
 
           if [ "$STAGE" = "all" ]; then
@@ -70,7 +73,7 @@ jobs:
 
           # Sentinel "none" lets the SMUS CLI manifest validator pass when no
           # model-package override is supplied.
-          ARN="${{ inputs.model_package_arn }}"
+          ARN="$INPUT_MODEL_PACKAGE_ARN"
           echo "model_package_arn=${ARN:-none}" >> $GITHUB_OUTPUT
           echo "model_package_group=bank-mktg-prediction-models" >> $GITHUB_OUTPUT
 
@@ -164,11 +167,14 @@ jobs:
         # SMUS CLI rejects unresolved substitutions in the manifest. Set sentinels
         # for the model-promotion vars and expose GIT_COMMIT so the manifest can
         # pin to the dispatching commit.
+        env:
+          RESOLVE_MODEL_PACKAGE_ARN: ${{ needs.resolve.outputs.model_package_arn }}
+          RESOLVE_MODEL_PACKAGE_GROUP: ${{ needs.resolve.outputs.model_package_group }}
         run: |
           {
             echo "GIT_COMMIT=${{ github.sha }}"
-            echo "MODEL_PACKAGE_ARN=${{ needs.resolve.outputs.model_package_arn }}"
-            echo "MODEL_PACKAGE_GROUP=${{ needs.resolve.outputs.model_package_group }}"
+            echo "MODEL_PACKAGE_ARN=$RESOLVE_MODEL_PACKAGE_ARN"
+            echo "MODEL_PACKAGE_GROUP=$RESOLVE_MODEL_PACKAGE_GROUP"
             echo "MODEL_DATA_URL_OVERRIDE=none"
           } >> $GITHUB_ENV
 

--- a/.github/workflows/e2e-mlops-promote.yml
+++ b/.github/workflows/e2e-mlops-promote.yml
@@ -151,16 +151,22 @@ jobs:
         # pinned. Manual workflow_dispatch lets you start mid-cascade
         # (e.g. start_at=test) for re-promotion scenarios.
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CLIENT_PAYLOAD_ARN: ${{ github.event.client_payload.model_package_arn }}
+          INPUT_START_AT: ${{ inputs.start_at }}
+          INPUT_MODEL_PACKAGE_ARN: ${{ inputs.model_package_arn }}
+          INPUT_RUN_SMOKE_TEST: ${{ inputs.run_smoke_test }}
         run: |
-          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+          if [ "$EVENT_NAME" = "repository_dispatch" ]; then
             START="dev"
-            ARN_OVERRIDE="${{ github.event.client_payload.model_package_arn }}"
+            ARN_OVERRIDE="$CLIENT_PAYLOAD_ARN"
             SMOKE="true"
             echo "Trigger: Lambda repository_dispatch (full cascade from dev)"
           else
-            START="${{ inputs.start_at }}"
-            ARN_OVERRIDE="${{ inputs.model_package_arn }}"
-            SMOKE="${{ inputs.run_smoke_test }}"
+            START="$INPUT_START_AT"
+            ARN_OVERRIDE="$INPUT_MODEL_PACKAGE_ARN"
+            SMOKE="$INPUT_RUN_SMOKE_TEST"
             echo "Trigger: workflow_dispatch (cascade from $START)"
           fi
           echo "  start_at:           $START"
@@ -293,10 +299,12 @@ jobs:
         run: pip install aws-smus-cicd-cli pyyaml boto3 -q
 
       - name: Export workflow env for manifest substitution
+        env:
+          PREPARE_MODEL_PACKAGE_ARN: ${{ needs.prepare.outputs.model_package_arn }}
         run: |
           {
             echo "GIT_COMMIT=${{ github.sha }}"
-            echo "MODEL_PACKAGE_ARN=${{ needs.prepare.outputs.model_package_arn }}"
+            echo "MODEL_PACKAGE_ARN=$PREPARE_MODEL_PACKAGE_ARN"
             # SMUS CLI manifest validator rejects empty env vars; "none"
             # is the sentinel deploy_model.py treats as "no override".
             echo "MODEL_DATA_URL_OVERRIDE=none"
@@ -353,12 +361,14 @@ jobs:
       - name: Record deploy on model package metadata
         if: ${{ needs.prepare.outputs.run_smoke_test == 'true' }}
         shell: bash
+        env:
+          MODEL_PKG_ARN: ${{ needs.prepare.outputs.model_package_arn }}
         run: |
           # AWS does not allow `add-tags` on a Model Package version (only on
           # the group), so promotion state is recorded via
           # CustomerMetadataProperties. update-model-package replaces the map,
           # so we merge existing keys before writing.
-          ARN="${{ needs.prepare.outputs.model_package_arn }}"
+          ARN="$MODEL_PKG_ARN"
           aws sagemaker describe-model-package --model-package-name "$ARN" \
             --query 'CustomerMetadataProperties' --output json > /tmp/props.json || echo '{}' > /tmp/props.json
           jq --arg ts "$(date -u +%FT%TZ)" \
@@ -468,15 +478,18 @@ jobs:
         run: pip install aws-smus-cicd-cli pyyaml boto3 -q
 
       - name: Export workflow env for manifest substitution
+        env:
+          STAGED_URL_TEST: ${{ needs.prepare.outputs.staged_url_test }}
+          PREPARE_MODEL_PACKAGE_ARN: ${{ needs.prepare.outputs.model_package_arn }}
         run: |
-          OVERRIDE='${{ needs.prepare.outputs.staged_url_test }}'
+          OVERRIDE="$STAGED_URL_TEST"
           if [ -z "$OVERRIDE" ]; then
             echo "::error::staged_url_test missing from prepare outputs"
             exit 1
           fi
           {
             echo "GIT_COMMIT=${{ github.sha }}"
-            echo "MODEL_PACKAGE_ARN=${{ needs.prepare.outputs.model_package_arn }}"
+            echo "MODEL_PACKAGE_ARN=$PREPARE_MODEL_PACKAGE_ARN"
             echo "MODEL_DATA_URL_OVERRIDE=$OVERRIDE"
           } >> $GITHUB_ENV
 
@@ -529,8 +542,10 @@ jobs:
       - name: Record deploy on model package metadata
         if: ${{ needs.prepare.outputs.run_smoke_test == 'true' }}
         shell: bash
+        env:
+          MODEL_PKG_ARN: ${{ needs.prepare.outputs.model_package_arn }}
         run: |
-          ARN="${{ needs.prepare.outputs.model_package_arn }}"
+          ARN="$MODEL_PKG_ARN"
           aws sagemaker describe-model-package --model-package-name "$ARN" \
             --query 'CustomerMetadataProperties' --output json > /tmp/props.json || echo '{}' > /tmp/props.json
           jq --arg ts "$(date -u +%FT%TZ)" \
@@ -637,15 +652,18 @@ jobs:
         run: pip install aws-smus-cicd-cli pyyaml boto3 -q
 
       - name: Export workflow env for manifest substitution
+        env:
+          STAGED_URL_PROD: ${{ needs.prepare.outputs.staged_url_prod }}
+          PREPARE_MODEL_PACKAGE_ARN: ${{ needs.prepare.outputs.model_package_arn }}
         run: |
-          OVERRIDE='${{ needs.prepare.outputs.staged_url_prod }}'
+          OVERRIDE="$STAGED_URL_PROD"
           if [ -z "$OVERRIDE" ]; then
             echo "::error::staged_url_prod missing from prepare outputs"
             exit 1
           fi
           {
             echo "GIT_COMMIT=${{ github.sha }}"
-            echo "MODEL_PACKAGE_ARN=${{ needs.prepare.outputs.model_package_arn }}"
+            echo "MODEL_PACKAGE_ARN=$PREPARE_MODEL_PACKAGE_ARN"
             echo "MODEL_DATA_URL_OVERRIDE=$OVERRIDE"
           } >> $GITHUB_ENV
 
@@ -698,8 +716,10 @@ jobs:
       - name: Record deploy on model package metadata
         if: ${{ needs.prepare.outputs.run_smoke_test == 'true' }}
         shell: bash
+        env:
+          MODEL_PKG_ARN: ${{ needs.prepare.outputs.model_package_arn }}
         run: |
-          ARN="${{ needs.prepare.outputs.model_package_arn }}"
+          ARN="$MODEL_PKG_ARN"
           aws sagemaker describe-model-package --model-package-name "$ARN" \
             --query 'CustomerMetadataProperties' --output json > /tmp/props.json || echo '{}' > /tmp/props.json
           jq --arg ts "$(date -u +%FT%TZ)" \

--- a/.github/workflows/mwaa-pipeline-lifecycle.yml
+++ b/.github/workflows/mwaa-pipeline-lifecycle.yml
@@ -65,9 +65,12 @@ jobs:
     
     - name: Resolve Domain and Project IDs
       id: resolve
+      env:
+        INPUT_DOMAIN_NAME: ${{ github.event.inputs.domain_name || 'cicd-test-domain' }}
+        INPUT_PROJECT_NAME: ${{ github.event.inputs.project_name || 'dev-marketing' }}
       run: |
-        DOMAIN_NAME="${{ github.event.inputs.domain_name || 'cicd-test-domain' }}"
-        PROJECT_NAME="${{ github.event.inputs.project_name || 'dev-marketing' }}"
+        DOMAIN_NAME="$INPUT_DOMAIN_NAME"
+        PROJECT_NAME="$INPUT_PROJECT_NAME"
         
         echo "🔍 Using domain: $DOMAIN_NAME"
         echo "🔍 Using project: $PROJECT_NAME"
@@ -129,10 +132,11 @@ jobs:
       env:
         DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         SMUS_LOG_LEVEL: WARNING
+        PIPELINE_FILE: ${{ needs.setup.outputs.pipeline-file }}
       run: |
         /examples/mwaa-example
         python -m smus_cicd.cli describe \
-          --pipeline "${{ needs.setup.outputs.pipeline-file }}" \
+          --pipeline "$PIPELINE_FILE" \
           --connect
         
         echo "✅ MWAA Pipeline configuration validated"
@@ -169,10 +173,11 @@ jobs:
       env:
         DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         SMUS_LOG_LEVEL: WARNING
+        PIPELINE_FILE: ${{ needs.setup.outputs.pipeline-file }}
       run: |
         /examples/mwaa-example
         python -m smus_cicd.cli bundle \
-          --pipeline "${{ needs.setup.outputs.pipeline-file }}"
+          --pipeline "$PIPELINE_FILE"
         
         echo "✅ MWAA Deployment bundle created"
     
@@ -220,10 +225,11 @@ jobs:
       env:
         DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         SMUS_LOG_LEVEL: WARNING
+        PIPELINE_FILE: ${{ needs.setup.outputs.pipeline-file }}
       run: |
         /examples/mwaa-example
         python -m smus_cicd.cli deploy \
-          --pipeline "${{ needs.setup.outputs.pipeline-file }}" \
+          --pipeline "$PIPELINE_FILE" \
           test
         
         echo "✅ Deployed to test environment"
@@ -260,10 +266,11 @@ jobs:
       env:
         DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         SMUS_LOG_LEVEL: WARNING
+        PIPELINE_FILE: ${{ needs.setup.outputs.pipeline-file }}
       run: |
         /examples/mwaa-example
         python -m smus_cicd.cli monitor \
-          --pipeline "${{ needs.setup.outputs.pipeline-file }}"
+          --pipeline "$PIPELINE_FILE"
         
         echo "✅ MWAA Pipeline monitoring completed"
 
@@ -305,10 +312,11 @@ jobs:
       env:
         DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         SMUS_LOG_LEVEL: WARNING
+        PIPELINE_FILE: ${{ needs.setup.outputs.pipeline-file }}
       run: |
         /examples/mwaa-example
         python -m smus_cicd.cli deploy \
-          --pipeline "${{ needs.setup.outputs.pipeline-file }}" \
+          --pipeline "$PIPELINE_FILE" \
           prod
         
         echo "✅ Deployed to production environment"
@@ -345,14 +353,16 @@ jobs:
       env:
         DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         SMUS_LOG_LEVEL: WARNING
+        PIPELINE_FILE: ${{ needs.setup.outputs.pipeline-file }}
+        DOMAIN_NAME_OUTPUT: ${{ needs.setup.outputs.domain-name }}
       run: |
         /examples/mwaa-example
         python -m smus_cicd.cli monitor \
-          --pipeline "${{ needs.setup.outputs.pipeline-file }}"
+          --pipeline "$PIPELINE_FILE"
         
         echo "🎉 MWAA Pipeline lifecycle demo completed successfully!"
         echo "📋 Resources deployed:"
         echo "  - Test Project: test-marketing-demo"
         echo "  - Production Project: prod-marketing-demo"
-        echo "  - Domain: ${{ needs.setup.outputs.domain-name }}"
+        echo "  - Domain: $DOMAIN_NAME_OUTPUT"
         echo "  - MWAA Environments: Created and configured"

--- a/.github/workflows/serverless-pipeline-lifecycle.yml
+++ b/.github/workflows/serverless-pipeline-lifecycle.yml
@@ -65,9 +65,12 @@ jobs:
     
     - name: Resolve Domain and Project IDs
       id: resolve
+      env:
+        INPUT_DOMAIN_NAME: ${{ github.event.inputs.domain_name || 'cicd-test-domain' }}
+        INPUT_PROJECT_NAME: ${{ github.event.inputs.project_name || 'dev-marketing' }}
       run: |
-        DOMAIN_NAME="${{ github.event.inputs.domain_name || 'cicd-test-domain' }}"
-        PROJECT_NAME="${{ github.event.inputs.project_name || 'dev-marketing' }}"
+        DOMAIN_NAME="$INPUT_DOMAIN_NAME"
+        PROJECT_NAME="$INPUT_PROJECT_NAME"
         
         echo "🔍 Using domain: $DOMAIN_NAME"
         echo "🔍 Using project: $PROJECT_NAME"
@@ -129,10 +132,11 @@ jobs:
       env:
         DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         SMUS_LOG_LEVEL: WARNING
+        PIPELINE_FILE: ${{ needs.setup.outputs.pipeline-file }}
       run: |
         /examples/serverless-example
         python -m smus_cicd.cli describe \
-          --pipeline "${{ needs.setup.outputs.pipeline-file }}" \
+          --pipeline "$PIPELINE_FILE" \
           --connect
         
         echo "✅ Serverless Pipeline configuration validated"
@@ -157,11 +161,12 @@ jobs:
     - name: Upload DAG files to S3
       env:
         DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
+        PIPELINE_FILE: ${{ needs.setup.outputs.pipeline-file }}
       run: |
         /examples/serverless-example
         
         # Get S3 location from describe command
-        S3_LOCATION=$(python -m smus_cicd.cli describe --pipeline "${{ needs.setup.outputs.pipeline-file }}" --connect | grep "s3Uri:" | head -1 | awk '{print $2}')
+        S3_LOCATION=$(python -m smus_cicd.cli describe --pipeline "$PIPELINE_FILE" --connect | grep "s3Uri:" | head -1 | awk '{print $2}')
         
         echo "📤 Uploading DAG files to S3..."
         aws s3 sync workflows/dags/ ${S3_LOCATION}workflows/dags/
@@ -200,10 +205,11 @@ jobs:
       env:
         DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         SMUS_LOG_LEVEL: WARNING
+        PIPELINE_FILE: ${{ needs.setup.outputs.pipeline-file }}
       run: |
         /examples/serverless-example
         python -m smus_cicd.cli bundle \
-          --pipeline "${{ needs.setup.outputs.pipeline-file }}"
+          --pipeline "$PIPELINE_FILE"
         
         echo "✅ Serverless Deployment bundle created"
     
@@ -251,10 +257,11 @@ jobs:
       env:
         DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         SMUS_LOG_LEVEL: WARNING
+        PIPELINE_FILE: ${{ needs.setup.outputs.pipeline-file }}
       run: |
         /examples/serverless-example
         python -m smus_cicd.cli deploy \
-          --pipeline "${{ needs.setup.outputs.pipeline-file }}" \
+          --pipeline "$PIPELINE_FILE" \
           test
         
         echo "✅ Deployed to test environment"
@@ -297,10 +304,11 @@ jobs:
       env:
         DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         SMUS_LOG_LEVEL: WARNING
+        PIPELINE_FILE: ${{ needs.setup.outputs.pipeline-file }}
       run: |
         /examples/serverless-example
         python -m smus_cicd.cli deploy \
-          --pipeline "${{ needs.setup.outputs.pipeline-file }}" \
+          --pipeline "$PIPELINE_FILE" \
           prod
         
         echo "✅ Deployed to production environment"
@@ -337,16 +345,18 @@ jobs:
       env:
         DOMAIN_REGION: ${{ vars.DOMAIN_REGION }}
         SMUS_LOG_LEVEL: WARNING
+        PIPELINE_FILE: ${{ needs.setup.outputs.pipeline-file }}
+        DOMAIN_NAME_OUTPUT: ${{ needs.setup.outputs.domain-name }}
       run: |
         /examples/serverless-example
         python -m smus_cicd.cli monitor \
-          --pipeline "${{ needs.setup.outputs.pipeline-file }}"
+          --pipeline "$PIPELINE_FILE"
         
         echo "🎉 Serverless Pipeline lifecycle demo completed successfully!"
         echo "📋 Resources deployed:"
         echo "  - Test Project: test-marketing-demo"
         echo "  - Production Project: prod-marketing-demo"
-        echo "  - Domain: ${{ needs.setup.outputs.domain-name }}"
+        echo "  - Domain: $DOMAIN_NAME_OUTPUT"
         echo "  - Serverless Airflow Workflows: Created with environment variables"
         echo "  - Environment Variables Resolved:"
         echo "    - test: ENV_NAME=test, S3_PREFIX=test-data, LOG_LEVEL=INFO"

--- a/.github/workflows/slack-pr-notification.yml
+++ b/.github/workflows/slack-pr-notification.yml
@@ -13,7 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack notification
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PR_WEBHOOK_URL }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          curl -X POST "${{ secrets.SLACK_PR_WEBHOOK_URL }}" \
+          curl -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
-            -d '{"PR_URL": "${{ github.event.pull_request.html_url }}", "PR_author": "${{ github.event.pull_request.user.login }}"}'
+            -d "{\"PR_URL\": \"$PR_URL\", \"PR_author\": \"$PR_AUTHOR\"}"


### PR DESCRIPTION
## Summary

Moves user-controlled event context data and job outputs from inline `${{ }}` expressions in `run:` blocks to intermediate environment variables. This prevents potential shell command injection by ensuring untrusted values are treated as data rather than part of the generated shell script.

## Changes

| Workflow | Data moved to env |
|----------|-------------------|
| `slack-pr-notification.yml` | `github.event.pull_request.html_url`, `user.login` |
| `mwaa-pipeline-lifecycle.yml` | `github.event.inputs.domain_name`, `project_name`, `needs.setup.outputs.*` |
| `serverless-pipeline-lifecycle.yml` | Same as mwaa |
| `e2e-mlops-promote.yml` | `github.event.client_payload.model_package_arn`, `inputs.*`, `needs.prepare.outputs.*` |
| `e2e-mlops-deploy.yml` | `inputs.stage`, `inputs.model_package_arn`, `needs.resolve.outputs.*` |

## Context

Per GitHub's security guidance on [script injections](https://securitylab.github.com/resources/github-actions-untrusted-input/), expressions like `${{ github.event.inputs.* }}` in `run:` blocks are substituted into the shell script _before_ execution. If the value contains shell metacharacters, it could break out of the string context and execute arbitrary commands. Routing through `env:` makes the shell treat the value as data.

## Testing

- All YAML files validated with `yaml.safe_load()`
- No functional behavior change — same values, just passed through env vars

## Related

- AppSec ticket: https://t.corp.amazon.com/V2270725343