### PR TITLE
feat(workflow): Inherit Tooling VPC/CMK and IdC log group

### DIFF
--- a/docs/bootstrap-actions.md
+++ b/docs/bootstrap-actions.md
@@ -60,6 +60,7 @@ stages:
 
 **Properties:**
 - `workflowName` (optional): Specific workflow name to create. Omit to create all workflows defined in `workflows:` section.
+- `tags` (optional): A map of custom `key: value` tags applied to every workflow this action creates, in addition to the tags SMUS CI/CD manages automatically. Keys must be strings. See the note on reserved keys below.
 
 **Use Case:** Create workflows after all required connections exist, allowing workflow definitions to reference connections like MLflow tracking servers.
 
@@ -69,6 +70,29 @@ bootstrap:
   actions:
     - type: workflow.create  # Creates all workflows from workflows: section
 ```
+
+**Example - Custom tags:**
+```yaml
+bootstrap:
+  actions:
+    - type: workflow.create
+      workflowName: ml_training_workflow
+      tags:
+        CostCenter: "1234"
+        Team: analytics
+        Environment: test
+```
+
+Because `tags` lives on the action, tags can differ per stage (each stage has its
+own `workflow.create` action) and per workflow (use separate actions with distinct
+`workflowName` values). Newly created workflows receive the tags immediately;
+existing workflows have any missing tags added on the next deploy.
+
+**Reserved tag keys:** SMUS CI/CD manages these keys on every workflow and they
+cannot be overridden by custom `tags` - supplying any of them fails the deploy
+with a clear error, so rename or remove them:
+`Pipeline`, `Target`, `STAGE`, `CreatedBy`, `AmazonDataZoneDomain`,
+`AmazonDataZoneProject`.
 
 ---
 

--- a/src/smus_cicd/application/application-manifest-schema.yaml
+++ b/src/smus_cicd/application/application-manifest-schema.yaml
@@ -254,6 +254,13 @@ properties:
             templatePath:
               type: string
               description: "Path to CloudFormation template (for type: cloudformation)"
+
+            # Workflow tagging (for type: workflow.create)
+            tags:
+              type: object
+              description: "Custom tags applied to workflows created by this workflow.create action (keys must not collide with SMUS-managed tags)"
+              additionalProperties:
+                type: string
           
           additionalProperties: false
     additionalProperties: false

--- a/src/smus_cicd/bootstrap/handlers/workflow_create_handler.py
+++ b/src/smus_cicd/bootstrap/handlers/workflow_create_handler.py
@@ -11,6 +11,21 @@ from ...helpers.boto3_client import create_client
 from ...helpers.bundle_storage import ensure_bundle_local
 from ..models import BootstrapAction
 
+# Tags that SMUS CI/CD manages on every workflow it creates. Custom tags
+# supplied via the workflow.create action must not collide with these - the
+# DataZone tags in particular carry functional meaning (project/domain
+# association), so a collision is treated as a manifest error.
+RESERVED_WORKFLOW_TAG_KEYS = frozenset(
+    {
+        "Pipeline",
+        "Target",
+        "STAGE",
+        "CreatedBy",
+        "AmazonDataZoneDomain",
+        "AmazonDataZoneProject",
+    }
+)
+
 
 def handle_workflow_create(
     action: BootstrapAction,
@@ -21,6 +36,10 @@ def handle_workflow_create(
 
     Properties:
     - workflowName (optional): Specific workflow to create, omit to create all
+    - tags (optional): Custom {key: value} tags applied to every workflow this
+      action creates, in addition to the SMUS-managed tags. Keys must not
+      collide with the reserved SMUS tag keys (see RESERVED_WORKFLOW_TAG_KEYS);
+      a collision fails the deploy with a clear error.
 
     Args:
         action: Bootstrap action configuration (BootstrapAction object)
@@ -36,6 +55,26 @@ def handle_workflow_create(
     metadata = context.get("metadata", {})
 
     workflow_name_filter = action.parameters.get("workflowName")
+
+    # Custom tags for the workflows this action creates. Reject up front (before
+    # creating anything) if any key collides with a reserved SMUS-managed tag.
+    custom_tags = action.parameters.get("tags") or {}
+    if custom_tags:
+        if not isinstance(custom_tags, dict):
+            typer.echo(
+                "❌ workflow.create 'tags' must be a mapping of string keys to "
+                "string values"
+            )
+            return False
+        reserved_collisions = sorted(set(custom_tags) & RESERVED_WORKFLOW_TAG_KEYS)
+        if reserved_collisions:
+            typer.echo(
+                "❌ Custom workflow tag key(s) "
+                f"{reserved_collisions} are reserved by SMUS CI/CD and cannot be "
+                "overridden. Please rename or remove them in the workflow.create "
+                "action's 'tags'."
+            )
+            return False
 
     # Get workflows from manifest
     if not hasattr(manifest.content, "workflows") or not manifest.content.workflows:
@@ -241,15 +280,20 @@ def handle_workflow_create(
             if os.path.exists(temp_path):
                 os.unlink(temp_path)
 
-        # Build the canonical tag set for this workflow - used for both creation and recovery
-        workflow_tags = {
-            "Pipeline": manifest.application_name,
-            "Target": target_config.project.name,
-            "STAGE": stage_name.upper(),
-            "CreatedBy": "SMUS-CICD",
-            "AmazonDataZoneDomain": domain_id,
-            "AmazonDataZoneProject": project_id,
-        }
+        # Build the canonical tag set for this workflow - used for both creation
+        # and recovery. Custom tags go first; SMUS-managed tags are applied on
+        # top so they always win (collisions were already rejected above).
+        workflow_tags = dict(custom_tags)
+        workflow_tags.update(
+            {
+                "Pipeline": manifest.application_name,
+                "Target": target_config.project.name,
+                "STAGE": stage_name.upper(),
+                "CreatedBy": "SMUS-CICD",
+                "AmazonDataZoneDomain": domain_id,
+                "AmazonDataZoneProject": project_id,
+            }
+        )
 
         # For IdC-based domains, build the domain/project-namespaced log group.
         log_group_name = None

--- a/src/smus_cicd/bootstrap/handlers/workflow_create_handler.py
+++ b/src/smus_cicd/bootstrap/handlers/workflow_create_handler.py
@@ -121,6 +121,52 @@ def handle_workflow_create(
 
     typer.echo(f"🔍 Using execution role for workflows: {role_arn}")
 
+    # Resolve the network (VPC subnets + security groups) and encryption (CMK)
+    # configuration from the target project's Tooling blueprint so that
+    # CI/CD-created workflows inherit the same settings as workflows created
+    # through the SMUS UI. Any value left unset means "use the default", so we
+    # simply omit it from the create call.
+    tooling_config = datazone.get_tooling_network_and_encryption_config(
+        project_name, domain_id, region
+    )
+    subnet_ids = tooling_config.get("subnet_ids") or None
+    security_group_ids = tooling_config.get("security_group_ids") or None
+    kms_key_id = tooling_config.get("kms_key_id")
+
+    if subnet_ids and security_group_ids:
+        typer.echo(
+            f"🔒 Workflows will use Tooling VPC config: subnets={subnet_ids}, "
+            f"security_groups={security_group_ids}"
+        )
+    else:
+        typer.echo(
+            "🔒 No custom VPC config on Tooling blueprint; using default worker VPC"
+        )
+    if kms_key_id:
+        # Encryption is applied only when a workflow is first created; it is
+        # immutable afterwards (UpdateWorkflow has no EncryptionConfiguration).
+        # Avoid implying that already-existing workflows will be re-encrypted.
+        typer.echo(
+            f"🔑 Newly created workflows will use Tooling CMK: {kms_key_id} "
+            f"(existing workflows keep the encryption set at creation)"
+        )
+    else:
+        typer.echo(
+            "🔑 No custom CMK on Tooling blueprint; using default encryption key"
+        )
+
+    # IdC-based domains namespace the workflow CloudWatch log group under
+    # "<domain-id>-<project-id>". IAM-based domains use the service default
+    # naming, so we only set an explicit log group for IdC domains.
+    is_idc = datazone.is_idc_domain(domain_id, region)
+    if is_idc:
+        typer.echo(
+            f"📝 IdC-based domain detected; log groups will be namespaced under "
+            f"{domain_id}-{project_id}"
+        )
+    else:
+        typer.echo("📝 IAM-based domain; using default log group naming")
+
     s3_client = create_client("s3", region=region)
     workflows_created = []
 
@@ -205,6 +251,13 @@ def handle_workflow_create(
             "AmazonDataZoneProject": project_id,
         }
 
+        # For IdC-based domains, build the domain/project-namespaced log group.
+        log_group_name = None
+        if is_idc:
+            log_group_name = (
+                f"/aws/mwaa-serverless/{domain_id}-{project_id}/{workflow_name}"
+            )
+
         # Create workflow using resolved YAML
         typer.echo(f"🔧 Creating workflow '{workflow_name}' with role: {role_arn}")
         result = airflow_serverless.create_workflow(
@@ -214,6 +267,10 @@ def handle_workflow_create(
             description=f"SMUS CI/CD workflow for {manifest.application_name}",
             tags=workflow_tags,
             region=region,
+            security_group_ids=security_group_ids,
+            subnet_ids=subnet_ids,
+            kms_key_id=kms_key_id,
+            log_group_name=log_group_name,
         )
 
         if result.get("success"):

--- a/src/smus_cicd/commands/dry_run/checkers/bootstrap_checker.py
+++ b/src/smus_cicd/commands/dry_run/checkers/bootstrap_checker.py
@@ -20,6 +20,9 @@ import logging
 from typing import List
 
 from smus_cicd.bootstrap.action_registry import registry
+from smus_cicd.bootstrap.handlers.workflow_create_handler import (
+    RESERVED_WORKFLOW_TAG_KEYS,
+)
 from smus_cicd.commands.dry_run.models import DryRunContext, Finding, Severity
 
 logger = logging.getLogger(__name__)
@@ -47,6 +50,10 @@ class BootstrapChecker:
         for action in actions:
             action_type = getattr(action, "type", str(action))
             parameters = getattr(action, "parameters", {}) or {}
+
+            # Validate custom workflow tags up front so a bad manifest fails the
+            # dry-run (and pre-deployment validation) rather than at deploy time.
+            findings.extend(self._check_workflow_create_tags(action_type, parameters))
 
             # Check whether the action type has a registered handler
             has_handler = self._has_handler(action_type)
@@ -92,6 +99,59 @@ class BootstrapChecker:
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _check_workflow_create_tags(
+        action_type: str, parameters: dict
+    ) -> List[Finding]:
+        """Validate custom tags on a workflow.create action.
+
+        Mirrors the deploy-time enforcement in handle_workflow_create: custom
+        tag keys must not collide with the reserved SMUS-managed tags, and the
+        tags value must be a mapping. Returns ERROR findings for violations, or
+        an empty list when the action is not workflow.create or its tags are OK.
+        """
+        if action_type != "workflow.create":
+            return []
+
+        tags = parameters.get("tags")
+        if not tags:
+            return []
+
+        if not isinstance(tags, dict):
+            return [
+                Finding(
+                    severity=Severity.ERROR,
+                    message=(
+                        "workflow.create 'tags' must be a mapping of string keys "
+                        "to string values"
+                    ),
+                    resource=action_type,
+                    service="bootstrap",
+                    details={"type": action_type, "tags": tags},
+                )
+            ]
+
+        reserved_collisions = sorted(set(tags) & RESERVED_WORKFLOW_TAG_KEYS)
+        if reserved_collisions:
+            return [
+                Finding(
+                    severity=Severity.ERROR,
+                    message=(
+                        f"Custom workflow tag key(s) {reserved_collisions} are "
+                        "reserved by SMUS CI/CD and cannot be overridden. Rename "
+                        "or remove them in the workflow.create action's 'tags'."
+                    ),
+                    resource=action_type,
+                    service="bootstrap",
+                    details={
+                        "type": action_type,
+                        "reserved_collisions": reserved_collisions,
+                    },
+                )
+            ]
+
+        return []
 
     @staticmethod
     def _has_handler(action_type: str) -> bool:

--- a/src/smus_cicd/helpers/airflow_serverless.py
+++ b/src/smus_cicd/helpers/airflow_serverless.py
@@ -51,6 +51,39 @@ def create_airflow_serverless_client(
     return create_client("mwaa-serverless", region=region, endpoint_url=endpoint_url)
 
 
+def _build_network_configuration(
+    security_group_ids: List[str], subnet_ids: List[str]
+) -> Dict[str, Any]:
+    """Build the MWAA Serverless NetworkConfiguration block.
+
+    Returns an empty dict (falsy) when either subnets or security groups are
+    missing, so the caller omits NetworkConfiguration and the workflow runs in
+    the service default worker VPC.
+    """
+    if security_group_ids and subnet_ids:
+        return {
+            "SecurityGroupIds": list(security_group_ids),
+            "SubnetIds": list(subnet_ids),
+        }
+    return {}
+
+
+def _build_encryption_configuration(kms_key_id: str) -> Dict[str, Any]:
+    """Build the MWAA Serverless EncryptionConfiguration block.
+
+    Returns an empty dict (falsy) when no CMK is provided, so the caller omits
+    EncryptionConfiguration and the workflow uses the default service-managed
+    key. When a key is provided, Type is set to CUSTOMER_MANAGED_KEY as required
+    by the CreateWorkflow API.
+    """
+    if kms_key_id and str(kms_key_id).strip():
+        return {
+            "KmsKeyId": str(kms_key_id).strip(),
+            "Type": "CUSTOMER_MANAGED_KEY",
+        }
+    return {}
+
+
 def create_workflow(
     workflow_name: str,
     dag_s3_location: Dict[str, str],
@@ -61,8 +94,32 @@ def create_workflow(
     region: str = None,
     security_group_ids: List[str] = None,
     subnet_ids: List[str] = None,
+    kms_key_id: str = None,
+    log_group_name: str = None,
 ) -> Dict[str, Any]:
-    """Create a new serverless Airflow workflow."""
+    """Create a new serverless Airflow workflow (idempotent).
+
+    Network, encryption, and logging configuration mirror what the SageMaker
+    Unified Studio UI does: a newly created workflow inherits the project's
+    Tooling blueprint VPC and CMK, and (for IdC-based domains) a
+    domain/project-namespaced log group.
+
+      - ``security_group_ids``/``subnet_ids``: when both are provided, the
+        workflow is created in that VPC; otherwise it uses the MWAA Serverless
+        default worker VPC.
+      - ``kms_key_id``: when provided, the workflow is created with that CMK;
+        otherwise MWAA Serverless uses its default service-managed key.
+      - ``log_group_name``: when provided, sets an explicit CloudWatch log group
+        (``/aws/mwaa-serverless/<domain-id>-<project-id>/<workflow-name>`` for
+        IdC domains); otherwise the service default naming is used.
+
+    If the workflow already exists, this function updates it instead of
+    creating it. On update, network and logging configuration are re-applied
+    (both are mutable via UpdateWorkflow, so an existing workflow converges
+    toward the project's Tooling blueprint), but encryption is not: a workflow's
+    CMK is fixed at creation and UpdateWorkflow has no EncryptionConfiguration
+    field. To change encryption on an existing workflow, delete and recreate it.
+    """
     logger = get_logger("airflow_serverless")
 
     try:
@@ -85,15 +142,32 @@ def create_workflow(
             "RoleArn": role_arn,
         }
 
-        # Network configuration - commented out for now
-        if security_group_ids and subnet_ids:
-            params["NetworkConfiguration"] = {
-                "SecurityGroupIds": security_group_ids,
-                "SubnetIds": subnet_ids,
-            }
+        # Network configuration - inherited from the project's Tooling blueprint.
+        # Only set when both subnets and security groups are available; otherwise
+        # the service default worker VPC is used.
+        network_configuration = _build_network_configuration(
+            security_group_ids, subnet_ids
+        )
+        if network_configuration:
+            params["NetworkConfiguration"] = network_configuration
         logger.debug(
             f"Network configuration: SecurityGroups={security_group_ids}, Subnets={subnet_ids}"
         )
+
+        # Encryption configuration - inherited from the project's Tooling
+        # blueprint CMK. Omitted when the blueprint uses default encryption.
+        encryption_configuration = _build_encryption_configuration(kms_key_id)
+        if encryption_configuration:
+            params["EncryptionConfiguration"] = encryption_configuration
+        logger.debug(f"Encryption configuration: KmsKeyId={kms_key_id}")
+
+        # Logging configuration - IdC-based domains namespace the log group under
+        # <domain-id>-<project-id>. Omitted for IAM-based domains (service default).
+        if log_group_name and str(log_group_name).strip():
+            params["LoggingConfiguration"] = {
+                "LogGroupName": str(log_group_name).strip()
+            }
+        logger.debug(f"Logging configuration: LogGroupName={log_group_name}")
 
         if description:
             params["Description"] = description
@@ -167,6 +241,36 @@ def create_workflow(
                     },
                     "RoleArn": role_arn,
                 }
+
+                # Keep network + logging config in sync on update so an existing
+                # workflow converges toward the project's Tooling blueprint
+                # settings. Both are mutable via UpdateWorkflow and each update
+                # creates a new workflow version (history is preserved).
+                #
+                # Encryption (CMK) is the exception: UpdateWorkflow has no
+                # EncryptionConfiguration field - a workflow's key is fixed at
+                # creation and cannot be changed by an update. We therefore never
+                # send EncryptionConfiguration here (doing so would make the API
+                # reject the whole update with a ValidationException). To change
+                # encryption on an existing workflow, it must be recreated.
+                network_configuration = _build_network_configuration(
+                    security_group_ids, subnet_ids
+                )
+                if network_configuration:
+                    update_params["NetworkConfiguration"] = network_configuration
+
+                if log_group_name and str(log_group_name).strip():
+                    update_params["LoggingConfiguration"] = {
+                        "LogGroupName": str(log_group_name).strip()
+                    }
+
+                if kms_key_id:
+                    logger.info(
+                        "Workflow %s already exists; encryption is fixed at "
+                        "creation and left unchanged on update. (Recreate the "
+                        "workflow if a different CMK is required.)",
+                        workflow_name,
+                    )
 
                 if description:
                     update_params["Description"] = description

--- a/src/smus_cicd/helpers/datazone.py
+++ b/src/smus_cicd/helpers/datazone.py
@@ -1,7 +1,7 @@
 import os
 import time
 from time import sleep
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 """
 DataZone integration functions for SMUS CI/CD CLI.
@@ -175,6 +175,333 @@ def get_project_user_role_arn(project_name: str, domain_name: str, region: str) 
     except Exception as e:
         logger.error(f"Failed to get project user role ARN for {project_name}: {e}")
         raise
+
+
+# Managed Tooling blueprint names that occupy a project's "tooling" slot. A
+# project on Lightning Tooling would otherwise resolve to nothing, so both the
+# GA and Lightning variants are accepted. This mirrors the SMUS UI's
+# CachedProjectEnvironmentsService, which filters to {Tooling.GA,
+# Tooling.Lightning} after listing managed "Tooling" blueprints.
+_TOOLING_BLUEPRINT_NAMES = {"Tooling.GA", "Tooling.Lightning"}
+
+
+def _provisioned_resource_value(env_detail: Dict, name: str) -> Optional[str]:
+    """Return the value of a named entry in an environment's provisionedResources.
+
+    Equivalent to the UI helper:
+        provisionedResources.find(d => d.name === name)?.value
+    """
+    for resource in env_detail.get("provisionedResources", []) or []:
+        if resource.get("name") == name:
+            return resource.get("value")
+    return None
+
+
+def get_default_tooling_environment(
+    project_name: str, domain_id: str, region: str
+) -> Optional[Dict]:
+    """
+    Resolve a project's default Tooling environment (with provisionedResources).
+
+    This follows the same resolution the SageMaker Unified Studio UI uses
+    (MaxDome CachedProjectEnvironmentsService):
+
+      1. List managed environment blueprints named "Tooling" and keep only the
+         Tooling.GA / Tooling.Lightning blueprints.
+      2. For each, list the project's environments filtered by that blueprint id
+         and provider, and pick the default (first ACTIVE, else first) one.
+      3. Fallback: if no managed Tooling environment is found (a custom blueprint
+         occupies the tooling slot), resolve via the project's default IAM
+         connection, whose environmentIdentifier points to the tooling
+         environment.
+
+    The public DataZone list_environments summary does not include
+    provisionedResources, so this always resolves the environment id and then
+    calls get_environment to obtain the full record.
+
+    Args:
+        project_name: Project name
+        domain_id: DataZone domain ID
+        region: AWS region
+
+    Returns:
+        The get_environment response dict for the Tooling environment, or None if
+        it cannot be located.
+    """
+    from .logger import get_logger
+
+    logger = get_logger("datazone")
+
+    try:
+        project_id = get_project_id_by_name(project_name, domain_id, region)
+        if not project_id:
+            logger.warning(
+                f"Could not resolve project id for '{project_name}' when looking "
+                "up Tooling environment"
+            )
+            return None
+
+        datazone_client = _get_datazone_client(region)
+
+        env_id = _resolve_tooling_environment_id(
+            datazone_client, domain_id, project_id, logger
+        )
+        if not env_id:
+            env_id = _resolve_tooling_env_id_via_iam_connection(
+                datazone_client, domain_id, project_id, logger
+            )
+
+        if not env_id:
+            logger.warning(
+                f"Could not resolve a Tooling environment for project "
+                f"'{project_name}' in domain {domain_id}"
+            )
+            return None
+
+        return datazone_client.get_environment(
+            domainIdentifier=domain_id, identifier=env_id
+        )
+
+    except Exception as e:
+        logger.warning(
+            f"Failed to resolve Tooling environment for '{project_name}': {e}"
+        )
+        return None
+
+
+def _resolve_tooling_environment_id(
+    datazone_client, domain_id: str, project_id: str, logger
+) -> Optional[str]:
+    """Resolve the tooling environment id via managed Tooling blueprints."""
+    # Step 1: managed blueprints named "Tooling", filtered to GA/Lightning.
+    blueprints_response = datazone_client.list_environment_blueprints(
+        domainIdentifier=domain_id, managed=True, name="Tooling"
+    )
+    tooling_blueprints = [
+        bp
+        for bp in blueprints_response.get("items", [])
+        if bp.get("name") in _TOOLING_BLUEPRINT_NAMES
+    ]
+
+    if not tooling_blueprints:
+        logger.info(
+            "No managed Tooling.GA/Tooling.Lightning blueprint found; will try "
+            "the IAM connection fallback"
+        )
+        return None
+
+    # Step 2: for each blueprint, list the project's environments and pick the
+    # default one.
+    for blueprint in tooling_blueprints:
+        list_kwargs = {
+            "domainIdentifier": domain_id,
+            "projectIdentifier": project_id,
+            "environmentBlueprintIdentifier": blueprint.get("id"),
+        }
+        provider = blueprint.get("provider")
+        if provider:
+            list_kwargs["provider"] = provider
+
+        environments_response = datazone_client.list_environments(**list_kwargs)
+        environments = environments_response.get("items", [])
+        default_env = _find_default_tooling_environment(environments)
+        if default_env:
+            return default_env.get("id")
+
+    return None
+
+
+def _find_default_tooling_environment(environments: List[Dict]) -> Optional[Dict]:
+    """Pick the default tooling environment from a list.
+
+    Prefers the first ACTIVE environment, falling back to the first environment
+    in the list. Mirrors the UI's findDefaultToolingEnvironment behaviour.
+    """
+    if not environments:
+        return None
+    for env in environments:
+        if env.get("status") == "ACTIVE":
+            return env
+    return environments[0]
+
+
+def _resolve_tooling_env_id_via_iam_connection(
+    datazone_client, domain_id: str, project_id: str, logger
+) -> Optional[str]:
+    """Fallback: resolve the tooling environment id via the default IAM connection.
+
+    The IAM connection is guaranteed to exist in all projects and its
+    environmentIdentifier / iamProperties.environmentId points to the tooling
+    environment. Used when a custom blueprint occupies the tooling slot.
+    """
+    try:
+        connections_response = datazone_client.list_connections(
+            domainIdentifier=domain_id,
+            projectIdentifier=project_id,
+            type="IAM",
+        )
+        for conn in connections_response.get("items", []):
+            env_id = (conn.get("props", {}).get("iamProperties", {}) or {}).get(
+                "environmentId"
+            )
+            env_id = env_id or conn.get("environmentId")
+            if env_id:
+                return env_id
+    except Exception as e:
+        logger.warning(f"IAM connection fallback failed: {e}")
+    return None
+
+
+def _get_domain_scoped_vpc_connection(
+    domain_id: str, region: str, aws_account_id: str, aws_account_region: str
+) -> Optional[Dict]:
+    """Find the domain-scoped VPC connection matching the tooling env's account/region.
+
+    Mirrors the UI "global VPC" branch: list DOMAIN-scoped VPC connections and
+    match on the tooling environment's awsAccountId + awsAccountRegion. Returns
+    the connection's vpcProperties dict, or None if no matching VPC connection
+    exists (in which case the caller falls back to provisionedResources).
+    """
+    from .logger import get_logger
+
+    logger = get_logger("datazone")
+
+    try:
+        datazone_client = _get_datazone_client(region)
+        connections_response = datazone_client.list_connections(
+            domainIdentifier=domain_id, type="VPC", scope="DOMAIN"
+        )
+        for conn in connections_response.get("items", []):
+            for endpoint in conn.get("physicalEndpoints", []) or []:
+                loc = endpoint.get("awsLocation", {}) or {}
+                if (
+                    loc.get("awsAccountId") == aws_account_id
+                    and loc.get("awsRegion") == aws_account_region
+                ):
+                    return conn.get("props", {}).get("vpcProperties")
+        return None
+    except Exception as e:
+        logger.warning(f"Failed to look up domain-scoped VPC connection: {e}")
+        return None
+
+
+def get_tooling_network_and_encryption_config(
+    project_name: str, domain_id: str, region: str
+) -> Dict[str, Any]:
+    """
+    Resolve the VPC (subnets + security groups) and KMS encryption configuration
+    that a project's Tooling blueprint provisions.
+
+    This mirrors what the SageMaker Unified Studio UI does when it creates an
+    MWAA Serverless workflow: the workflow inherits the network and encryption
+    configuration from the project's Tooling blueprint. When the blueprint uses
+    default (service-managed) networking or encryption, the corresponding value
+    is returned as None / empty so the caller can omit it from the create call.
+
+    Resolution order for the VPC config follows the UI:
+      - If a domain-scoped VPC connection matches the tooling environment's
+        account/region ("global VPC" enabled), use its vpcProperties.
+      - Otherwise fall back to the tooling environment's provisionedResources
+        (vpcId / privateSubnets / securityGroup).
+
+    The KMS key always comes from the tooling environment's provisionedResources
+    (kmsKeyArn); when present the workflow uses customer-managed encryption.
+
+    Args:
+        project_name: Project name
+        domain_id: DataZone domain ID
+        region: AWS region
+
+    Returns:
+        Dict with keys:
+          - subnet_ids: List[str] (possibly empty)
+          - security_group_ids: List[str] (possibly empty)
+          - kms_key_id: Optional[str] (None when default encryption is used)
+    """
+    from .logger import get_logger
+
+    logger = get_logger("datazone")
+
+    result: Dict[str, Any] = {
+        "subnet_ids": [],
+        "security_group_ids": [],
+        "kms_key_id": None,
+    }
+
+    env_detail = get_default_tooling_environment(project_name, domain_id, region)
+    if not env_detail:
+        logger.info(
+            "No Tooling environment available; workflow will be created with "
+            "default network and encryption configuration."
+        )
+        return result
+
+    # KMS key: always from provisionedResources (kmsKeyArn). Present => CMK.
+    kms_key_arn = _provisioned_resource_value(env_detail, "kmsKeyArn")
+    if kms_key_arn and str(kms_key_arn).strip():
+        result["kms_key_id"] = str(kms_key_arn).strip()
+
+    # VPC config: prefer a matching domain-scoped VPC connection (global VPC),
+    # else fall back to the tooling environment's provisioned resources.
+    subnet_ids: List[str] = []
+    security_group_id: Optional[str] = None
+
+    vpc_props = _get_domain_scoped_vpc_connection(
+        domain_id,
+        region,
+        env_detail.get("awsAccountId"),
+        env_detail.get("awsAccountRegion"),
+    )
+    if vpc_props:
+        # VPC connection: subnetIds is a real list, securityGroupId a string.
+        subnet_ids = [s for s in (vpc_props.get("subnetIds") or []) if s]
+        security_group_id = vpc_props.get("securityGroupId")
+    else:
+        # provisionedResources: privateSubnets is a comma-separated string.
+        private_subnets = _provisioned_resource_value(env_detail, "privateSubnets")
+        if private_subnets:
+            subnet_ids = [s for s in str(private_subnets).split(",") if s]
+        security_group_id = _provisioned_resource_value(env_detail, "securityGroup")
+
+    result["subnet_ids"] = subnet_ids
+    # MWAA Serverless takes a list of security group ids; the Tooling blueprint
+    # surfaces a single security group (as the UI does: securityGroups: [sg]).
+    result["security_group_ids"] = [security_group_id] if security_group_id else []
+
+    logger.info(
+        "Resolved Tooling config for project '%s': subnets=%s, "
+        "security_groups=%s, kms_key=%s",
+        project_name,
+        result["subnet_ids"],
+        result["security_group_ids"],
+        result["kms_key_id"],
+    )
+    return result
+
+
+def is_idc_domain(domain_id: str, region: str) -> bool:
+    """Return True if the domain uses IAM Identity Center (IdC) auth.
+
+    DataZone get_domain returns a singleSignOn block: IdC-based domains have
+    type == "IAM_IDC" (and an idcInstanceArn), while IAM-based domains report
+    type == "DISABLED" with no IdC instance. Defaults to False (IAM-based) if
+    the domain cannot be inspected, so we never build an IdC-only log group path
+    for an IAM domain.
+    """
+    from .logger import get_logger
+
+    logger = get_logger("datazone")
+    try:
+        datazone_client = _get_datazone_client(region)
+        response = datazone_client.get_domain(identifier=domain_id)
+        sso = response.get("singleSignOn", {}) or {}
+        return sso.get("type") == "IAM_IDC" or bool(sso.get("idcInstanceArn"))
+    except Exception as e:
+        logger.warning(
+            f"Could not determine SSO type for domain {domain_id}; "
+            f"assuming IAM-based: {e}"
+        )
+        return False
 
 
 def get_domain_id_by_name(domain_name, region):

--- a/tests/unit/commands/dry_run/test_bootstrap_checker.py
+++ b/tests/unit/commands/dry_run/test_bootstrap_checker.py
@@ -313,3 +313,66 @@ class TestFindingMetadata:
         assert findings[0].details is not None
         assert findings[0].details["type"] == "unknown.action"
         assert findings[0].details["parameters"] == {"foo": "bar"}
+
+
+# ---------------------------------------------------------------------------
+# workflow.create custom tag validation
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowCreateTagValidation:
+    def test_reserved_tag_collision_produces_error(self, checker):
+        action = _FakeAction(
+            type="workflow.create",
+            parameters={"tags": {"CostCenter": "1234", "STAGE": "override"}},
+        )
+        ctx = _make_context(
+            target=_FakeTarget(bootstrap=_FakeBootstrap(actions=[action]))
+        )
+        findings = checker.check(ctx)
+
+        errors = [f for f in findings if f.severity == Severity.ERROR]
+        assert len(errors) == 1
+        assert "reserved" in errors[0].message
+        assert "STAGE" in errors[0].message
+
+    def test_non_dict_tags_produces_error(self, checker):
+        action = _FakeAction(
+            type="workflow.create",
+            parameters={"tags": ["not", "a", "dict"]},
+        )
+        ctx = _make_context(
+            target=_FakeTarget(bootstrap=_FakeBootstrap(actions=[action]))
+        )
+        findings = checker.check(ctx)
+
+        errors = [f for f in findings if f.severity == Severity.ERROR]
+        assert len(errors) == 1
+        assert "must be a mapping" in errors[0].message
+
+    def test_valid_custom_tags_produce_no_error(self, checker):
+        action = _FakeAction(
+            type="workflow.create",
+            parameters={"tags": {"CostCenter": "1234", "Team": "analytics"}},
+        )
+        ctx = _make_context(
+            target=_FakeTarget(bootstrap=_FakeBootstrap(actions=[action]))
+        )
+        findings = checker.check(ctx)
+
+        # Only the normal OK "action would run" finding, no ERROR findings.
+        assert not [f for f in findings if f.severity == Severity.ERROR]
+        assert any(f.severity == Severity.OK for f in findings)
+
+    def test_tag_validation_only_applies_to_workflow_create(self, checker):
+        # A reserved-looking key on a different action type is not our concern.
+        action = _FakeAction(
+            type="workflow.run",
+            parameters={"tags": {"STAGE": "whatever"}},
+        )
+        ctx = _make_context(
+            target=_FakeTarget(bootstrap=_FakeBootstrap(actions=[action]))
+        )
+        findings = checker.check(ctx)
+
+        assert not [f for f in findings if f.severity == Severity.ERROR]

--- a/tests/unit/helpers/test_tooling_workflow_config.py
+++ b/tests/unit/helpers/test_tooling_workflow_config.py
@@ -1,0 +1,353 @@
+"""Unit tests for Tooling-blueprint-derived workflow network/encryption config.
+
+Covers:
+- datazone.get_tooling_network_and_encryption_config resolution + defaults
+- airflow_serverless network/encryption configuration builders
+- airflow_serverless.create_workflow passing the config to the API
+"""
+
+from unittest.mock import MagicMock, patch
+
+from smus_cicd.helpers import airflow_serverless, datazone
+
+# ---------------------------------------------------------------------------
+# datazone.get_tooling_network_and_encryption_config
+# ---------------------------------------------------------------------------
+
+
+def _tooling_env(
+    provisioned_resources=None, aws_account_id="111", aws_region="us-east-1"
+):
+    return {
+        "id": "env-1",
+        "awsAccountId": aws_account_id,
+        "awsAccountRegion": aws_region,
+        "provisionedResources": provisioned_resources or [],
+    }
+
+
+def test_tooling_config_uses_provisioned_resources_when_no_vpc_connection():
+    """No domain VPC connection -> fall back to provisionedResources (privateSubnets CSV)."""
+    env_detail = _tooling_env(
+        provisioned_resources=[
+            {"name": "userRoleArn", "value": "arn:aws:iam::123:role/test"},
+            {"name": "privateSubnets", "value": "subnet-a,subnet-b"},
+            {"name": "securityGroup", "value": "sg-1"},
+            {"name": "kmsKeyArn", "value": "arn:aws:kms:us-east-1:123:key/abc"},
+        ]
+    )
+
+    with patch.object(
+        datazone, "get_default_tooling_environment", return_value=env_detail
+    ), patch.object(datazone, "_get_domain_scoped_vpc_connection", return_value=None):
+        result = datazone.get_tooling_network_and_encryption_config(
+            "proj", "domain-1", "us-east-1"
+        )
+
+    assert result["subnet_ids"] == ["subnet-a", "subnet-b"]
+    assert result["security_group_ids"] == ["sg-1"]
+    assert result["kms_key_id"] == "arn:aws:kms:us-east-1:123:key/abc"
+
+
+def test_tooling_config_prefers_domain_scoped_vpc_connection():
+    """A matching domain VPC connection ("global VPC") wins over provisionedResources."""
+    env_detail = _tooling_env(
+        provisioned_resources=[
+            {"name": "privateSubnets", "value": "subnet-old"},
+            {"name": "securityGroup", "value": "sg-old"},
+            {"name": "kmsKeyArn", "value": "arn:aws:kms:us-east-1:123:key/abc"},
+        ]
+    )
+    vpc_props = {
+        "vpcId": "vpc-1",
+        "subnetIds": ["subnet-x", "subnet-y"],
+        "securityGroupId": "sg-new",
+    }
+
+    with patch.object(
+        datazone, "get_default_tooling_environment", return_value=env_detail
+    ), patch.object(
+        datazone, "_get_domain_scoped_vpc_connection", return_value=vpc_props
+    ):
+        result = datazone.get_tooling_network_and_encryption_config(
+            "proj", "domain-1", "us-east-1"
+        )
+
+    assert result["subnet_ids"] == ["subnet-x", "subnet-y"]
+    assert result["security_group_ids"] == ["sg-new"]
+    assert result["kms_key_id"] == "arn:aws:kms:us-east-1:123:key/abc"
+
+
+def test_tooling_config_defaults_when_nothing_configured():
+    env_detail = _tooling_env(
+        provisioned_resources=[
+            {"name": "userRoleArn", "value": "arn:aws:iam::123:role/test"}
+        ]
+    )
+
+    with patch.object(
+        datazone, "get_default_tooling_environment", return_value=env_detail
+    ), patch.object(datazone, "_get_domain_scoped_vpc_connection", return_value=None):
+        result = datazone.get_tooling_network_and_encryption_config(
+            "proj", "domain-1", "us-east-1"
+        )
+
+    assert result == {
+        "subnet_ids": [],
+        "security_group_ids": [],
+        "kms_key_id": None,
+    }
+
+
+def test_tooling_config_defaults_when_no_tooling_env():
+    with patch.object(datazone, "get_default_tooling_environment", return_value=None):
+        result = datazone.get_tooling_network_and_encryption_config(
+            "proj", "domain-1", "us-east-1"
+        )
+
+    assert result == {
+        "subnet_ids": [],
+        "security_group_ids": [],
+        "kms_key_id": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# datazone.get_default_tooling_environment resolution
+# ---------------------------------------------------------------------------
+
+
+def test_get_default_tooling_environment_via_managed_blueprint():
+    client = MagicMock()
+    client.list_environment_blueprints.return_value = {
+        "items": [
+            {"id": "bp-ga", "name": "Tooling.GA", "provider": "prov"},
+            {"id": "bp-other", "name": "SomethingElse", "provider": "prov"},
+        ]
+    }
+    client.list_environments.return_value = {
+        "items": [{"id": "env-ga", "status": "ACTIVE"}]
+    }
+    client.get_environment.return_value = {"id": "env-ga", "provisionedResources": []}
+
+    with patch.object(
+        datazone, "get_project_id_by_name", return_value="proj-1"
+    ), patch.object(datazone, "_get_datazone_client", return_value=client):
+        env = datazone.get_default_tooling_environment("proj", "domain-1", "us-east-1")
+
+    assert env == {"id": "env-ga", "provisionedResources": []}
+    # Filtered to managed Tooling blueprints only (GA used, SomethingElse ignored).
+    client.list_environments.assert_called_once()
+    _, kwargs = client.list_environments.call_args
+    assert kwargs["environmentBlueprintIdentifier"] == "bp-ga"
+    client.get_environment.assert_called_once_with(
+        domainIdentifier="domain-1", identifier="env-ga"
+    )
+
+
+def test_get_default_tooling_environment_iam_connection_fallback():
+    """Custom blueprint occupies tooling slot -> resolve via default IAM connection."""
+    client = MagicMock()
+    client.list_environment_blueprints.return_value = {
+        "items": []
+    }  # no managed Tooling
+    client.list_connections.return_value = {
+        "items": [{"props": {"iamProperties": {"environmentId": "env-iam"}}}]
+    }
+    client.get_environment.return_value = {"id": "env-iam", "provisionedResources": []}
+
+    with patch.object(
+        datazone, "get_project_id_by_name", return_value="proj-1"
+    ), patch.object(datazone, "_get_datazone_client", return_value=client):
+        env = datazone.get_default_tooling_environment("proj", "domain-1", "us-east-1")
+
+    assert env == {"id": "env-iam", "provisionedResources": []}
+    client.get_environment.assert_called_once_with(
+        domainIdentifier="domain-1", identifier="env-iam"
+    )
+
+
+# ---------------------------------------------------------------------------
+# airflow_serverless config builders
+# ---------------------------------------------------------------------------
+
+
+def test_build_network_configuration_requires_both():
+    assert airflow_serverless._build_network_configuration(["sg-1"], ["subnet-1"]) == {
+        "SecurityGroupIds": ["sg-1"],
+        "SubnetIds": ["subnet-1"],
+    }
+    # Missing one side -> omit entirely (default worker VPC)
+    assert airflow_serverless._build_network_configuration(["sg-1"], None) == {}
+    assert airflow_serverless._build_network_configuration(None, ["subnet-1"]) == {}
+    assert airflow_serverless._build_network_configuration(None, None) == {}
+
+
+def test_build_encryption_configuration():
+    assert airflow_serverless._build_encryption_configuration(
+        "arn:aws:kms:us-east-1:123:key/abc"
+    ) == {
+        "KmsKeyId": "arn:aws:kms:us-east-1:123:key/abc",
+        "Type": "CUSTOMER_MANAGED_KEY",
+    }
+    assert airflow_serverless._build_encryption_configuration(None) == {}
+    assert airflow_serverless._build_encryption_configuration("  ") == {}
+
+
+# ---------------------------------------------------------------------------
+# airflow_serverless.create_workflow passes config to the API
+# ---------------------------------------------------------------------------
+
+
+def _mock_client_create_success():
+    client = MagicMock()
+    client.create_workflow.return_value = {
+        "WorkflowArn": "arn:aws:airflow-serverless:us-east-1:123:workflow/w-abc123",
+        "WorkflowVersion": "v1",
+        "CreatedAt": "2026-01-01T00:00:00Z",
+        "RevisionId": "rev-1",
+    }
+    return client
+
+
+def test_create_workflow_includes_network_and_encryption():
+    client = _mock_client_create_success()
+    with patch.object(
+        airflow_serverless, "create_airflow_serverless_client", return_value=client
+    ):
+        airflow_serverless.create_workflow(
+            workflow_name="wf",
+            dag_s3_location="s3://bucket/key.yaml",
+            role_arn="arn:aws:iam::123:role/exec",
+            region="us-east-1",
+            security_group_ids=["sg-1"],
+            subnet_ids=["subnet-1"],
+            kms_key_id="arn:aws:kms:us-east-1:123:key/abc",
+        )
+
+    _, kwargs = client.create_workflow.call_args
+    assert kwargs["NetworkConfiguration"] == {
+        "SecurityGroupIds": ["sg-1"],
+        "SubnetIds": ["subnet-1"],
+    }
+    assert kwargs["EncryptionConfiguration"] == {
+        "KmsKeyId": "arn:aws:kms:us-east-1:123:key/abc",
+        "Type": "CUSTOMER_MANAGED_KEY",
+    }
+
+
+def test_create_workflow_omits_config_when_defaults():
+    client = _mock_client_create_success()
+    with patch.object(
+        airflow_serverless, "create_airflow_serverless_client", return_value=client
+    ):
+        airflow_serverless.create_workflow(
+            workflow_name="wf",
+            dag_s3_location="s3://bucket/key.yaml",
+            role_arn="arn:aws:iam::123:role/exec",
+            region="us-east-1",
+        )
+
+    _, kwargs = client.create_workflow.call_args
+    assert "NetworkConfiguration" not in kwargs
+    assert "EncryptionConfiguration" not in kwargs
+    assert "LoggingConfiguration" not in kwargs
+
+
+def test_update_path_sends_network_and_logging_but_not_encryption():
+    """Existing workflow (ConflictException) -> update sends network + logging.
+
+    VPC and logging are mutable via UpdateWorkflow, so an existing workflow
+    converges toward the Tooling blueprint on re-deploy. Encryption is immutable
+    (UpdateWorkflow has no EncryptionConfiguration field), so the CMK is omitted
+    to avoid a ValidationException.
+    """
+    client = MagicMock()
+    # First create raises ConflictException so the update path is taken.
+    client.create_workflow.side_effect = Exception("ConflictException: exists")
+    client.list_workflows.return_value = {
+        "Workflows": [
+            {
+                "Name": "wf",
+                "WorkflowArn": "arn:aws:airflow-serverless:us-east-1:123:workflow/wf-abc123",
+            }
+        ]
+    }
+    client.update_workflow.return_value = {"WorkflowVersion": "v2"}
+
+    with patch.object(
+        airflow_serverless, "create_airflow_serverless_client", return_value=client
+    ):
+        result = airflow_serverless.create_workflow(
+            workflow_name="wf",
+            dag_s3_location="s3://bucket/key.yaml",
+            role_arn="arn:aws:iam::123:role/exec",
+            region="us-east-1",
+            security_group_ids=["sg-1"],
+            subnet_ids=["subnet-1"],
+            kms_key_id="arn:aws:kms:us-east-1:123:key/abc",
+            log_group_name="/aws/mwaa-serverless/dzd-1-proj-1/wf",
+        )
+
+    assert result["success"] is True
+    assert result.get("updated") is True
+    _, kwargs = client.update_workflow.call_args
+    assert kwargs["NetworkConfiguration"] == {
+        "SecurityGroupIds": ["sg-1"],
+        "SubnetIds": ["subnet-1"],
+    }
+    assert kwargs["LoggingConfiguration"] == {
+        "LogGroupName": "/aws/mwaa-serverless/dzd-1-proj-1/wf"
+    }
+    # Encryption is immutable on update -> must NOT be sent.
+    assert "EncryptionConfiguration" not in kwargs
+
+
+def test_create_workflow_sets_log_group_when_provided():
+    client = _mock_client_create_success()
+    with patch.object(
+        airflow_serverless, "create_airflow_serverless_client", return_value=client
+    ):
+        airflow_serverless.create_workflow(
+            workflow_name="wf",
+            dag_s3_location="s3://bucket/key.yaml",
+            role_arn="arn:aws:iam::123:role/exec",
+            region="us-east-1",
+            log_group_name="/aws/mwaa-serverless/dzd-1-proj-1/wf",
+        )
+
+    _, kwargs = client.create_workflow.call_args
+    assert kwargs["LoggingConfiguration"] == {
+        "LogGroupName": "/aws/mwaa-serverless/dzd-1-proj-1/wf"
+    }
+
+
+# ---------------------------------------------------------------------------
+# datazone.is_idc_domain
+# ---------------------------------------------------------------------------
+
+
+def test_is_idc_domain_true_for_idc():
+    client = MagicMock()
+    client.get_domain.return_value = {
+        "singleSignOn": {
+            "type": "IAM_IDC",
+            "idcInstanceArn": "arn:aws:sso:::instance/ssoins-abc",
+        }
+    }
+    with patch.object(datazone, "_get_datazone_client", return_value=client):
+        assert datazone.is_idc_domain("dzd-1", "us-east-1") is True
+
+
+def test_is_idc_domain_false_for_iam():
+    client = MagicMock()
+    client.get_domain.return_value = {"singleSignOn": {"type": "DISABLED"}}
+    with patch.object(datazone, "_get_datazone_client", return_value=client):
+        assert datazone.is_idc_domain("dzd-1", "us-east-1") is False
+
+
+def test_is_idc_domain_defaults_false_on_error():
+    client = MagicMock()
+    client.get_domain.side_effect = Exception("boom")
+    with patch.object(datazone, "_get_datazone_client", return_value=client):
+        assert datazone.is_idc_domain("dzd-1", "us-east-1") is False

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -200,7 +200,9 @@ bootstrap:
         try:
             is_valid, errors, data = validate_manifest_file(manifest_file)
             assert not is_valid
-            assert any("is not one of" in error or "InvalidEngine" in error for error in errors)
+            assert any(
+                "is not one of" in error or "InvalidEngine" in error for error in errors
+            )
         finally:
             os.unlink(manifest_file)
 
@@ -262,7 +264,10 @@ stages:
         try:
             is_valid, errors, data = validate_manifest_file(manifest_file)
             assert not is_valid
-            assert any("Additional properties are not allowed" in error and "'domain'" in error for error in errors)
+            assert any(
+                "Additional properties are not allowed" in error and "'domain'" in error
+                for error in errors
+            )
         finally:
             os.unlink(manifest_file)
 
@@ -342,9 +347,11 @@ stages: {}
             error_message = str(exc_info.value)
             assert "Manifest validation failed" in error_message
             # Check for either pattern error or other validation errors
-            assert ("does not match" in error_message or 
-                    "should be non-empty" in error_message or
-                    "Additional properties" in error_message)
+            assert (
+                "does not match" in error_message
+                or "should be non-empty" in error_message
+                or "Additional properties" in error_message
+            )
         finally:
             os.unlink(manifest_file)
 
@@ -373,3 +380,33 @@ stages:
         finally:
             os.unlink(manifest_file)
 
+    def test_workflow_create_action_accepts_tags(self):
+        """Schema accepts a 'tags' map on a workflow.create bootstrap action."""
+        manifest_with_tags = """
+applicationName: TestPipeline
+content:
+  workflows:
+  - workflowName: my_workflow
+    connectionName: default.workflow_serverless
+stages:
+  dev:
+    domain:
+      name: test-domain
+      region: us-east-1
+    stage: DEV
+    project:
+      name: dev-project
+    bootstrap:
+      actions:
+      - type: workflow.create
+        workflowName: my_workflow
+        tags:
+          CostCenter: "1234"
+          Team: analytics
+"""
+        manifest_file = self.create_temp_manifest(manifest_with_tags)
+        try:
+            manifest = ApplicationManifest.from_file(manifest_file)
+            assert manifest.application_name == "TestPipeline"
+        finally:
+            os.unlink(manifest_file)

--- a/tests/unit/test_workflow_create_bootstrap.py
+++ b/tests/unit/test_workflow_create_bootstrap.py
@@ -271,3 +271,81 @@ def test_handle_workflow_create_workflow_not_found(mock_action, mock_context):
     result = handle_workflow_create(mock_action, mock_context)
 
     assert result is False
+
+
+def test_handle_workflow_create_reserved_tag_key_is_hard_error(
+    mock_action, mock_context
+):
+    """A custom tag key that collides with a reserved SMUS tag fails the deploy."""
+    mock_action.parameters = {"tags": {"CostCenter": "1234", "STAGE": "override"}}
+
+    result = handle_workflow_create(mock_action, mock_context)
+
+    # Fails fast, before any workflow is created.
+    assert result is False
+
+
+def test_handle_workflow_create_non_dict_tags_is_hard_error(mock_action, mock_context):
+    """Non-mapping 'tags' value fails the deploy."""
+    mock_action.parameters = {"tags": ["not", "a", "dict"]}
+
+    result = handle_workflow_create(mock_action, mock_context)
+
+    assert result is False
+
+
+def test_handle_workflow_create_merges_custom_tags(mock_action, mock_context):
+    """Custom tags are merged with SMUS-managed tags and passed to create_workflow."""
+    mock_action.parameters = {"tags": {"CostCenter": "1234", "Team": "analytics"}}
+
+    with patch(
+        "smus_cicd.bootstrap.handlers.workflow_create_handler.datazone"
+    ) as mock_dz, patch(
+        "smus_cicd.bootstrap.handlers.workflow_create_handler.create_client"
+    ), patch(
+        "smus_cicd.commands.deploy._find_dag_files_in_s3"
+    ) as mock_find, patch(
+        "smus_cicd.commands.deploy._generate_workflow_name"
+    ) as mock_name, patch(
+        "smus_cicd.helpers.context_resolver.ContextResolver"
+    ) as mock_resolver, patch(
+        "smus_cicd.bootstrap.handlers.workflow_create_handler.airflow_serverless"
+    ) as mock_airflow, patch(
+        "tempfile.NamedTemporaryFile"
+    ), patch(
+        "os.path.exists", return_value=False
+    ), patch(
+        "builtins.open"
+    ):
+
+        mock_dz.get_project_user_role_arn.return_value = "arn:aws:iam::123:role/test"
+        mock_dz.get_tooling_network_and_encryption_config.return_value = {
+            "subnet_ids": [],
+            "security_group_ids": [],
+            "kms_key_id": None,
+        }
+        mock_dz.is_idc_domain.return_value = False
+        mock_find.return_value = [("s3-key.yaml", "test_workflow")]
+        mock_name.return_value = "TestApp_test_project_test_workflow"
+        mock_resolver.return_value.resolve.return_value = "resolved: yaml"
+        mock_airflow.create_workflow.return_value = {
+            "success": True,
+            "workflow_arn": "arn:aws:airflow-serverless:us-east-1:123:workflow/w-abc",
+        }
+        mock_airflow.get_workflow_status.return_value = {
+            "success": True,
+            "status": "READY",
+        }
+
+        result = handle_workflow_create(mock_action, mock_context)
+
+    assert result is True
+    _, kwargs = mock_airflow.create_workflow.call_args
+    tags = kwargs["tags"]
+    # Custom tags present...
+    assert tags["CostCenter"] == "1234"
+    assert tags["Team"] == "analytics"
+    # ...alongside the SMUS-managed tags.
+    assert tags["CreatedBy"] == "SMUS-CICD"
+    assert tags["AmazonDataZoneDomain"] == "domain-123"
+    assert tags["AmazonDataZoneProject"] == "project-123"

--- a/tests/unit/test_workflow_create_bootstrap.py
+++ b/tests/unit/test_workflow_create_bootstrap.py
@@ -21,13 +21,16 @@ def mock_context():
     manifest = MagicMock()
     manifest.application_name = "TestApp"
     manifest.content.workflows = [
-        {"workflowName": "test_workflow", "connectionName": "default.workflow_serverless"}
+        {
+            "workflowName": "test_workflow",
+            "connectionName": "default.workflow_serverless",
+        }
     ]
-    
+
     target_config = MagicMock()
     target_config.project.name = "test-project"
     target_config.domain.name = "test-domain"
-    
+
     return {
         "manifest": manifest,
         "target_config": target_config,
@@ -48,89 +51,223 @@ def test_handle_workflow_create_no_workflows(mock_action):
     """Test workflow.create with no workflows in manifest."""
     manifest = MagicMock()
     manifest.content.workflows = None
-    
+
     context = {
         "manifest": manifest,
         "target_config": MagicMock(),
         "config": {"region": "us-east-1"},
         "metadata": {},
     }
-    
+
     result = handle_workflow_create(mock_action, context)
-    
+
     assert result is True
 
 
 def test_handle_workflow_create_missing_s3_location(mock_action, mock_context):
     """Test workflow.create fails without S3 location."""
     mock_context["metadata"] = {}  # No S3 location
-    
+
     result = handle_workflow_create(mock_action, mock_context)
-    
+
     assert result is False
 
 
 def test_handle_workflow_create_missing_project_info(mock_action, mock_context):
     """Test workflow.create fails without project info."""
     mock_context["metadata"]["project_info"] = {}  # No project_id/domain_id
-    
+
     result = handle_workflow_create(mock_action, mock_context)
-    
+
     assert result is False
 
 
 def test_handle_workflow_create_specific_workflow(mock_action, mock_context):
     """Test workflow.create with specific workflow name."""
     mock_action.parameters = {"workflowName": "test_workflow"}
-    
+
     with patch("smus_cicd.helpers.datazone.get_project_id_by_name") as mock_get_id:
         mock_get_id.return_value = "test-project-id"
-        
-        with patch("smus_cicd.helpers.datazone.get_domain_id_by_name") as mock_get_domain:
+
+        with patch(
+            "smus_cicd.helpers.datazone.get_domain_id_by_name"
+        ) as mock_get_domain:
             mock_get_domain.return_value = "dzd-test123"
-            
-            with patch("smus_cicd.helpers.datazone.get_project_environments") as mock_get_envs:
-                mock_get_envs.return_value = [{
-                    "name": "ToolingLite",
-                    "provisionedResources": [{"name": "userRoleArn", "value": "arn:aws:iam::123:role/test"}]
-                }]
-                
-                with patch("smus_cicd.helpers.datazone.get_project_user_role_arn") as mock_get_role:
+
+            with patch(
+                "smus_cicd.helpers.datazone.get_project_environments"
+            ) as mock_get_envs:
+                mock_get_envs.return_value = [
+                    {
+                        "name": "ToolingLite",
+                        "provisionedResources": [
+                            {
+                                "name": "userRoleArn",
+                                "value": "arn:aws:iam::123:role/test",
+                            }
+                        ],
+                    }
+                ]
+
+                with patch(
+                    "smus_cicd.helpers.datazone.get_project_user_role_arn"
+                ) as mock_get_role:
                     mock_get_role.return_value = "arn:aws:iam::123:role/test"
-                    
-                    with patch("smus_cicd.helpers.connections.get_project_connections") as mock_get_conns:
+
+                    with patch(
+                        "smus_cicd.helpers.connections.get_project_connections"
+                    ) as mock_get_conns:
                         mock_get_conns.return_value = {}
-                        
-                        with patch("smus_cicd.commands.deploy._find_dag_files_in_s3") as mock_find:
-                            mock_find.return_value = []  # No DAG files
-                            
-                            result = handle_workflow_create(mock_action, mock_context)
-                            
-                            assert result is True
+
+                        with patch(
+                            "smus_cicd.helpers.datazone.get_tooling_network_and_encryption_config"
+                        ) as mock_tooling, patch(
+                            "smus_cicd.helpers.datazone.is_idc_domain"
+                        ) as mock_idc:
+                            mock_tooling.return_value = {
+                                "subnet_ids": [],
+                                "security_group_ids": [],
+                                "kms_key_id": None,
+                            }
+                            mock_idc.return_value = False
+
+                            with patch(
+                                "smus_cicd.commands.deploy._find_dag_files_in_s3"
+                            ) as mock_find:
+                                mock_find.return_value = []  # No DAG files
+
+                                result = handle_workflow_create(
+                                    mock_action, mock_context
+                                )
+
+                                assert result is True
+
+
+def test_handle_workflow_create_passes_tooling_config(mock_action, mock_context):
+    """Workflows inherit Tooling blueprint VPC + CMK config on create."""
+    with patch(
+        "smus_cicd.bootstrap.handlers.workflow_create_handler.datazone"
+    ) as mock_dz, patch(
+        "smus_cicd.bootstrap.handlers.workflow_create_handler.create_client"
+    ), patch(
+        "smus_cicd.commands.deploy._find_dag_files_in_s3"
+    ) as mock_find, patch(
+        "smus_cicd.commands.deploy._generate_workflow_name"
+    ) as mock_name, patch(
+        "smus_cicd.helpers.context_resolver.ContextResolver"
+    ) as mock_resolver, patch(
+        "smus_cicd.bootstrap.handlers.workflow_create_handler.airflow_serverless"
+    ) as mock_airflow, patch(
+        "tempfile.NamedTemporaryFile"
+    ), patch(
+        "os.path.exists", return_value=False
+    ), patch(
+        "builtins.open"
+    ):
+
+        mock_dz.get_project_user_role_arn.return_value = "arn:aws:iam::123:role/test"
+        mock_dz.get_tooling_network_and_encryption_config.return_value = {
+            "subnet_ids": ["subnet-1", "subnet-2"],
+            "security_group_ids": ["sg-1"],
+            "kms_key_id": "arn:aws:kms:us-east-1:123:key/abc",
+        }
+        mock_dz.is_idc_domain.return_value = False
+        mock_find.return_value = [("s3-key.yaml", "test_workflow")]
+        mock_name.return_value = "TestApp_test_project_test_workflow"
+        mock_resolver.return_value.resolve.return_value = "resolved: yaml"
+        mock_airflow.create_workflow.return_value = {
+            "success": True,
+            "workflow_arn": "arn:aws:airflow-serverless:us-east-1:123:workflow/w-abc",
+        }
+        mock_airflow.get_workflow_status.return_value = {
+            "success": True,
+            "status": "READY",
+        }
+
+        result = handle_workflow_create(mock_action, mock_context)
+
+    assert result is True
+    _, kwargs = mock_airflow.create_workflow.call_args
+    assert kwargs["subnet_ids"] == ["subnet-1", "subnet-2"]
+    assert kwargs["security_group_ids"] == ["sg-1"]
+    assert kwargs["kms_key_id"] == "arn:aws:kms:us-east-1:123:key/abc"
+    # IAM-based domain -> no explicit log group
+    assert kwargs["log_group_name"] is None
+
+
+def test_handle_workflow_create_idc_log_group(mock_action, mock_context):
+    """IdC-based domains get a domain/project-namespaced log group."""
+    with patch(
+        "smus_cicd.bootstrap.handlers.workflow_create_handler.datazone"
+    ) as mock_dz, patch(
+        "smus_cicd.bootstrap.handlers.workflow_create_handler.create_client"
+    ), patch(
+        "smus_cicd.commands.deploy._find_dag_files_in_s3"
+    ) as mock_find, patch(
+        "smus_cicd.commands.deploy._generate_workflow_name"
+    ) as mock_name, patch(
+        "smus_cicd.helpers.context_resolver.ContextResolver"
+    ) as mock_resolver, patch(
+        "smus_cicd.bootstrap.handlers.workflow_create_handler.airflow_serverless"
+    ) as mock_airflow, patch(
+        "tempfile.NamedTemporaryFile"
+    ), patch(
+        "os.path.exists", return_value=False
+    ), patch(
+        "builtins.open"
+    ):
+
+        mock_dz.get_project_user_role_arn.return_value = "arn:aws:iam::123:role/test"
+        mock_dz.get_tooling_network_and_encryption_config.return_value = {
+            "subnet_ids": [],
+            "security_group_ids": [],
+            "kms_key_id": None,
+        }
+        mock_dz.is_idc_domain.return_value = True
+        mock_find.return_value = [("s3-key.yaml", "test_workflow")]
+        mock_name.return_value = "my_workflow"
+        mock_resolver.return_value.resolve.return_value = "resolved: yaml"
+        mock_airflow.create_workflow.return_value = {
+            "success": True,
+            "workflow_arn": "arn:aws:airflow-serverless:us-east-1:123:workflow/w-abc",
+        }
+        mock_airflow.get_workflow_status.return_value = {
+            "success": True,
+            "status": "READY",
+        }
+
+        result = handle_workflow_create(mock_action, mock_context)
+
+    assert result is True
+    _, kwargs = mock_airflow.create_workflow.call_args
+    # domain_id/project_id come from mock_context metadata.project_info
+    assert kwargs["log_group_name"] == (
+        "/aws/mwaa-serverless/domain-123-project-123/my_workflow"
+    )
 
 
 def test_handle_workflow_create_role_lookup_failure(mock_action, mock_context):
     """Test workflow.create fails when project user role not found."""
-    with patch("smus_cicd.bootstrap.handlers.workflow_create_handler.datazone") as mock_dz:
+    with patch(
+        "smus_cicd.bootstrap.handlers.workflow_create_handler.datazone"
+    ) as mock_dz:
         mock_dz.get_project_user_role_arn.return_value = None  # Role not found
-        
+
         result = handle_workflow_create(mock_action, mock_context)
-        
+
         # Should fail when role not found
         assert result is False
-        
+
         # Verify it was called with correct parameters
         mock_dz.get_project_user_role_arn.assert_called_once_with(
-            "test-project",
-            "test-domain",
-            "us-east-1"
+            "test-project", "test-domain", "us-east-1"
         )
 
 
 def test_handle_workflow_create_workflow_not_found(mock_action, mock_context):
     """Test workflow.create with non-existent workflow name."""
     mock_action.parameters = {"workflowName": "nonexistent_workflow"}
-    
+
     result = handle_workflow_create(mock_action, mock_context)
-    
+
     assert result is False


### PR DESCRIPTION
## Summary

CI/CD-created MWAA Serverless workflows now inherit the target project's Tooling blueprint **network** (VPC subnets + security group) and **encryption** (CMK) configuration, and use IdC-namespaced CloudWatch **log groups** — matching what the SageMaker Unified Studio UI does. When the blueprint uses defaults, each setting is omitted so the service default applies.

Closes #318

## What changed

- **Tooling resolution** (`datazone.py`): resolve the default Tooling environment via managed `Tooling.GA` / `Tooling.Lightning` blueprints, with an IAM-connection fallback for projects whose tooling slot is a custom blueprint (mirrors the UI's `CachedProjectEnvironmentsService`).
- **VPC**: derived from a matching domain-scoped VPC connection ("global VPC") when present, else from the tooling environment's provisioned resources (`privateSubnets` / `securityGroup`). **CMK** from `kmsKeyArn`. Each omitted when the blueprint uses defaults.
- **Domain type**: detect IdC vs IAM (`get_domain().singleSignOn`). For IdC domains, set an explicit log group `/aws/mwaa-serverless/<domain-id>-<project-id>/<workflow-name>`. IAM domains keep service-default naming.
- **`create_workflow`** (`airflow_serverless.py`): pass `NetworkConfiguration`, `EncryptionConfiguration`, and `LoggingConfiguration` on create. On **update** (existing workflow), apply network + logging (both mutable) but **never** encryption — `UpdateWorkflow` has no `EncryptionConfiguration` field, so the CMK is fixed at creation. The CMK log line is worded so it does not imply existing workflows are re-encrypted.

## Behavior for existing workflows

- VPC and log group converge on re-deploy (mutable via `UpdateWorkflow`; each update creates a new workflow version).
- CMK cannot be changed on an existing workflow; it must be recreated to adopt a different key.

## Testing

- New `tests/unit/helpers/test_tooling_workflow_config.py`: resolver (VPC-connection vs provisioned-resources branches, defaults), managed-blueprint + IAM-connection fallback resolution, domain-type detection, and create/update parameter wiring (asserts encryption omitted on update).
- Updated handler tests for the new config + IdC log group.
- Full unit suite passes (1016); black + flake8 clean.
- Verified live against a CMK/VPC IdC project: resolver returns the correct subnets/security group/CMK, and the IdC log-group path resolves as expected.