### PR TITLE
fix(security): Prevent env var secret exfiltration via S3 workflow YAMLs

### DIFF
--- a/src/smus_cicd/commands/run.py
+++ b/src/smus_cicd/commands/run.py
@@ -585,7 +585,18 @@ def _execute_airflow_serverless_workflows(
                 typer.echo(f"🔗 ARN: {workflow_arn}")
 
             # Start workflow run (workflow uses role specified during creation)
-            result = airflow_serverless.start_workflow_run(workflow_arn, region=region)
+            # Pass environment_variables as override parameters for runtime resolution
+            override_parameters = None
+            if (
+                hasattr(target_config, "environment_variables")
+                and target_config.environment_variables
+            ):
+                override_parameters = {
+                    k: str(v) for k, v in target_config.environment_variables.items()
+                }
+            result = airflow_serverless.start_workflow_run(
+                workflow_arn, region=region, override_parameters=override_parameters
+            )
 
             if result.get("success"):
                 run_id = result.get("run_id")

--- a/src/smus_cicd/helpers/airflow_serverless.py
+++ b/src/smus_cicd/helpers/airflow_serverless.py
@@ -324,6 +324,7 @@ def start_workflow_run(
     run_name: str = None,
     connection_info: Dict[str, Any] = None,
     region: str = None,
+    override_parameters: Dict[str, str] = None,
 ) -> Dict[str, Any]:
     """Start a serverless Airflow workflow run."""
     logger = get_logger("airflow_serverless")
@@ -335,6 +336,8 @@ def start_workflow_run(
         # Note: RunName is not supported by the API, using ClientToken for uniqueness if needed
         if run_name:
             params["ClientToken"] = run_name
+        if override_parameters:
+            params["OverrideParameters"] = override_parameters
 
         logger.info(f"Starting workflow run for: {workflow_arn}")
         response = client.start_workflow_run(**params)
@@ -809,6 +812,7 @@ def start_workflow_run_verified(
     connection_info: Dict[str, Any] = None,
     verify_started: bool = True,
     wait_seconds: int = 10,
+    override_parameters: Dict[str, str] = None,
 ) -> Dict[str, Any]:
     """
     Start workflow run and optionally verify it actually started.
@@ -823,6 +827,7 @@ def start_workflow_run_verified(
         connection_info: Optional connection info
         verify_started: Whether to verify workflow started (default: True)
         wait_seconds: Seconds to wait before verification (default: 10)
+        override_parameters: Optional parameters to pass to workflow at runtime
 
     Returns:
         Dict with run_id, status, workflow_arn, success
@@ -838,6 +843,7 @@ def start_workflow_run_verified(
         run_name=run_name,
         connection_info=connection_info,
         region=region,
+        override_parameters=override_parameters,
     )
 
     if not result.get("success"):

--- a/src/smus_cicd/helpers/context_resolver.py
+++ b/src/smus_cicd/helpers/context_resolver.py
@@ -157,7 +157,7 @@ class ContextResolver:
             values. This prevents secrets from being stored in S3.
 
         Raises:
-            ValueError: If any non-env variable cannot be resolved
+            ValueError: If any variable cannot be resolved
         """
         context = self._build_context()
 
@@ -172,6 +172,9 @@ class ContextResolver:
             # Convert {env.VAR} to Jinja template syntax for runtime resolution
             # instead of resolving to actual values (prevents secret exposure in S3)
             if namespace == "env":
+                if path not in self.env_vars:
+                    unresolved.append(f"{{{namespace}.{path}}}")
+                    return match.group(0)
                 return "{{ params." + path + " }}"
 
             try:

--- a/src/smus_cicd/helpers/context_resolver.py
+++ b/src/smus_cicd/helpers/context_resolver.py
@@ -151,10 +151,13 @@ class ContextResolver:
             content: String content with {env.VAR}, {proj.property}, or {stage.name} variables
 
         Returns:
-            Content with variables replaced
+            Content with variables replaced. Note: {env.VAR} references are converted
+            to Jinja template syntax ({{ params.VAR }}) for runtime resolution via
+            MWAA Serverless override parameters, rather than being resolved to actual
+            values. This prevents secrets from being stored in S3.
 
         Raises:
-            ValueError: If any variable cannot be resolved
+            ValueError: If any non-env variable cannot be resolved
         """
         context = self._build_context()
 
@@ -165,6 +168,11 @@ class ContextResolver:
         def replacer(match):
             namespace = match.group(1)
             path = match.group(2)
+
+            # Convert {env.VAR} to Jinja template syntax for runtime resolution
+            # instead of resolving to actual values (prevents secret exposure in S3)
+            if namespace == "env":
+                return "{{ params." + path + " }}"
 
             try:
                 value = context[namespace]

--- a/src/smus_cicd/workflows/operations.py
+++ b/src/smus_cicd/workflows/operations.py
@@ -48,9 +48,27 @@ class WorkflowOperations:
             workflow_name=full_workflow_name, region=region
         )
 
+        # Pass environment_variables as override parameters for runtime resolution.
+        # The workflow YAML contains {{ params.VAR }} Jinja placeholders that get
+        # substituted by MWAA Serverless at execution time using these parameters.
+        override_parameters = None
+        if (
+            hasattr(target_config, "environment_variables")
+            and target_config.environment_variables
+        ):
+            override_parameters = {
+                k: str(v) for k, v in target_config.environment_variables.items()
+            }
+            logger.info(
+                f"Passing {len(override_parameters)} override parameters to workflow"
+            )
+
         # Start workflow run with verification
         result = airflow_serverless.start_workflow_run_verified(
-            workflow_arn=workflow_arn, region=region, verify_started=True
+            workflow_arn=workflow_arn,
+            region=region,
+            verify_started=True,
+            override_parameters=override_parameters,
         )
 
         logger.info(

--- a/tests/unit/test_all_substitutions.py
+++ b/tests/unit/test_all_substitutions.py
@@ -39,14 +39,14 @@ def test_env_variables(mock_aws_calls):
         env_vars=env_vars
     )
     
-    # Test single env var
-    assert resolver.resolve("{env.AWS_REGION}") == "us-east-1"
-    assert resolver.resolve("{env.S3_PREFIX}") == "test"
-    assert resolver.resolve("{env.CUSTOM_VAR}") == "value123"
+    # Test single env var - now converts to Jinja params
+    assert resolver.resolve("{env.AWS_REGION}") == "{{ params.AWS_REGION }}"
+    assert resolver.resolve("{env.S3_PREFIX}") == "{{ params.S3_PREFIX }}"
+    assert resolver.resolve("{env.CUSTOM_VAR}") == "{{ params.CUSTOM_VAR }}"
     
     # Test multiple env vars
     result = resolver.resolve("Region: {env.AWS_REGION}, Prefix: {env.S3_PREFIX}")
-    assert result == "Region: us-east-1, Prefix: test"
+    assert result == "Region: {{ params.AWS_REGION }}, Prefix: {{ params.S3_PREFIX }}"
 
 
 def test_stage_properties(mock_aws_calls):
@@ -254,7 +254,7 @@ def test_complex_workflow_yaml(mock_aws_calls):
     
     assert "s3://my-bucket/shared/scripts/process.py" in result
     assert "ProjectRole" in result
-    assert "us-east-1" in result
+    assert "{{ params.AWS_REGION }}" in result
     assert "4.0" in result
     assert "dev" in result
 

--- a/tests/unit/test_context_resolver.py
+++ b/tests/unit/test_context_resolver.py
@@ -117,7 +117,7 @@ def test_resolve_mlflow_connection(mock_get_project_id, mock_get_role, mock_get_
 @patch('smus_cicd.helpers.datazone.get_project_user_role_arn')
 @patch('smus_cicd.helpers.datazone.get_project_id_by_name')
 def test_resolve_missing_variable(mock_get_project_id, mock_get_role, mock_get_connections):
-    """Test that missing env variables are converted to Jinja params (not raised as errors)."""
+    """Test that missing env variables raise an error at deploy time."""
     mock_get_project_id.return_value = "proj123"
     mock_get_role.return_value = "arn:aws:iam::123:role/TestRole"
     mock_get_connections.return_value = {}
@@ -132,9 +132,9 @@ def test_resolve_missing_variable(mock_get_project_id, mock_get_role, mock_get_c
     
     content = "Missing: {env.DOES_NOT_EXIST}"
     
-    # env vars are now converted to Jinja syntax regardless of whether they exist
-    result = resolver.resolve(content)
-    assert result == "Missing: {{ params.DOES_NOT_EXIST }}"
+    # Should raise ValueError for missing environment variable
+    with pytest.raises(ValueError, match="Failed to resolve variables"):
+        resolver.resolve(content)
 
 
 @patch('smus_cicd.helpers.connections.get_project_connections')

--- a/tests/unit/test_context_resolver.py
+++ b/tests/unit/test_context_resolver.py
@@ -9,7 +9,7 @@ from smus_cicd.helpers.context_resolver import ContextResolver
 @patch('smus_cicd.helpers.datazone.get_project_user_role_arn')
 @patch('smus_cicd.helpers.datazone.get_project_id_by_name')
 def test_resolve_env_variables(mock_get_project_id, mock_get_role, mock_get_connections):
-    """Test resolving environment variables."""
+    """Test resolving environment variables to Jinja template syntax."""
     mock_get_project_id.return_value = "proj123"
     mock_get_role.return_value = "arn:aws:iam::123:role/TestRole"
     mock_get_connections.return_value = {}
@@ -26,7 +26,7 @@ def test_resolve_env_variables(mock_get_project_id, mock_get_role, mock_get_conn
     content = "Region: {env.AWS_REGION}, Prefix: {env.S3_PREFIX}"
     result = resolver.resolve(content)
     
-    assert result == "Region: us-east-1, Prefix: test"
+    assert result == "Region: {{ params.AWS_REGION }}, Prefix: {{ params.S3_PREFIX }}"
 
 
 @patch('smus_cicd.helpers.connections.get_project_connections')
@@ -117,7 +117,7 @@ def test_resolve_mlflow_connection(mock_get_project_id, mock_get_role, mock_get_
 @patch('smus_cicd.helpers.datazone.get_project_user_role_arn')
 @patch('smus_cicd.helpers.datazone.get_project_id_by_name')
 def test_resolve_missing_variable(mock_get_project_id, mock_get_role, mock_get_connections):
-    """Test that missing variables are left unchanged."""
+    """Test that missing env variables are converted to Jinja params (not raised as errors)."""
     mock_get_project_id.return_value = "proj123"
     mock_get_role.return_value = "arn:aws:iam::123:role/TestRole"
     mock_get_connections.return_value = {}
@@ -132,9 +132,9 @@ def test_resolve_missing_variable(mock_get_project_id, mock_get_role, mock_get_c
     
     content = "Missing: {env.DOES_NOT_EXIST}"
     
-    # Should raise ValueError for missing environment variable
-    with pytest.raises(ValueError, match="Failed to resolve variables"):
-        resolver.resolve(content)
+    # env vars are now converted to Jinja syntax regardless of whether they exist
+    result = resolver.resolve(content)
+    assert result == "Missing: {{ params.DOES_NOT_EXIST }}"
 
 
 @patch('smus_cicd.helpers.connections.get_project_connections')
@@ -170,7 +170,7 @@ def test_resolve_complex_yaml(mock_get_project_id, mock_get_role, mock_get_conne
     
     assert "s3://my-bucket/etl/script.py" in result
     assert "arn:aws:iam::123:role/TestRole" in result
-    assert "us-east-1" in result
+    assert "{{ params.AWS_REGION }}" in result
 
 
 @patch('smus_cicd.helpers.connections.get_project_connections')


### PR DESCRIPTION
## Summary

Prevents secrets defined via `environment_variables` in the manifest from being stored in S3, where data engineers with project bucket access could read them.

## Problem

When the CLI deployed workflows, the `ContextResolver` resolved `{env.VAR}` placeholders to their actual values and uploaded the resolved YAML to S3. This meant secrets (DB passwords, API keys, tokens) stored in CI environment variables were permanently written to the project's S3 bucket in plain text.

## Solution

Instead of resolving `{env.VAR}` to the actual value at deploy time, the resolver now emits Jinja template syntax (`{{ params.VAR }}`). The actual values are passed at **runtime** via MWAA Serverless `OverrideParameters` in the `start_workflow_run` API call.

### Before
```
{env.SECRET_KEY} → "actual-secret-value" (written to S3)
```

### After
```
{env.SECRET_KEY} → "{{ params.SECRET_KEY }}" (written to S3, no secret)
                  → actual value injected at runtime via OverrideParameters
```

## Changes

| File | Change |
|------|--------|
| `context_resolver.py` | `{env.VAR}` emits `{{ params.VAR }}` instead of resolving |
| `airflow_serverless.py` | `start_workflow_run` accepts `override_parameters` |
| `operations.py` | Passes `environment_variables` as override params at runtime |
| `commands/run.py` | Same for CLI run path |
| Unit tests | Updated assertions to expect Jinja syntax |

## Backward Compatibility

- The `{env.VAR}` syntax in workflow YAMLs remains unchanged
- No manifest or example changes required
- `{proj.*}`, `{domain.*}`, `{stage.*}` still resolve at deploy time (infrastructure metadata, not secrets)

## Testing

- Manually verified with MWAA Serverless: `create-workflow` accepts Jinja placeholders, `start-workflow-run` with `--override-parameters` substitutes them correctly in both operator fields and `input_params`
- All unit tests pass (22/22 context resolver + all substitution tests)
- E2E verified with data-notebooks example: S3 contains only `{{ params.TEST_SECRET }}`, notebook output shows actual value

## Related

- AppSec ticket: https://t.corp.amazon.com/P460824733/communication