### PR TITLE
docs: Document generate-bundle-manifest skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ aws-smus-cicd-cli destroy --manifest manifest.yaml --targets test --force
 
 ---
 
+## Generate a Manifest with AI (Skill)
+
+Don't want to write `manifest.yaml` by hand? This repo ships an [Agent Skill](https://agentskills.io/) that scans your SageMaker Unified Studio project and generates a deployment manifest — and an orchestration workflow when one is needed. Add it to a coding agent (Kiro, Amazon Q CLI, Claude Code, or any [AgentSkills](https://agentskills.io/)-compatible agent), then ask *"Generate an SMUS CI/CD manifest for my project."*
+
+→ **[Generate a Manifest with AI](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/docs/generate-manifest-skill.md)** - Setup and usage instructions
+
+---
+
 ## Who Is This For?
 
 ### 👨‍💻 Data Teams (Data Scientists, Data Engineers, GenAI App Developers)
@@ -1162,6 +1170,7 @@ All setup scripts are idempotent and safe to run multiple times. Use `--dry-run`
 ### Getting Started
 - **[Quick Start Guide](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/docs/getting-started/quickstart.md)** - Deploy your first application (10 min)
 - **[Admin Guide](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/docs/getting-started/admin-quickstart.md)** - Set up infrastructure (15 min)
+- **[Generate a Manifest with AI](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/docs/generate-manifest-skill.md)** - Agent skill that scans your project and generates a manifest
 
 ### Guides
 - **[Application Manifest](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/blob/main/docs/manifest.md)** - Complete YAML configuration reference

--- a/docs/generate-manifest-skill.md
+++ b/docs/generate-manifest-skill.md
@@ -1,0 +1,79 @@
+# Generate a Manifest with AI (Skill)
+
+← [Back to Main README](../README.md)
+
+Don't want to write `manifest.yaml` by hand? This repo ships an [Agent Skill](https://agentskills.io/) that scans your SageMaker Unified Studio project and generates a deployment manifest — and an orchestration workflow when one is needed — for you.
+
+## What it does
+
+You point a coding agent (Kiro, Amazon Q CLI, Claude Code, or any agent that supports the [AgentSkills](https://agentskills.io/) standard) at the skill and ask it to generate a manifest. The skill:
+
+- Discovers your project's connections, storage layout, and workflows using your agent's AWS access.
+- Produces a ready-to-review `manifest.yaml` that follows the [manifest schema](manifest-schema.md), with `${VAR}` placeholders for test/prod stages.
+- Generates an MWAA orchestration workflow when your Glue jobs need one to run.
+
+The skill is **read-only** — it never writes or changes anything in your AWS account or your files. It presents the generated content in the chat, and you save and edit the output.
+
+## How to use it
+
+### 1. Get the skill
+
+Either clone this repo:
+
+```bash
+git clone https://github.com/aws/CICD-for-SageMakerUnifiedStudio.git
+# the skill lives at:
+#   CICD-for-SageMakerUnifiedStudio/skills/generate-bundle-manifest/
+```
+
+Or sparse-checkout just the skill folder without the full repo:
+
+```bash
+git clone --no-checkout --depth 1 https://github.com/aws/CICD-for-SageMakerUnifiedStudio.git
+cd CICD-for-SageMakerUnifiedStudio
+git sparse-checkout set skills/generate-bundle-manifest
+git checkout
+```
+
+### 2. Add it to your agent
+
+Copy the `skills/generate-bundle-manifest/` directory into wherever your agent loads skills from (for example, a `skills/` or `.kiro/skills/` folder in your project). The skill is a self-contained `SKILL.md` plus a bundled `references/` folder — no install step.
+
+### 3. Make sure the agent has AWS access
+
+The skill uses your agent's AWS CLI (or equivalent) to discover project resources, so authenticate to the account and region where your dev project lives:
+
+```bash
+aws sts get-caller-identity   # confirm you're in the right account
+```
+
+### 4. Ask the agent to generate a manifest
+
+For example:
+
+- *"Generate an SMUS CI/CD manifest for my project."*
+- *"Bundle my project so I can promote it to test and prod."*
+- *"Scan my project and create a manifest plus an orchestration workflow for my Glue jobs."*
+
+The agent asks for (or discovers) your domain and project, then returns a `manifest.yaml` in the chat. Save it to your app directory, review the `${VAR}` placeholders, and deploy with the CLI:
+
+```bash
+# Validate the manifest and connectivity
+aws-smus-cicd-cli describe --manifest manifest.yaml --connect
+
+# Preview the deployment (no changes made)
+aws-smus-cicd-cli deploy --targets test --manifest manifest.yaml --dry-run
+
+# Deploy to test
+aws-smus-cicd-cli deploy --targets test --manifest manifest.yaml
+```
+
+> **Note:** Target projects (test, prod) must already exist in SMUS — the CLI deploys into projects, it does not create them.
+
+## Related documentation
+
+- **[Skill source](https://github.com/aws/CICD-for-SageMakerUnifiedStudio/tree/main/skills/generate-bundle-manifest)** - `SKILL.md` and bundled reference manifests
+- **[Application Manifest](manifest.md)** - Complete YAML configuration reference
+- **[Manifest Schema](manifest-schema.md)** - YAML schema validation and structure
+- **[CLI Commands](cli-commands.md)** - All available commands and options
+- **[Quick Start Guide](getting-started/quickstart.md)** - Deploy your first application

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -26,6 +26,8 @@ You want to create deployable data applications with Spark code, Python scripts,
 - ML Training with Notebooks + SageMaker
 - GenAI with Bedrock + Notebooks
 
+> 💡 **Tip: Skip the hand-writing.** If you already have a project in SageMaker Unified Studio, use the [generate-bundle-manifest skill](../generate-manifest-skill.md) to have a coding agent (Kiro, Amazon Q CLI, Claude Code, etc.) scan your project and generate a `manifest.yaml` — and an orchestration workflow if your Glue jobs need one — for you. Add the skill to your agent, make sure it has AWS access, and ask *"Generate an SMUS CI/CD manifest for my project."*
+
 ---
 
 ## 🔧 For DevOps Teams
@@ -52,6 +54,9 @@ You're responsible for configuring CI/CD pipelines (GitHub Actions), managing Sa
 
 **Build and deploy data applications (bundles)**  
 → [Quick Start Guide](quickstart.md)
+
+**Generate a manifest automatically from my existing project**  
+→ [Generate a Manifest with AI (Skill)](../generate-manifest-skill.md)
 
 **Set up CI/CD pipelines and infrastructure**  
 → [Admin Quick Start](admin-quickstart.md)

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -59,6 +59,8 @@ Before deploying, you need a SageMaker Unified Studio IAM domain and project. Yo
 
 ## Step 4: Customize the Manifest
 
+> 💡 **Prefer to generate it automatically?** If you already have your own project in SageMaker Unified Studio, you can skip the hand-editing: use the [generate-bundle-manifest skill](../generate-manifest-skill.md) with your coding agent (Kiro, Amazon Q CLI, Claude Code, etc.), give the agent AWS access to your account, and ask *"Generate an SMUS CI/CD manifest for my project."* The agent scans your project (read-only) and returns a ready-to-review `manifest.yaml`. Save its output over the file below and jump to Step 5.
+
 Edit `manifest.yaml` to match your environment:
 
 ```yaml


### PR DESCRIPTION
## Summary

Adds customer-facing documentation for the `generate-bundle-manifest` agent skill that shipped in an earlier commit. Previously the skill existed in the repo (`skills/generate-bundle-manifest/`) but was not referenced anywhere, so customers had no way to discover it.

## Changes

- **New `docs/generate-manifest-skill.md`** — full setup and usage guide: how to get the skill (full clone or sparse-checkout of just the skill folder), how to add it to an agent, the AWS-access prerequisite, example prompts, and the follow-up CLI commands.
- **Main `README.md`** — short blurb + link to the new doc (kept lean rather than inlining all the steps), plus a link in the Documentation section.
- **`docs/getting-started/README.md`** — added an "I want to..." entry and a tip callout for data teams.
- **`docs/getting-started/quickstart.md`** — added a tip at the manifest-customization step offering the skill as an alternative to hand-editing.

Messaging is kept faithful to the skill's actual behavior: read-only, agent-agnostic (Kiro / Q CLI / Claude Code / any AgentSkills-compatible agent), needs AWS access for discovery, outputs a manifest plus an optional orchestration workflow, and target projects must pre-exist.

## Testing

Docs-only change. Verified all relative/absolute links resolve to existing files.

## Notes

Not included in this PR (happy to follow up if wanted):
- Localized READMEs (`docs/langs/*/README.md`) — left untouched since a `translate-docs` workflow appears to regenerate them from the English README.
- MCP knowledge-base config (`mcp-config.yaml`) — does not currently include `skills/`; separate mechanism from agent skills.