### PR TITLE
spec: add Glue Visual ETL support (bundle/deploy/destroy/dry-run)

### DIFF
--- a/.kiro/specs/glue-visual-etl-support/.config.kiro
+++ b/.kiro/specs/glue-visual-etl-support/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "b7e3f2a1-4c8d-4e6f-9a2b-1d5c7e9f3a06", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/glue-visual-etl-support/design.md
+++ b/.kiro/specs/glue-visual-etl-support/design.md
@@ -1,0 +1,638 @@
+# Design Document: Glue Visual ETL Support
+
+## Overview
+
+### Background: what is a Glue Visual ETL job?
+
+SageMaker Unified Studio lets data engineers build AWS Glue ETL pipelines with a **visual, drag-and-drop editor** instead of writing Spark code by hand. A job built this way is a **Visual ETL job** (`JobMode: VISUAL` in Glue). Under the hood, each Visual ETL job is backed by three files stored in the project's S3 bucket:
+
+- `<job>.py` — the PySpark script Glue generates from the visual graph and actually runs
+- `<job>.vetl` — the visual graph definition; this is what lets the Unified Studio UI re-open the job in the drag-and-drop editor
+- `<job>.json` — the job's metadata (worker sizing, arguments, connections, etc.)
+
+### The problem this feature solves
+
+Teams build and test a Visual ETL job in a **development** project, then need to promote it to **test** and **production** projects. The SMUS CI/CD CLI has no first-class way to move a Glue job between projects today — a user hand-copies files and hand-writes orchestration. Two things routinely go wrong: forgetting the `.vetl` (the promoted job loses its visual graph), and — most importantly — the promoted job does not appear in the target project's UI at all, because Unified Studio only shows jobs that carry the right project tag.
+
+This feature adds an **end-to-end, declarative way to promote Visual ETL jobs**. A new `content.glue_jobs` manifest section declares which jobs to promote, and the CLI handles the full lifecycle: `bundle` (export), `deploy` (recreate in the target), `destroy` (clean up), and `deploy --dry-run` (validate first).
+
+### What makes a deployed job appear correctly in the Unified Studio UI
+
+This is the crux of the feature. The UI only shows Glue jobs tagged as belonging to a project, and only renders the visual editor when the job points at its `.vetl`. Three elements are required, and the importer injects all three automatically:
+
+| Element | Where it is set | What happens without it |
+|---|---|---|
+| `AmazonDataZoneProject` tag = target project ID | job `Tags` | Job exists in Glue but is **invisible** in the UI |
+| `--smus-orig-asset` = deployed `.vetl` location | `DefaultArguments` | Job appears but **without the visual graph** (looks like a script job) |
+| `--custom-logGroup-prefix` = `datazone-<projectId>-<stage>` | `DefaultArguments` | Job appears but **logs are not associated** with the project |
+
+### How the two halves fit together
+
+The `bundle` phase reads a job and produces a portable bundle (files + a small index manifest), scrubbed of every source-account/region/bucket value. The `deploy` phase reads that bundle, uploads the files into the target project's S3, recomputes all target-scoped values, injects the three UI elements plus a source-tracking tag, and creates or updates the job. `destroy` and `dry-run` operate on the same source-tracking tag.
+
+### How it fits the CLI
+
+The design mirrors the existing **catalog import/export** feature (`catalog_export.py` / `catalog_import.py`): two new helper modules plus small hooks in `bundle`, `deploy`, `destroy`, and the dry-run engine. The `glue_job` resource type already exists in the deploy registry; this feature adds it to the destroy registry and implements the deletion path.
+
+### Design Goals
+
+- **UI-first correctness**: guarantee deployed jobs appear in the UI by always injecting the project tag, `--smus-orig-asset`, and `--custom-logGroup-prefix`
+- **Portability**: sanitize all source-account/region/bucket values so a bundle from one account can be deployed into another
+- **Idempotency & ownership**: re-deploys update the existing job in place, tracked by a source tag; jobs the tool does not own are never overwritten or deleted
+- **Resilience**: one job failing does not abort the others; failures are collected and reported
+- **Consistency**: follow the module structure, error handling, and reporting patterns of the catalog feature
+
+### Key Design Decisions
+
+1. **Generic section, restricted behavior** — the manifest section is the generic `content.glue_jobs` list, but this iteration only handles `JobMode: VISUAL` jobs and rejects script jobs at validation with a clear "not yet supported" message. Future work adds script jobs without a schema change.
+2. **Three-file model** — `.py` from `Command.ScriptLocation`, `.vetl` from `--smus-orig-asset`, `.json` as the script's sibling. A Visual ETL job must have a `.vetl`; if it can't be located, that job fails.
+3. **Sanitize at export, rewrite at deploy** — export strips `Role`, `Connections`, `Command.ScriptLocation`, `Tags`, and placeholders the four location-specific arguments; deploy recomputes them for the target. This keeps bundles portable and both sides testable as pure functions.
+4. **Tag-based source tracking** — deployed jobs carry `smus-cicd-source-job-name`. Update discovery, destroy filtering, and the ownership guard all key off this tag.
+5. **Ownership guard** — if a target job with the computed name exists but lacks the tracking tag, deploy fails that job rather than clobbering a manually created one.
+6. **Reuse the `glue_job` resource type** — already in `DEPLOY_RESOURCE_TYPES`; this feature adds it to `DESTROY_SUPPORTED_RESOURCE_TYPES` and implements deletion, satisfying the `TestDeployDestroyDrift` invariant.
+7. **Two helper modules** — `visual_etl_export.py` and `visual_etl_import.py`, mirroring `catalog_export.py` / `catalog_import.py`.
+
+---
+
+## Architecture
+
+### High-Level Data Flow
+
+```mermaid
+graph TD
+    subgraph BundlePhase["Bundle Phase (source project)"]
+        A[Bundle Command] --> A0{content.glue_jobs non-empty?}
+        A0 -->|No| A1[Skip — no glue_jobs/ dir]
+        A0 -->|Yes| B[VisualETLExporter]
+        B --> B2[Validate ALL jobs via GetJob]
+        B2 -->|Any missing| B3[FAIL — list missing names]
+        B2 -->|Any not VISUAL| B3b[FAIL — list non-visual names]
+        B2 -->|All exist & VISUAL| B4[Export each job]
+        B4 --> E[GetJob → read definition]
+        E --> F[Locate .py / .vetl / .json]
+        F --> G{.vetl located?}
+        G -->|No| G1[Log error, count failed, continue]
+        G -->|Yes| H[Copy files from source S3 into bundle]
+        H --> I[Sanitize definition]
+        I --> J[Write glue_jobs/<name>/ files + manifest JSON]
+    end
+
+    subgraph DeployPhase["Deploy Phase (target project)"]
+        K[Deploy Command] --> L[VisualETLImporter]
+        L --> L1["Upload files to target S3"]
+        L1 --> L2["Rewrite Role, ScriptLocation, TempDir, spark-logs, smus-orig-asset, logGroup-prefix"]
+        L2 --> L3["Inject tags: AmazonDataZoneProject + smus-cicd-source-job-name"]
+        L3 --> L4["GetJob on deployed name"]
+        L4 --> L5{Exists?}
+        L5 -->|No| L6[CreateJob]
+        L5 -->|Yes + owns tag| L7[UpdateJob in place]
+        L5 -->|Yes, no tag| L8[FAIL — do not clobber]
+        L6 --> L9[Report created/updated/failed]
+        L7 --> L9
+        L8 --> L9
+    end
+
+    subgraph DestroyPhase["Destroy Phase (target project)"]
+        Q[Destroy Command] --> R["List jobs by AmazonDataZoneProject tag"]
+        R --> R1["Keep those with smus-cicd-source-job-name"]
+        R1 --> R2["Filter by source names in content.glue_jobs"]
+        R2 --> S[Display destruction plan]
+        S --> T[DeleteJob per job]
+    end
+
+    J --> |bundle.zip| K
+```
+
+In plain terms: `bundle` confirms every configured job exists and is a Visual ETL job, then copies each job's three files into the bundle and records a small manifest, scrubbing source-specific values. `deploy` uploads those files into the target project, recomputes every target-scoped value, injects the tags and arguments that make the job usable and visible, and creates or updates the job. `destroy` finds only the jobs this tool deployed (by tag) and deletes them.
+
+### Module Placement
+
+```
+src/smus_cicd/
+├── helpers/
+│   ├── visual_etl_export.py        # NEW: export logic for bundle
+│   ├── visual_etl_import.py        # NEW: create/update logic for deploy
+│   └── ...
+├── commands/
+│   ├── bundle.py                   # MODIFIED: call exporter when content.glue_jobs set
+│   ├── deploy.py                   # MODIFIED: call importer after catalog import
+│   ├── destroy_validator.py        # MODIFIED: discover glue jobs by tag
+│   ├── destroy_executor.py         # MODIFIED: delete glue jobs
+│   ├── destroy_models.py           # MODIFIED: add "glue_job" to DESTROY_SUPPORTED_RESOURCE_TYPES
+│   └── dry_run/
+│       └── checkers/
+│           └── glue_job_checker.py # NEW: dry-run validation for glue jobs
+├── application/
+│   └── application_manifest.py     # MODIFIED: add GlueJobEntry + content.glue_jobs list
+└── resource_types.py               # UNCHANGED: "glue_job" already present
+```
+
+### Integration Points
+
+| Command | Integration Point | Action |
+|---------|-------------------|--------|
+| `bundle` | After catalog export | Call `export_visual_etl_jobs()` if `content.glue_jobs` non-empty |
+| `deploy` | After catalog import, before bootstrap | Call `deploy_visual_etl_jobs()` if manifest present and not disabled |
+| `destroy` | Validation phase | List by tag → filter by `smus-cicd-source-job-name` → filter by configured source names |
+| `destroy` | Execution phase | DeleteJob per filtered job |
+| `dry-run` | After catalog checker | `GlueJobChecker.check()` validates prerequisites |
+
+---
+
+## Components and Interfaces
+
+### 1. Manifest Configuration (`application_manifest.py`)
+
+```python
+@dataclass
+class GlueJobEntry:
+    """A single content.glue_jobs entry."""
+    name: str                          # required; source Glue job name; pattern [a-zA-Z0-9_-]{1,255}
+    source: Optional[str] = None       # optional source stage; defaults to bundle default source
+    target_name: Optional[str] = None  # optional; deployed job base name; defaults to `name`
+```
+
+Added to `ContentConfig`:
+
+```python
+@dataclass
+class ContentConfig:
+    storage: List[StorageConfig] = field(default_factory=list)
+    git: List[GitContentConfig] = field(default_factory=list)
+    catalog: Optional[CatalogConfig] = None
+    glue_jobs: List[GlueJobEntry] = field(default_factory=list)  # NEW
+    quicksight: List[QuickSightDashboardConfig] = field(default_factory=list)
+    workflows: List[Dict[str, Any]] = field(default_factory=list)
+```
+
+Per-stage deployment configuration:
+
+```python
+@dataclass
+class DeploymentConfiguration:
+    storage: List[StorageConfig] = field(default_factory=list)
+    git: List[GitTargetConfig] = field(default_factory=list)
+    catalog: Optional[Dict[str, Any]] = None
+    glue_jobs: Optional[Dict[str, Any]] = None  # NEW: {disable, target_suffix, overrides}
+    quicksight: Optional[Dict[str, Any]] = None
+```
+
+Parsing rules: `name` must match `[a-zA-Z0-9_-]{1,255}`; `(name, source)` pairs unique; `target_name` parsed from YAML key `targetName`; absent/empty `glue_jobs` list means neither export nor deploy runs.
+
+### 2. VisualETLExporter (`helpers/visual_etl_export.py`)
+
+```python
+def export_visual_etl_jobs(
+    domain_id: str,
+    region: str,
+    entries: List[GlueJobEntry],
+    resolve_project_for_stage: Callable[[Optional[str]], Tuple[str, str, str]],
+) -> Tuple[List[ExportedVisualEtlJob], Dict[str, Any]]:
+    """
+    Export Visual ETL (JobMode: VISUAL) jobs configured in content.glue_jobs.
+
+    Validation (fail-fast, before any file copy):
+      1. GetJob(name) for each entry against its source stage project.
+      2. Fail if any missing (list all) or any not JobMode == VISUAL (list all).
+    Export (per validated entry):
+      - locate + copy .py / .vetl / .json from source S3
+      - sanitize the definition; record sourceStage and targetName
+
+    Returns (exported jobs, export manifest dict). Raises SystemExit on validation failure.
+    """
+```
+
+Internal: `_validate_entries`, `_locate_artifacts`, `_copy_artifact`, `_sanitize_definition`, `_build_export_manifest` (as in the export design), plus:
+
+```python
+@dataclass
+class ExportedVisualEtlJob:
+    source_job_name: str
+    source_stage: str
+    target_name: Optional[str]
+    job_mode: str                 # always "VISUAL"
+    definition: Dict[str, Any]    # sanitized create_job kwargs
+    artifacts: Dict[str, str]     # {"script": path, "visual": path, "metadata": path?}
+```
+
+### 3. VisualETLImporter (`helpers/visual_etl_import.py`)
+
+```python
+def deploy_visual_etl_jobs(
+    domain_id: str,
+    project_id: str,
+    region: str,
+    stage_name: str,
+    manifest_data: Dict[str, Any],
+    artifact_files: Dict[str, bytes],
+    s3_uri: str,
+    iam_role_arn: str,
+    target_suffix: str = "",
+    overrides: Optional[Dict[str, Dict[str, Any]]] = None,
+) -> GlueJobDeploySummary:
+    """
+    Deploy Visual ETL jobs into a target project.
+
+    For each job in the manifest:
+      Step 1: upload files to {s3Uri}glue_jobs/<deployedName>/
+      Step 2: rewrite Role, Command.ScriptLocation, --TempDir, --spark-event-logs-path,
+              --smus-orig-asset, --custom-logGroup-prefix
+      Step 3: inject Tags AmazonDataZoneProject=project_id, smus-cicd-source-job-name=sourceJobName
+      Step 4: GetJob(deployedName) → CreateJob or UpdateJob (ownership-guarded)
+    Returns GlueJobDeploySummary(created, updated, failed).
+    """
+```
+
+Internal functions:
+
+```python
+def _validate_export_manifest(manifest_data) -> None:
+    """Require metadata{sourceProjectId,sourceDomainId,sourceRegion,exportTimestamp,jobCount}
+    and jobs[]. Raise ValueError before any API calls."""
+
+def _upload_artifacts(s3, s3_uri, deployed_name, artifact_files) -> Dict[str, str]:
+    """Upload files; return {kind: target_s3_uri}."""
+
+def _deployed_name(job_entry, target_suffix) -> str:
+    """(targetName or sourceJobName) + target_suffix."""
+
+def _build_target_kwargs(job_entry, target_uris, s3_uri, iam_role_arn,
+                         project_id, stage_name, overrides) -> Dict[str, Any]:
+    """Construct create/update kwargs with all target rewrites + tags + overrides."""
+
+def _rewrite_default_arguments(args, s3_uri, project_id, stage_name, visual_uri) -> Dict[str, str]:
+    """Rewrite --TempDir, --spark-event-logs-path, --smus-orig-asset, --custom-logGroup-prefix."""
+
+def _resolve_target_job(glue, deployed_name) -> Optional[Dict]:
+    """GetJob; return def or None on EntityNotFoundException."""
+
+def _owns_job(job_def, source_job_name) -> bool:
+    """True iff smus-cicd-source-job-name tag == source_job_name."""
+
+def _create_or_update(glue, deployed_name, kwargs, existing) -> DeployResult:
+    """CreateJob if not existing; UpdateJob if owned; FAIL if exists unowned."""
+```
+
+Result/summary models:
+
+```python
+class DeployStatus(enum.Enum):
+    CREATED = "created"; UPDATED = "updated"; FAILED = "failed"
+
+@dataclass
+class DeployResult:
+    status: DeployStatus
+    source_job_name: str
+    deployed_job_name: Optional[str] = None
+    message: str = ""
+
+@dataclass
+class GlueJobDeploySummary:
+    created: int = 0
+    updated: int = 0
+    failed: int = 0
+    @property
+    def total(self) -> int: return self.created + self.updated + self.failed
+    @property
+    def has_failures(self) -> bool: return self.failed > 0
+```
+
+### 4. Dry-Run Checker (`commands/dry_run/checkers/glue_job_checker.py`)
+
+```python
+class GlueJobChecker:
+    """Validates Glue job deployment prerequisites during dry-run."""
+
+    def check(self, context: DryRunContext) -> List[Finding]:
+        """
+        1. S3 connection (default.s3_shared) exists and bucket reachable (HEAD).
+        2. IAM perms via SimulatePrincipalPolicy: glue:GetJob, glue:CreateJob,
+           glue:UpdateJob, glue:TagResource, glue:GetTags, s3:PutObject.
+        3. Report jobCount from the export manifest.
+        4. WARN for any VISUAL job missing a visual artifact.
+        """
+```
+
+Registered in `engine.py` after the catalog checker; invoked only when the bundle contains `glue_jobs/glue_jobs_export_manifest.json`.
+
+### 5. Destroy Integration
+
+`destroy_models.py`: add `"glue_job"` to `DESTROY_SUPPORTED_RESOURCE_TYPES`.
+
+`destroy_validator.py`:
+
+```python
+def _discover_glue_jobs(glue, project_id, configured_source_names) -> List[ResourceToDelete]:
+    """List jobs by AmazonDataZoneProject tag → keep those with smus-cicd-source-job-name →
+    filter to those whose tag value is in configured_source_names."""
+```
+
+`destroy_executor.py`:
+
+```python
+def _delete_glue_job(glue, job_name) -> ResourceResult:
+    """DeleteJob. EntityNotFoundException → not_found; other → error; continue."""
+```
+
+---
+
+## Data Models
+
+### GlueJobsExportManifest (JSON in bundle)
+
+```json
+{
+  "metadata": {
+    "sourceProjectId": "6roqiksku0ljtz",
+    "sourceDomainId": "dzd-xxxxxxxx",
+    "sourceRegion": "us-east-1",
+    "exportTimestamp": "2026-07-21T10:30:00Z",
+    "jobCount": 1
+  },
+  "jobs": [
+    {
+      "sourceJobName": "test_visual_job",
+      "sourceStage": "dev",
+      "targetName": "test_visual_job_prod",
+      "jobMode": "VISUAL",
+      "definition": {
+        "JobMode": "VISUAL",
+        "GlueVersion": "5.1",
+        "WorkerType": "G.1X",
+        "NumberOfWorkers": 10,
+        "Timeout": 480,
+        "MaxRetries": 0,
+        "ExecutionClass": "STANDARD",
+        "Command": { "Name": "glueetl", "PythonVersion": "3.9" },
+        "DefaultArguments": {
+          "--enable-glue-datacatalog": "true",
+          "--job-language": "python",
+          "--enable-auto-scaling": "true",
+          "--TempDir": "<TARGET_REWRITE>",
+          "--spark-event-logs-path": "<TARGET_REWRITE>",
+          "--smus-orig-asset": "<TARGET_REWRITE>",
+          "--custom-logGroup-prefix": "<TARGET_REWRITE>"
+        }
+      },
+      "artifacts": {
+        "script": "glue_jobs/test_visual_job/test_visual_job.py",
+        "visual": "glue_jobs/test_visual_job/test_visual_job.vetl",
+        "metadata": "glue_jobs/test_visual_job/test_visual_job.json"
+      }
+    }
+  ]
+}
+```
+
+### Manifest YAML Configuration
+
+```yaml
+content:
+  glue_jobs:
+  - name: test_visual_job          # source Glue job to promote
+    source: dev                    # optional: which stage to export from (default: bundle source)
+    targetName: test_visual_job_prod   # optional: deployed job base name (default: name)
+
+stages:
+  prod:
+    stage: PROD
+    domain:
+      id: dzd-xxxxxxxx
+      region: us-east-1
+    project:
+      name: projet_analytics_prod
+    deployment_configuration:
+      glue_jobs:
+        disable: false             # optional, default false
+        target_suffix: ""          # optional, appended to deployed job name
+        overrides:                 # optional per-source-job partial definition
+          test_visual_job:
+            NumberOfWorkers: 20
+            Timeout: 600
+```
+
+### Why the definition is sanitized
+
+A definition read from the source project is full of values that only make sense in that account: the IAM `Role` ARN, VPC `Connections`, the S3 `ScriptLocation`, temp/log S3 paths, and source project tags. Copying them verbatim would break a deploy into a different account. So export removes those fields and placeholders the four location-specific arguments; deploy recomputes real target values.
+
+### Validation Rules
+
+- each entry `name` matches `[a-zA-Z0-9_-]{1,255}`; `(name, source)` pairs unique
+- absent/empty `glue_jobs` list skips both export and deploy
+- a configured job whose `JobMode` is not `VISUAL` fails the bundle (fail-fast)
+
+---
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system.*
+
+### Property 1: Fail-Fast Validation Completeness
+
+*For any* set of configured entries where at least one is missing (GetJob returns EntityNotFoundException) or non-visual (`JobMode != VISUAL`), the bundle command SHALL validate every entry before any file copy, collect all missing and all non-visual names, fail listing all offenders, and produce zero exported files.
+
+**Validates: Requirements 2.1, 2.2, 2.3**
+
+### Property 2: Manifest Entry Uniqueness and Pattern
+
+*For any* `content.glue_jobs` list, parsing SHALL raise a validation error iff some entry `name` violates `[a-zA-Z0-9_-]{1,255}` or some `(name, source)` pair is duplicated; otherwise parsing SHALL succeed.
+
+**Validates: Requirements 1.2, 1.7, 1.8**
+
+### Property 3: Export Manifest Schema Correctness
+
+*For any* set of exported jobs (including the empty set), the serialized manifest SHALL have exactly two top-level keys (`metadata`, `jobs`); `metadata` SHALL contain `sourceProjectId`, `sourceDomainId`, `sourceRegion`, `exportTimestamp` (ISO 8601), and `jobCount` (equal to the length of `jobs`); each job entry SHALL contain `sourceJobName`, `sourceStage`, `targetName`, `jobMode` (equal to `VISUAL`), `definition`, and `artifacts`.
+
+**Validates: Requirements 4.2, 4.3, 4.4, 4.7**
+
+### Property 4: Definition Sanitization Removes Source Coordinates
+
+*For any* source job definition, the sanitized `definition` SHALL NOT contain a `Role`, `Connections`, `Command.ScriptLocation`, or `Tags` key, any 12-digit AWS account ID, any source S3 bucket name, or any AWS region string in a retained value; and `--TempDir`, `--spark-event-logs-path`, `--custom-logGroup-prefix`, and `--smus-orig-asset` SHALL each equal `<TARGET_REWRITE>`.
+
+**Validates: Requirements 4.5, 4.6, 4.8**
+
+### Property 5: Bundle Internal Consistency
+
+*For any* successful export, every artifact path in the manifest SHALL correspond to a file in the bundle, and every file under `glue_jobs/<name>/` (excluding the manifest) SHALL be referenced by exactly one job entry.
+
+**Validates: Requirements 4.7**
+
+### Property 6: Visual Artifact Requirement
+
+*For any* configured job, the job SHALL appear in the manifest with a `visual` artifact iff its `.vetl` was located and copied; otherwise the job SHALL be counted as failed and absent from `jobs`.
+
+**Validates: Requirements 3.2, 3.4**
+
+### Property 7: Target Kwargs Construction Invariants
+
+*For any* manifest job entry, the constructed create/update kwargs SHALL set `Command.ScriptLocation` to the uploaded script's target URI, `Role` to the target IAM role ARN, `Tags["AmazonDataZoneProject"]` to the target project ID, `Tags["smus-cicd-source-job-name"]` to `sourceJobName`, `DefaultArguments["--custom-logGroup-prefix"]` to `datazone-<targetProjectId>-<stage>`, and `DefaultArguments["--smus-orig-asset"]` to the deployed `.vetl` location.
+
+**Validates: Requirements 6.2, 6.3, 6.4, 6.5**
+
+### Property 8: Ownership Guard
+
+*For any* existing target job, deploy SHALL update it in place iff its `smus-cicd-source-job-name` tag equals the entry's `sourceJobName`; if the tag is absent, deploy SHALL count the job as failed and SHALL NOT call UpdateJob or CreateJob for it.
+
+**Validates: Requirements 7.2, 7.3, 7.4**
+
+### Property 9: Deployed Name and Override Application
+
+*For any* entry and stage config, the deployed job name SHALL equal `(targetName or sourceJobName) + target_suffix`; and for any `overrides` map, definition field values SHALL equal the override where present and the manifest value elsewhere, with overrides referencing unknown names altering no deployed job.
+
+**Validates: Requirements 6.7, 6.11**
+
+### Property 10: Destroy Tag-Based Filtering
+
+*For any* set of target jobs, the destruction plan SHALL include exactly those jobs that carry a `smus-cicd-source-job-name` tag whose value equals the `name` of some `content.glue_jobs` entry; jobs without the tag SHALL never be included.
+
+**Validates: Requirements 9.3, 9.4**
+
+### Property 11: Summary Count Invariant
+
+*For any* deploy processing N jobs, `created + updated + failed` SHALL equal N; *for any* export processing M configured jobs, `exported + failed` SHALL equal M and `metadata.jobCount` SHALL equal `exported`.
+
+**Validates: Requirements 3.5, 6.10**
+
+---
+
+## Error Handling
+
+| Error Source | Behavior | Impact |
+|---|---|---|
+| GetJob fails for a configured name (EntityNotFoundException) | Collect missing name, continue validating, then fail bundle listing all | Bundle fails (fail-fast) |
+| Resolved job is not `JobMode: VISUAL` | Collect non-visual name, continue validating, then fail bundle listing all | Bundle fails (fail-fast) |
+| `.vetl` cannot be located/copied (export, single) | Log error with job name, count failed, continue | Export continues |
+| File S3 copy failure (export, single) | Log job name + key, count failed, continue | Export continues |
+| Missing S3 connection (deploy) | Raise error, skip all glue job deploy | Deploy reports failure |
+| File upload failure (deploy, single) | Log job name + key, count failed, skip create/update, continue | Deploy continues |
+| CreateJob/UpdateJob error (single) | Log job name + error, count failed, continue | Deploy continues |
+| Target job exists without tracking tag | Log warning, count failed, do NOT overwrite | Deploy continues |
+| Missing file in bundle (deploy) | Log job name + path, count failed, continue | Deploy continues |
+| Missing manifest keys (deploy) | Raise validation error before any API calls | Deploy reports failure |
+| ThrottlingException (Glue/S3) | Retry exponential backoff (initial 1s, doubling, max 3 retries) | Transparent retry |
+| DeleteJob EntityNotFoundException (destroy) | Record not_found, continue | Destroy continues |
+| DeleteJob other error (destroy) | Log name + error, record error, continue | Destroy continues |
+| List failure (destroy validation) | Report error, fail validation for that stage | Destroy aborts |
+
+### Exit Code Rules
+
+- **Bundle**: non-zero if any configured job is missing or non-visual (fail-fast), OR any job failed to export
+- **Deploy**: non-zero if any job failed to create/update
+- **Destroy**: reports counts (deleted, not_found, error); non-zero on unexpected errors
+
+### Throttling Retry Strategy
+
+Glue/S3 API calls are wrapped with a retry decorator identical in behavior to the catalog feature:
+
+```python
+def _retry_on_throttle(func, max_retries=3, initial_delay=1.0):
+    for attempt in range(max_retries + 1):
+        try:
+            return func()
+        except ClientError as e:
+            code = e.response["Error"]["Code"]
+            if code in ("ThrottlingException", "ThrottledException") and attempt < max_retries:
+                time.sleep(initial_delay * (2 ** attempt) + random.uniform(0, 0.5))
+            else:
+                raise
+```
+
+---
+
+## Testing Strategy
+
+### Property-Based Testing (Hypothesis)
+
+Tested with `hypothesis`, minimum 100 iterations per property, on pure functions decoupled from AWS APIs.
+
+**Test file**: `tests/unit/helpers/test_glue_job_properties.py`
+
+| Property | Function Under Test | Generator Strategy |
+|---|---|---|
+| P1: Fail-Fast Validation | `_validate_entries()` (mocked GetJob) | Random entry sets with missing/non-visual subsets |
+| P2: Entry Uniqueness/Pattern | manifest parsing | Random entries with duplicate/invalid names |
+| P3: Manifest Schema | `_build_export_manifest()` | Random ExportedVisualEtlJob lists (0-20) |
+| P4: Sanitization | `_sanitize_definition()` | Random defs with account/region/bucket noise + target args |
+| P5: Bundle Consistency | End-to-end export (mocked APIs) | Random job sets with files |
+| P6: Visual Artifact | Export pipeline (mocked APIs) | Random jobs with/without resolvable `.vetl` |
+| P7: Kwargs Construction | `_build_target_kwargs()` | Random entries + target context |
+| P8: Ownership Guard | `_create_or_update()` (mocked GetJob) | Random existing jobs with/without tag |
+| P9: Name/Override | `_deployed_name()` + `_build_target_kwargs()` | Random suffix + overrides incl. unknown names |
+| P10: Destroy Filtering | `_discover_glue_jobs()` (mocked list) | Random jobs + configured name sets |
+| P11: Summary Count | export + deploy accumulation | Random success/failure sequences |
+
+Each test uses `@settings(max_examples=100)`. Tag format: `# Feature: glue-visual-etl-support, Property {N}: {description}`.
+
+### Unit Tests (pytest)
+
+**Test files**:
+- `tests/unit/helpers/test_visual_etl_export.py`
+- `tests/unit/helpers/test_visual_etl_import.py`
+- `tests/unit/commands/test_glue_job_dry_run.py`
+- `tests/unit/commands/test_glue_job_destroy.py`
+
+**Key scenarios**:
+- Manifest parsing: list entries with/without `source`/`targetName`, invalid name → error, duplicate `(name, source)` → error, absent/empty → skip
+- Fail-fast: missing name → error lists all missing; `JobMode: SCRIPT` entry → error lists non-visual with "not yet supported"
+- Export happy path: locate `.py`/`.vetl`/`.json` → copy → complete manifest entry
+- Export missing `.json` sibling → `metadata` artifact omitted, still succeeds
+- Export VISUAL missing `.vetl` → counted failed, absent from `jobs`
+- Sanitization strips Role/Connections/ScriptLocation/Tags and placeholders the four args
+- Deploy create path: no existing target → CreateJob with all rewrites + tags
+- Deploy update path: existing target owns tag → UpdateJob in place
+- Deploy ownership guard: existing target without tag → failed, no API write
+- Deploy overrides: values applied; unknown name warns
+- Deployed name: `(targetName or name) + target_suffix`
+- Deploy `deployment_configuration.glue_jobs.disable: true` → skip
+- Deploy no manifest in bundle → skip silently
+- S3 connection missing → raise, skip all
+- Destroy: filters by tag, respects configured names, source env → zero deletions
+- Destroy: EntityNotFoundException (not_found), other errors (error)
+- Dry-run: S3 reachable, IAM perms, jobCount reported, VISUAL-without-vetl warning
+- `TestDeployDestroyDrift` still passes with `glue_job` in both registries
+
+### Integration Test / Example
+
+**Example directory**: `examples/analytic-workflow/glue-visual-etl/` (new)
+
+**End-to-end round-trip** (real AWS APIs):
+1. Author a Visual ETL job in a source project
+2. Bundle with `content.glue_jobs: [{name: <job>, source: dev, targetName: <job>_prod}]`
+3. Deploy to a target project → first run creates the job
+4. Verify the deployed job carries `AmazonDataZoneProject` and `smus-cicd-source-job-name` tags, `JobMode: VISUAL`, and `--smus-orig-asset` pointing at the target `.vetl`
+5. Verify the job appears in the target project's Unified Studio UI (observed step)
+6. Deploy again → job updated in place (same name, ownership tag intact)
+7. Apply an override (NumberOfWorkers) → verify it takes effect
+8. Destroy → only the tagged job is deleted; a manually created job remains
+9. Negative: configure a `JobMode: SCRIPT` job → bundle fails listing the non-visual name
+
+### Test Utilities
+
+```python
+# tests/unit/helpers/conftest.py additions
+@pytest.fixture
+def sample_get_job_visual():
+    """A GetJob response for a Visual ETL job."""
+    return {
+        "Job": {
+            "Name": "test_visual_job",
+            "JobMode": "VISUAL",
+            "GlueVersion": "5.1",
+            "WorkerType": "G.1X",
+            "NumberOfWorkers": 10,
+            "Role": "arn:aws:iam::111122223333:role/datazone_usr_role_x",
+            "Command": {
+                "Name": "glueetl",
+                "PythonVersion": "3.9",
+                "ScriptLocation": "s3://bkt/dzd-x/proj/shared/jobs/test_visual_job/test_visual_job.py",
+            },
+            "DefaultArguments": {
+                "--job-language": "python",
+                "--smus-orig-asset": "jobs/test_visual_job/test_visual_job.vetl",
+                "--TempDir": "s3://bkt/dzd-x/proj/sys/glue/temp/",
+                "--custom-logGroup-prefix": "datazone-proj-dev",
+            },
+            "Tags": {"AmazonDataZoneProject": "proj", "AmazonDataZoneUsername": "u@x"},
+        }
+    }
+```

--- a/.kiro/specs/glue-visual-etl-support/requirements.md
+++ b/.kiro/specs/glue-visual-etl-support/requirements.md
@@ -1,0 +1,210 @@
+# Requirements Document
+
+## Introduction
+
+SageMaker Unified Studio lets data engineers build AWS Glue ETL pipelines with a **visual, drag-and-drop editor** instead of writing Spark code by hand. A job built this way is a **Visual ETL job** (`JobMode: VISUAL` in Glue), and is backed by three files in the project's S3 bucket: the generated PySpark script (`<job>.py`), the visual graph definition (`<job>.vetl`, which lets the UI re-open the drag-and-drop editor), and the job metadata (`<job>.json`).
+
+Teams build and test such jobs in a **development** project and need to promote them to **test** and **production** projects. The SMUS CI/CD CLI has no first-class way to move a Glue job between projects today, so users hand-copy files and hand-write orchestration. This is error-prone, and — critically — a job created without the right Unified Studio metadata is **invisible in the target project's UI** even though it exists in Glue.
+
+This feature adds an end-to-end, declarative way to promote Visual ETL jobs across environments. A new `content.glue_jobs` manifest section declares which jobs to promote, and the CLI handles the full lifecycle:
+
+- **bundle (export)**: read a Visual ETL job from a source project and package its definition + three backing files into a portable bundle
+- **deploy**: recreate the job in a target project with a target-scoped configuration and the tags/arguments required for it to appear correctly in the Unified Studio UI
+- **destroy**: remove jobs previously deployed by this tool from a target project
+- **deploy --dry-run**: validate the prerequisites before making changes
+
+### What makes a deployed job appear correctly in the Unified Studio UI
+
+The Unified Studio UI only shows Glue jobs that are tagged as belonging to a project, and it only renders the visual editor when the job points at its `.vetl` file. Three elements are required, and this feature injects all three automatically during deploy:
+
+1. the `AmazonDataZoneProject` tag set to the target project ID — without it, the job exists in Glue but is **invisible** in the UI
+2. the `--smus-orig-asset` argument pointing at the deployed `.vetl` — without it, the job appears but **without its visual graph** (shows as a plain script job)
+3. the `--custom-logGroup-prefix` argument scoped to the target project — without it, the job's **logs are not associated** with the project
+
+### Scope
+
+**In scope:**
+- The `content.glue_jobs` manifest section and per-stage `deployment_configuration.glue_jobs`
+- Exporting `JobMode: VISUAL` jobs during `bundle`
+- Deploying them into a target project during `deploy` (create/update, tag injection, argument/role/S3 rewrites)
+- Idempotent in-place updates tracked by a source tag, with an ownership guard
+- `destroy` support and `deploy --dry-run` validation
+- Documentation of behavior and prerequisites
+
+**Out of scope:**
+- Script-mode Glue jobs (`JobMode: SCRIPT`) — only `JobMode: VISUAL` in this iteration
+- Glue crawlers, triggers, and Glue-native workflows
+- Running a job (execution) — this feature deploys job *definitions*
+- Automatically granting Glue IAM permissions to the target project role (documented as a prerequisite)
+
+## Glossary
+
+- **CLI**: The `aws-smus-cicd-cli` command-line interface for SMUS CI/CD operations
+- **Bundle_Command / Deploy_Command / Destroy_Command**: The CLI commands that package, deploy, and remove content
+- **Visual_ETL_Exporter**: The component that reads each configured job via `GetJob`, verifies it is `JobMode: VISUAL`, copies its S3 files, sanitizes the definition, and produces the export manifest
+- **Visual_ETL_Importer**: The component that uploads job files to the target S3, rewrites project-scoped fields, injects tags, and creates/updates the job via `CreateJob`/`UpdateJob`
+- **Visual_ETL_Job**: A Glue job with `JobMode: VISUAL`, backed by `<job>.py`, `<job>.vetl`, and `<job>.json`
+- **Job_Artifact**: One of the backing files: the `.py` script, the `.vetl` visual definition, or the `.json` metadata
+- **Glue_Job_Entry**: An element of the `content.glue_jobs` list, with fields `name` (required), `source` (optional source stage), and `targetName` (optional target job base name)
+- **DataZone_Project**: A project within a DataZone domain that owns Glue job resources
+- **Source_Stage / Target_Stage**: The stage/project a job is exported from, and the stage/project it is deployed to
+- **Glue_Jobs_Export_Manifest**: A JSON file in the bundle recording each exported job's name, mode, target name, sanitized definition, and file paths
+- **DataZone_Project_Tag**: The tag `AmazonDataZoneProject` (value = project ID) that makes a Glue job visible in the Unified Studio UI
+- **Source_Job_Tracking_Tag**: The tag `smus-cicd-source-job-name` written to deployed jobs to track which source job they came from
+- **Orig_Asset_Argument**: The `--smus-orig-asset` Glue argument that points to the `.vetl` file and activates the visual graph
+- **Log_Group_Prefix_Argument**: The `--custom-logGroup-prefix` Glue argument (pattern `datazone-<projectId>-<stage>`) that associates logs with the project
+- **GetJob_API / GetJobs_API / CreateJob_API / UpdateJob_API / DeleteJob_API**: Glue APIs to read, list, create, update, and delete job definitions
+- **S3_Connection**: The `default.s3_shared` connection of a project, used to read and write job artifacts
+- **Manifest**: The `manifest.yaml` file defining content and stages
+
+## Requirements
+
+### Requirement 1: Manifest Configuration for Glue Jobs
+
+**User Story:** As a data engineer, I want to declare Glue jobs in my manifest.yaml using the `content.glue_jobs` list, so that the CLI knows which Visual ETL jobs to promote and where.
+
+#### Acceptance Criteria
+
+1. THE Manifest SHALL support a `content.glue_jobs` section defined as a list of Glue_Job_Entry objects
+2. EACH Glue_Job_Entry SHALL support a required `name` field (the source Glue job name) matching the pattern `[a-zA-Z0-9_-]{1,255}`
+3. EACH Glue_Job_Entry SHALL support an optional `source` field naming the source stage to export from; IF omitted, THE Bundle_Command SHALL use the bundle's default source stage (consistent with other content types)
+4. EACH Glue_Job_Entry SHALL support an optional `targetName` field giving the base name of the deployed job; IF omitted, THE deployed job's base name SHALL default to the entry's `name`
+5. THE Manifest SHALL support a per-stage `deployment_configuration.glue_jobs` section with an optional `disable` boolean (default false), an optional `target_suffix` string appended to each deployed job name, and an optional `overrides` map keyed by source job name whose values are partial job definitions
+6. IF the `content.glue_jobs` list is absent or empty, THEN THE Bundle_Command SHALL skip Glue job export and SHALL NOT create a `glue_jobs/` directory in the bundle
+7. IF two or more Glue_Job_Entry objects share the same `name` within the same `source`, THEN THE Bundle_Command SHALL raise a validation error identifying the duplicate
+8. IF a Glue_Job_Entry has a `name` that does not match the required pattern, THEN THE Bundle_Command SHALL raise a validation error
+
+### Requirement 2: Validate Configured Jobs Before Export
+
+**User Story:** As a data engineer, I want the bundle command to validate every configured job upfront, so that a misconfiguration fails fast before any file is copied.
+
+#### Acceptance Criteria
+
+1. WHEN the bundle command runs and `content.glue_jobs` is non-empty, THE Visual_ETL_Exporter SHALL call the GetJob_API for each entry's `name` (resolved against the entry's source stage project) to retrieve the full job definition, before copying any files
+2. IF any configured job name does not exist (GetJob_API returns EntityNotFoundException), THEN THE Bundle_Command SHALL fail with a non-zero exit code and an error listing all missing job names — no files shall be copied
+3. IF any configured job exists but its `JobMode` is not `VISUAL`, THEN THE Bundle_Command SHALL fail with a non-zero exit code and an error listing the non-visual job names and stating that only Visual ETL jobs are supported in this iteration — no files shall be copied
+4. IF all configured jobs exist and are `JobMode: VISUAL`, THEN THE Visual_ETL_Exporter SHALL proceed to export them
+
+### Requirement 3: Export Visual ETL Jobs During Bundle
+
+**User Story:** As a data engineer, I want the bundle command to export Visual ETL job definitions and their backing files, so that they can be deployed to another project.
+
+#### Acceptance Criteria
+
+1. FOR EACH configured job, THE Visual_ETL_Exporter SHALL determine the job's file locations — the `.py` from `Command.ScriptLocation`, the `.vetl` from the `--smus-orig-asset` argument (resolved relative to the script location when the argument is a relative path), and the `.json` as the script's sibling — and copy each located file from the source project's S3 into a `glue_jobs/<name>/` directory within the bundle archive
+2. THE Visual_ETL_Exporter SHALL verify that a `.vetl` file was located and copied for each job; IF the `.vetl` cannot be located or copied, THEN THE Visual_ETL_Exporter SHALL log an error identifying the job, count the job as failed, and continue with the next job
+3. THE Visual_ETL_Exporter SHALL produce a `glue_jobs/glue_jobs_export_manifest.json` recording, for each exported job, `sourceJobName`, `sourceStage`, `targetName` (or null), `jobMode`, the sanitized definition (see Requirement 4), and the relative bundle paths of its copied files
+4. IF the S3 copy of a file fails for a specific job, THEN THE Visual_ETL_Exporter SHALL log the error including the job name and S3 key, count the job as failed, and continue with the next job
+5. WHEN all configured jobs have been processed, IF any jobs failed to export, THEN THE Bundle_Command SHALL exit with a non-zero exit code and output a failure message listing the names of all jobs that failed and their error messages
+6. THE `sourceStage` recorded per job SHALL equal the entry's `source` field, or the bundle's default source stage when `source` was omitted
+
+### Requirement 4: Export Manifest Serialization
+
+**User Story:** As a data engineer, I want the exported metadata stored in a structured, portable manifest, so that deploy has everything it needs to recreate the job in a target project.
+
+#### Acceptance Criteria
+
+1. THE Visual_ETL_Exporter SHALL produce a UTF-8 encoded JSON file at `glue_jobs/glue_jobs_export_manifest.json` within the bundle archive
+2. THE Glue_Jobs_Export_Manifest SHALL contain a top-level object with exactly two keys: `metadata` (object) and `jobs` (array)
+3. THE `metadata` section SHALL include `sourceProjectId`, `sourceDomainId`, `sourceRegion`, `exportTimestamp` (ISO 8601), and `jobCount` (equal to the length of the `jobs` array)
+4. EACH entry in the `jobs` array SHALL include `sourceJobName` (string), `sourceStage` (string), `targetName` (string or null), `jobMode` (always `VISUAL`), `definition` (object, the sanitized create-job kwargs — see AC#5 and AC#6), and `artifacts` (object mapping `script`/`visual`/`metadata` to the relative bundle path of an existing file, omitting kinds not present on the source)
+5. THE `definition` object SHALL be derived from the source `GetJob` response and SHALL retain: `JobMode`, `GlueVersion`, `WorkerType`, `NumberOfWorkers`, `Timeout`, `MaxRetries`, `ExecutionClass`, `Command` (name and python version, but NOT the source `ScriptLocation`), and `DefaultArguments`
+6. THE `definition` object SHALL exclude source-specific fields recomputed at deploy time: `Role`, `Connections`, `Command.ScriptLocation`, and any pre-existing `Tags`. The source values of the `--TempDir`, `--spark-event-logs-path`, `--custom-logGroup-prefix`, and `--smus-orig-asset` arguments SHALL be replaced with a `<TARGET_REWRITE>` placeholder
+7. THE Glue_Jobs_Export_Manifest SHALL be valid JSON, and every file path referenced in any job entry SHALL correspond to a file present in the bundle archive
+8. THE `definition` object SHALL NOT contain the source AWS account ID, source S3 bucket names, or source region strings in any retained value
+
+### Requirement 5: Deploy Command Integration
+
+**User Story:** As a data engineer, I want Glue job deployment integrated into the deploy command, so that jobs are deployed alongside other bundle content.
+
+#### Acceptance Criteria
+
+1. THE Deploy_Command SHALL process Glue job deployment after storage and catalog deployments, and before bootstrap actions
+2. WHERE the stage's `deployment_configuration.glue_jobs.disable` is true, THE Deploy_Command SHALL skip Glue job deployment for that stage and log an informational message
+3. IF Glue job deployment is not disabled and the bundle contains a `glue_jobs/glue_jobs_export_manifest.json`, THEN THE Deploy_Command SHALL invoke the Visual_ETL_Importer for the jobs in the manifest
+4. IF the bundle does not contain a `glue_jobs/glue_jobs_export_manifest.json`, THEN THE Deploy_Command SHALL skip Glue job deployment without warning or error
+5. WHEN the Visual_ETL_Importer completes, THE Deploy_Command SHALL report the deployment summary (created, updated, failed counts) in the deployment output
+
+### Requirement 6: Deploy Visual ETL Jobs into the Target Project
+
+**User Story:** As a data engineer, I want deployed jobs to run correctly and appear in the Unified Studio UI, so that promoted jobs behave identically to the source.
+
+#### Acceptance Criteria
+
+1. THE Visual_ETL_Importer SHALL execute, for each job in the manifest, this ordered sequence: (Step 1) upload the job's files to the target project's `default.s3_shared` S3 URI under `glue_jobs/<deployedName>/`; (Step 2) build target create/update kwargs with all rewrites and tags; (Step 3) create or update the job (see Requirement 7); (Step 4) record the result
+2. THE Visual_ETL_Importer SHALL set `Command.ScriptLocation` to the uploaded `.py` file's target S3 URI
+3. THE Visual_ETL_Importer SHALL set the job's `Role` to the target project's IAM role ARN resolved from the target project context
+4. THE Visual_ETL_Importer SHALL rewrite `DefaultArguments` to target-scoped values: `--TempDir` and `--spark-event-logs-path` to the target project's S3 shared paths, `--smus-orig-asset` to the deployed `.vetl` file's location, and `--custom-logGroup-prefix` to `datazone-<targetProjectId>-<stage>`
+5. THE Visual_ETL_Importer SHALL set the job `Tags` to include `AmazonDataZoneProject` equal to the target project ID and `smus-cicd-source-job-name` equal to the manifest entry's `sourceJobName`
+6. THE Visual_ETL_Importer SHALL preserve `JobMode` (VISUAL), `GlueVersion`, `WorkerType`, `NumberOfWorkers`, `Timeout`, `MaxRetries`, and `ExecutionClass` from the manifest definition, applying any per-job `overrides` from the deployment configuration
+7. THE deployed job's name SHALL be `(targetName or sourceJobName) + target_suffix` where `target_suffix` comes from the stage's deployment configuration (default empty)
+8. IF CreateJob_API or UpdateJob_API returns an error, THEN THE Visual_ETL_Importer SHALL log the job name and error, count the job as failed, and continue with the next job
+9. WHEN a job entry references a file path not present in the bundle, THE Visual_ETL_Importer SHALL log an error identifying the missing file and job, count it as failed, and continue
+10. WHEN all jobs have been processed, IF any failed, THEN THE Deploy_Command SHALL exit with a non-zero exit code and list the names of all jobs that failed and their error messages
+11. IF an `overrides` entry references a source job name not present in the manifest, THEN THE Deploy_Command SHALL log a warning identifying the unknown name and continue
+
+### Requirement 7: Idempotent In-Place Update with Ownership Guard
+
+**User Story:** As a data engineer, I want re-deployments to update the existing target job rather than create duplicates, and to never clobber jobs the tool doesn't own, so that promotion is safe and idempotent.
+
+#### Acceptance Criteria
+
+1. WHEN deploying a job, THE Visual_ETL_Importer SHALL call GetJob_API on the computed deployed job name to determine whether it already exists
+2. IF the target job exists and its `smus-cicd-source-job-name` tag equals the manifest entry's `sourceJobName`, THEN THE Visual_ETL_Importer SHALL update it in place via UpdateJob_API
+3. IF the target job exists but does NOT carry a `smus-cicd-source-job-name` tag, THEN THE Visual_ETL_Importer SHALL log a warning that a non-CI/CD-managed job with the same name exists, count the job as failed, and continue — it SHALL NOT overwrite it
+4. IF the target job does not exist (EntityNotFoundException), THEN THE Visual_ETL_Importer SHALL create it via CreateJob_API
+5. THE Visual_ETL_Importer SHALL make create/update idempotent such that repeated deploys of an unchanged manifest converge to the same target job definition
+
+### Requirement 8: S3 Artifact Upload for Deployment
+
+**User Story:** As a data engineer, I want job files uploaded to the target project S3 before job creation, so that the job's script and visual graph resolve correctly in the target.
+
+#### Acceptance Criteria
+
+1. THE Visual_ETL_Importer SHALL upload files to the target project's `default.s3_shared` S3 URI, constructing keys as `{s3Uri}glue_jobs/<deployedName>/<fileName>`
+2. WHEN uploading, THE Visual_ETL_Importer SHALL verify that the target project's `default.s3_shared` connection exists and contains a non-empty `s3Uri` before attempting any uploads
+3. IF a file upload fails, THEN THE Visual_ETL_Importer SHALL log the error including the job name and S3 key, count that job as failed, skip its create/update, and continue
+4. IF the target project's `default.s3_shared` connection does not exist or has no `s3Uri`, THEN THE Visual_ETL_Importer SHALL raise an error indicating the missing connection and skip all Glue job deployment for that project
+
+### Requirement 9: Destroy Command Support for Glue Jobs
+
+**User Story:** As a data engineer, I want the destroy command to clean up deployed Glue jobs, so that I can remove all deployed resources from a target environment.
+
+#### Acceptance Criteria
+
+1. WHEN the destroy command validates a target stage and `content.glue_jobs` is non-empty, THE Destroy_Command SHALL discover Glue jobs in the target account/region carrying the `AmazonDataZoneProject` tag equal to the target project ID, handling pagination until all are retrieved
+2. FOR EACH discovered job, THE Destroy_Command SHALL read its tags and check whether they contain the key `smus-cicd-source-job-name`
+3. THE Destroy_Command SHALL include a job in the destruction plan only if its tags contain `smus-cicd-source-job-name` (indicating it was deployed by this tool)
+4. THE Destroy_Command SHALL additionally filter the destruction plan to include only jobs whose `smus-cicd-source-job-name` tag value equals the `name` of some entry in `content.glue_jobs`
+5. THE Destroy_Command SHALL display each filtered job's name in the destruction plan under a `glue_job` resource type for user confirmation before deletion
+6. IF the user confirms destruction, THEN THE Destroy_Command SHALL delete each job via DeleteJob_API, continuing to the next job if an individual deletion fails
+7. IF a job is not found at deletion time (EntityNotFoundException), THEN THE Destroy_Command SHALL record the job as `not_found` and continue
+8. IF a job deletion fails with any other error, THEN THE Destroy_Command SHALL log the job name and error, record the job as `error`, and continue
+9. THE Destroy_Command SHALL report the count of deleted, not_found, and failed deletions in the destruction summary consistent with the existing format
+10. THE `glue_job` resource type SHALL be present in both `DEPLOY_RESOURCE_TYPES` (`resource_types.py`) and `DESTROY_SUPPORTED_RESOURCE_TYPES` (`destroy_models.py`), keeping the `TestDeployDestroyDrift` unit test passing
+
+### Requirement 10: Dry-Run Validation for Glue Jobs
+
+**User Story:** As a data engineer, I want `deploy --dry-run` to validate Glue job prerequisites, so that I can detect issues before deploying.
+
+#### Acceptance Criteria
+
+1. WHEN the deploy command runs with `--dry-run` and the bundle contains a `glue_jobs/glue_jobs_export_manifest.json`, THE Dry_Run_Engine SHALL verify that the target project's `default.s3_shared` connection exists and is reachable via a HEAD request against the resolved S3 bucket
+2. WHEN the deploy command runs with `--dry-run` and the bundle contains a `glue_jobs/glue_jobs_export_manifest.json`, THE Dry_Run_Engine SHALL verify that the IAM identity has `glue:GetJob`, `glue:CreateJob`, `glue:UpdateJob`, `glue:TagResource`, `glue:GetTags`, and `s3:PutObject` permissions via `iam:SimulatePrincipalPolicy`
+3. THE Dry_Run_Engine SHALL report the number of jobs that would be deployed (from the manifest's `jobCount`)
+4. IF the S3 connection is not found or the HEAD request fails, THEN THE Dry_Run_Engine SHALL report a WARNING finding indicating the connection name and reason
+5. IF `iam:SimulatePrincipalPolicy` reports a denied decision for any required permission, THEN THE Dry_Run_Engine SHALL report a WARNING finding indicating the denied permission and resource
+6. IF any manifest job is VISUAL but has no `visual` artifact, THEN THE Dry_Run_Engine SHALL report a WARNING finding indicating the visual graph will be missing in the target UI
+
+### Requirement 11: Documentation — UI Visibility and Prerequisites
+
+**User Story:** As a data engineer reading the documentation, I want to understand what makes a deployed job appear in the Unified Studio UI and what prerequisites exist, so that my promoted jobs are usable.
+
+#### Acceptance Criteria
+
+1. THE documentation SHALL explain that three elements are required for a deployed job to appear correctly in the Unified Studio UI — the `AmazonDataZoneProject` tag (visibility), the `--smus-orig-asset` argument (visual graph), and the `--custom-logGroup-prefix` argument (log association) — and that this feature injects all three automatically
+2. THE documentation SHALL state that jobs are tracked across environments via the `smus-cicd-source-job-name` tag, that existing target jobs with a matching tag are updated in place, and that jobs without the tag are never modified or deleted
+3. THE documentation SHALL explain that destroy only removes jobs carrying the `smus-cicd-source-job-name` tag, so manually created jobs are not affected
+4. THE documentation SHALL document the prerequisite that the target project IAM role must have Glue job management permissions (`glue:CreateJob`, `glue:GetJob`, `glue:UpdateJob`, `glue:StartJobRun`, `glue:GetJobRun`, `glue:GetJobRuns`, `glue:BatchStopJobRun`, `glue:GetSecurityConfigurations`), since the toolkit does not grant these automatically
+5. THE documentation SHALL document that on IdC-based domains the CI/CD principal must be a member (owner) of the target project for connection resolution to succeed
+6. THE documentation SHALL explain the `content.glue_jobs` schema (`name`, `source`, `targetName`) and the per-stage `deployment_configuration.glue_jobs` options (`disable`, `target_suffix`, `overrides`)

--- a/.kiro/specs/glue-visual-etl-support/tasks.md
+++ b/.kiro/specs/glue-visual-etl-support/tasks.md
@@ -1,0 +1,164 @@
+# Implementation Plan: Glue Visual ETL Support
+
+## Overview
+
+Implements end-to-end promotion of Glue **Visual ETL** jobs (`JobMode: VISUAL`) across environments in the SMUS CI/CD CLI: `bundle` (export), `deploy` (create/update with UI-visibility tags and target rewrites), `destroy`, and `deploy --dry-run`. Follows the catalog import/export architecture with two new helper modules (`visual_etl_export.py`, `visual_etl_import.py`), manifest configuration extensions, and integration into the `bundle`, `deploy`, `destroy`, and dry-run flows.
+
+## Tasks
+
+- [ ] 1. Extend manifest configuration and resource types
+  - [ ] 1.1 Add GlueJobEntry and `content.glue_jobs` list, plus `deployment_configuration.glue_jobs`, in `application_manifest.py`
+    - Add `GlueJobEntry` dataclass (`name`, `source`, `target_name`)
+    - Add `glue_jobs: List[GlueJobEntry] = field(default_factory=list)` to `ContentConfig`
+    - Add `glue_jobs: Optional[Dict[str, Any]] = None` to `DeploymentConfiguration` (`disable`, `target_suffix`, `overrides`)
+    - Parse `content.glue_jobs` (YAML `targetName` → `target_name`) and `deployment_configuration.glue_jobs`
+    - Validate `name` pattern `[a-zA-Z0-9_-]{1,255}` and unique `(name, source)`
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8_
+
+  - [ ] 1.2 Add `glue_job` to `DESTROY_SUPPORTED_RESOURCE_TYPES` in `destroy_models.py`
+    - `glue_job` is already in `DEPLOY_RESOURCE_TYPES` — add it to the destroy set
+    - Ensure `TestDeployDestroyDrift` passes
+    - _Requirements: 9.10_
+
+  - [ ]* 1.3 Write property test for entry uniqueness and pattern (Property 2)
+    - **Validates: Requirements 1.2, 1.7, 1.8**
+
+- [ ] 2. Implement the export module
+  - [ ] 2.1 Create `src/smus_cicd/helpers/visual_etl_export.py`
+    - `export_visual_etl_jobs()`, `_validate_entries()` (fail-fast, VISUAL-only), `_locate_artifacts()`, `_copy_artifact()`, `_sanitize_definition()`, `_build_export_manifest()`
+    - Define `ExportedVisualEtlJob`, `VisualEtlExportSummary`
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8_
+
+  - [ ]* 2.2 Property test: fail-fast validation completeness (Property 1) — **Validates: 2.1, 2.2, 2.3**
+  - [ ]* 2.3 Property test: export manifest schema (Property 3) — **Validates: 4.2, 4.3, 4.4, 4.7**
+  - [ ]* 2.4 Property test: definition sanitization (Property 4) — **Validates: 4.5, 4.6, 4.8**
+  - [ ]* 2.5 Property test: visual artifact requirement (Property 6) — **Validates: 3.2, 3.4**
+  - [ ]* 2.6 Unit tests `tests/unit/helpers/test_visual_etl_export.py`
+    - Fail-fast missing/non-visual, VISUAL happy path, missing `.json`, missing `.vetl`, sanitization, `source` default
+    - _Requirements: 2.2, 2.3, 3.1, 3.2, 3.6, 4.5, 4.6_
+
+- [ ] 3. Integrate export into the bundle command
+  - [ ] 3.1 Modify `src/smus_cicd/commands/bundle.py` to call `export_visual_etl_jobs()` when `content.glue_jobs` is non-empty
+    - After catalog export; skip (no `glue_jobs/` dir) when absent/empty
+    - Write files under `glue_jobs/<name>/` and `glue_jobs_export_manifest.json` into the ZIP
+    - Report summary; non-zero exit on failures
+    - _Requirements: 1.6, 3.3, 3.5_
+
+  - [ ]* 3.2 Property test: bundle internal consistency (Property 5) — **Validates: 4.7**
+
+- [ ] 4. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 5. Implement the import/deploy module
+  - [ ] 5.1 Create `src/smus_cicd/helpers/visual_etl_import.py`
+    - `deploy_visual_etl_jobs()` (4-step per-job sequence), `_validate_export_manifest()`, `_upload_artifacts()`, `_deployed_name()`, `_build_target_kwargs()`, `_rewrite_default_arguments()`, `_resolve_target_job()`, `_owns_job()`, `_create_or_update()`
+    - Define `GlueJobDeploySummary`, `DeployResult`, `DeployStatus`
+    - _Requirements: 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7, 6.8, 6.9, 6.10, 6.11, 7.1, 7.2, 7.3, 7.4, 7.5, 8.1, 8.2, 8.3, 8.4_
+
+  - [ ]* 5.2 Property test: manifest validation before API calls — **Validates: 6.1 (manifest handling)**
+  - [ ]* 5.3 Property test: target kwargs construction invariants (Property 7) — **Validates: 6.2, 6.3, 6.4, 6.5**
+  - [ ]* 5.4 Property test: ownership guard (Property 8) — **Validates: 7.2, 7.3, 7.4**
+  - [ ]* 5.5 Property test: deployed name and override application (Property 9) — **Validates: 6.7, 6.11**
+  - [ ]* 5.6 Property test: summary count invariant (Property 11) — **Validates: 3.5, 6.10**
+  - [ ]* 5.7 Unit tests `tests/unit/helpers/test_visual_etl_import.py`
+    - Create path, update path, ownership guard, overrides, deployed name, missing file, S3 connection missing, manifest validation
+    - _Requirements: 6.2, 6.3, 6.4, 6.5, 6.7, 6.8, 6.9, 7.2, 7.3, 7.4, 8.2, 8.3, 8.4_
+
+- [ ] 6. Integrate deploy into the deploy command
+  - [ ] 6.1 Modify `src/smus_cicd/commands/deploy.py` to call `deploy_visual_etl_jobs()` after catalog import
+    - Add `_deploy_glue_jobs_from_bundle()` following `_import_catalog_from_bundle()`
+    - Honor `deployment_configuration.glue_jobs.disable` (skip w/ message), skip silently if no manifest in bundle
+    - Extract manifest + files; resolve `default.s3_shared` S3 URI and target IAM role ARN; pass `target_suffix`/`overrides`
+    - Report summary; non-zero exit on failures
+    - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5, 6.10, 6.11_
+
+  - [ ]* 6.2 Unit tests `tests/unit/commands/test_deploy_glue_jobs.py`
+    - disable → skip; no manifest → skip; happy path → summary; failures → non-zero
+    - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5_
+
+- [ ] 7. Implement destroy support
+  - [ ] 7.1 Add discovery/deletion to `destroy_validator.py` and `destroy_executor.py`
+    - `_discover_glue_jobs()`: list by `AmazonDataZoneProject` tag → filter by `smus-cicd-source-job-name` → filter by configured source names
+    - `_delete_glue_job()`: DeleteJob, handle EntityNotFoundException (not_found) + other errors
+    - Display under `glue_job` resource type; report deleted/not_found/error
+    - _Requirements: 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8, 9.9_
+
+  - [ ]* 7.2 Property test: destroy tag-based filtering (Property 10) — **Validates: 9.3, 9.4**
+  - [ ]* 7.3 Unit tests `tests/unit/commands/test_glue_job_destroy.py`
+    - Filter by tag, respect configured names, source env → zero, EntityNotFoundException/other errors, list failure
+    - _Requirements: 9.1, 9.2, 9.3, 9.4, 9.6, 9.7, 9.8, 9.9_
+
+- [ ] 8. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 9. Implement dry-run checker
+  - [ ] 9.1 Create `src/smus_cicd/commands/dry_run/checkers/glue_job_checker.py`
+    - `GlueJobChecker` following `catalog_checker.py`: S3 reachable (HEAD), IAM perms (glue:GetJob/CreateJob/UpdateJob/TagResource/GetTags, s3:PutObject), jobCount, VISUAL-without-vetl warning
+    - _Requirements: 10.1, 10.2, 10.3, 10.4, 10.5, 10.6_
+
+  - [ ] 9.2 Register `GlueJobChecker` in the dry-run engine (`engine.py`) after the catalog checker; invoke only when the bundle has `glue_jobs/glue_jobs_export_manifest.json`
+    - _Requirements: 10.1, 10.2, 10.3_
+
+  - [ ]* 9.3 Unit tests `tests/unit/commands/test_glue_job_dry_run.py`
+    - S3 reachable/missing, IAM denied, jobCount reported, VISUAL-without-vetl warning
+    - _Requirements: 10.1, 10.2, 10.3, 10.4, 10.5, 10.6_
+
+- [ ] 10. Consolidate property-based tests
+  - [ ] 10.1 Create `tests/unit/helpers/test_glue_job_properties.py` aggregating all 11 property tests
+    - From tasks 1.3, 2.2-2.5, 3.2, 5.2-5.6, 7.2, following `test_catalog_export_properties.py`
+    - Each uses `@settings(max_examples=100)`; tag `# Feature: glue-visual-etl-support, Property {N}: {description}`
+    - _Requirements: All correctness properties P1-P11_
+
+- [ ] 11. Example and integration test
+  - [ ] 11.1 Create example at `examples/analytic-workflow/glue-visual-etl/`
+    - `manifest.yaml` with `content.glue_jobs` and per-stage `deployment_configuration.glue_jobs`
+    - `README.md` documenting the three UI-visibility elements, source-tag tracking, destroy semantics, and IAM/IdC prerequisites (Requirement 11)
+    - Sample source job files (`.py`, `.vetl`, `.json`) for a representative Visual ETL job
+    - _Requirements: 11.1, 11.2, 11.3, 11.4, 11.5, 11.6_
+
+  - [ ] 11.2 Create integration helpers at `tests/integration/glue-visual-etl/`
+    - `__init__.py`, `glue_job_test_helpers.py` (seed job, read tags, find bundle), test manifests (incl. disabled)
+    - _Requirements: 1.1, 5.2, 9.5_
+
+  - [ ]* 11.3 Integration test `tests/integration/glue-visual-etl/test_glue_job_round_trip.py`
+    - Extend `IntegrationTestBase`, follow `test_catalog_round_trip.py`
+    - Round-trip: bundle → deploy (create) → verify tags + JobMode + smus-orig-asset → deploy again (update) → override → destroy → verify only CI/CD-managed job deleted
+    - `disable: true` → skip; `JobMode: SCRIPT` configured → bundle fails
+    - _Requirements: 5.2, 6.2, 6.3, 6.4, 6.5, 6.7, 7.2, 9.3, 9.6_
+
+- [ ] 12. Documentation
+  - [ ] 12.1 Add `docs/glue-visual-etl.md`
+    - Cover `content.glue_jobs` and `deployment_configuration.glue_jobs`, the three UI-visibility elements, `smus-cicd-source-job-name` tracking, destroy semantics, `<TARGET_REWRITE>` sanitization, and IAM/IdC prerequisites
+    - Link from `README.md` and `docs/examples-guide.md`; add a brief reminder in the deploy command help when Glue jobs are involved
+    - _Requirements: 11.1, 11.2, 11.3, 11.4, 11.5, 11.6_
+
+- [ ] 13. Final checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Only `JobMode: VISUAL` jobs are handled; script jobs are rejected at validation (future work)
+- All new modules follow the existing `catalog_export.py` / `catalog_import.py` patterns
+- Integration tests extend `IntegrationTestBase` and follow `test_catalog_round_trip.py`
+- The `glue_job` resource type already exists in `DEPLOY_RESOURCE_TYPES`; this feature adds the destroy side and the deletion logic
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "id": 0, "tasks": ["1.1", "1.2"] },
+    { "id": 1, "tasks": ["1.3", "2.1"] },
+    { "id": 2, "tasks": ["2.2", "2.3", "2.4", "2.5", "2.6", "3.1"] },
+    { "id": 3, "tasks": ["3.2", "5.1"] },
+    { "id": 4, "tasks": ["5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "6.1"] },
+    { "id": 5, "tasks": ["6.2", "7.1"] },
+    { "id": 6, "tasks": ["7.2", "7.3", "9.1"] },
+    { "id": 7, "tasks": ["9.2", "9.3"] },
+    { "id": 8, "tasks": ["10.1", "11.1", "11.2"] },
+    { "id": 9, "tasks": ["11.3", "12.1"] }
+  ]
+}
+```


### PR DESCRIPTION
Add a spec for promoting Glue Visual ETL jobs across environments.

- content.glue_jobs manifest section (name/source/targetName) and per-stage deployment_configuration.glue_jobs (disable/target_suffix/overrides)
- bundle: export JobMode=VISUAL jobs (.py/.vetl/.json) + portable, sanitized export manifest
- deploy: create/update in the target project, inject the three UI-visibility elements (AmazonDataZoneProject tag, --smus-orig-asset, --custom-logGroup-prefix), track source via smus-cicd-source-job-name, idempotent update with ownership guard
- destroy: delete only tool-managed jobs (tag-filtered)
- deploy --dry-run: validate S3 connection and Glue/S3 IAM permissions

Includes requirements.md, design.md (11 correctness properties), and tasks.md.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
