### PR TITLE
[workflow_create_handler] Tag MWAA workflows with DataZone project and domain IDs

### DIFF
--- a/src/smus_cicd/bootstrap/handlers/workflow_create_handler.py
+++ b/src/smus_cicd/bootstrap/handlers/workflow_create_handler.py
@@ -58,7 +58,13 @@ def handle_workflow_create(
     # Get required info from context
     project_name = target_config.project.name
     region = config["region"]
-    stage_name = config.get("stage_name", "unknown")
+    # Prefer the explicit "stage" field from the manifest (e.g. "TEST"), fall back to
+    # the target key name (e.g. "test-idc") which is stored in context as "stage_name"/"stage"
+    stage_name = (
+        getattr(target_config, "stage", None)
+        or context.get("stage_name")
+        or context.get("stage", "unknown")
+    )
 
     # Get project info from metadata (resolved once in deploy)
     project_info = metadata.get("project_info", {})
@@ -189,6 +195,16 @@ def handle_workflow_create(
             if os.path.exists(temp_path):
                 os.unlink(temp_path)
 
+        # Build the canonical tag set for this workflow - used for both creation and recovery
+        workflow_tags = {
+            "Pipeline": manifest.application_name,
+            "Target": target_config.project.name,
+            "STAGE": stage_name.upper(),
+            "CreatedBy": "SMUS-CICD",
+            "AmazonDataZoneDomain": domain_id,
+            "AmazonDataZoneProject": project_id,
+        }
+
         # Create workflow using resolved YAML
         typer.echo(f"🔧 Creating workflow '{workflow_name}' with role: {role_arn}")
         result = airflow_serverless.create_workflow(
@@ -196,20 +212,22 @@ def handle_workflow_create(
             dag_s3_location=resolved_location,
             role_arn=role_arn,
             description=f"SMUS CI/CD workflow for {manifest.application_name}",
-            tags={
-                "Pipeline": manifest.application_name,
-                "Target": target_config.project.name,
-                "STAGE": stage_name.upper(),
-                "CreatedBy": "SMUS-CICD",
-            },
+            tags=workflow_tags,
             region=region,
         )
 
         if result.get("success"):
             workflow_arn = result["workflow_arn"]
+            already_existed = result.get("already_exists", False)
             workflows_created.append({"name": workflow_name, "arn": workflow_arn})
-            typer.echo(f"✅ Created workflow: {workflow_name}")
+            if already_existed:
+                typer.echo(f"♻️  Workflow already existed, updated: {workflow_name}")
+            else:
+                typer.echo(f"✅ Created workflow: {workflow_name}")
             typer.echo(f"   ARN: {workflow_arn}")
+
+            # Ensure all required tags are present (handles both new and pre-existing workflows)
+            _ensure_workflow_tags(workflow_arn, workflow_tags, region)
 
             # Validate status
             workflow_status = airflow_serverless.get_workflow_status(
@@ -233,3 +251,41 @@ def handle_workflow_create(
     else:
         typer.echo("⚠️ No workflows were created")
         return True
+
+
+def _ensure_workflow_tags(
+    workflow_arn: str,
+    desired_tags: Dict[str, str],
+    region: str,
+) -> None:
+    """
+    Check the current tags on a workflow and add any that are missing.
+
+    This allows recovery of pre-existing workflows that were created before
+    tagging was introduced.
+
+    Args:
+        workflow_arn: ARN of the MWAA Serverless workflow
+        desired_tags: Full set of tags the workflow should have
+        region: AWS region
+    """
+    client = airflow_serverless.create_airflow_serverless_client(region=region)
+
+    try:
+        response = client.list_tags_for_resource(ResourceArn=workflow_arn)
+        current_tags = response.get("Tags", {})
+    except Exception as e:
+        typer.echo(f"   ⚠️  Could not read tags for {workflow_arn}: {e}")
+        return
+
+    missing_tags = {k: v for k, v in desired_tags.items() if k not in current_tags}
+
+    if not missing_tags:
+        typer.echo("   🏷️  All required tags already present")
+        return
+
+    try:
+        client.tag_resource(ResourceArn=workflow_arn, Tags=missing_tags)
+        typer.echo(f"   🏷️  Added missing tags: {list(missing_tags.keys())}")
+    except Exception as e:
+        typer.echo(f"   ⚠️  Could not add tags to {workflow_arn}: {e}")


### PR DESCRIPTION
## Summary

Fixes #297

MWAA Serverless workflows created by `workflow.create` were not associated with the DataZone project/domain in the console because the required tags were missing.

## Changes

**Add `AmazonDataZoneProject` and `AmazonDataZoneDomain` tags** at workflow creation time so DataZone can display the workflow under the correct project.

**Reconcile tags on pre-existing workflows** via a new `_ensure_workflow_tags()` helper. After every create/update, the handler fetches the workflow's current tags and calls `tag_resource` only for those that are missing. This recovers workflows created before this fix without touching any tags the user may have set manually.

**Fix `STAGE` tag always showing `UNKNOWN`** — the value was previously read from `config` (where `stage_name` is never stored). It now reads from the execution context using the following priority:
1. `target_config.stage` — explicit `stage:` field in the manifest (e.g. `TEST`)
2. `context["stage_name"]` / `context["stage"]` — the target key name (e.g. `test-idc`)

**Single source of truth for tags** — the `workflow_tags` dict is defined once per workflow iteration and passed to both `create_workflow` and `_ensure_workflow_tags`, eliminating the duplicated dict that existed before.

## Testing

Verified with `examples/analytic-workflow/data-notebooks/manifest-idc.yaml` — workflows now appear in IdC domains with all required tags, and `STAGE` correctly shows `TEST` instead of `UNKNOWN`.